### PR TITLE
Add DoRA Power LoRA Loader node with Flux2/OneTrainer key fixes and web UI

### DIFF
--- a/ComfyUI/custom_nodes/comfyui_dora_dynamic_lora/README.md
+++ b/ComfyUI/custom_nodes/comfyui_dora_dynamic_lora/README.md
@@ -1,0 +1,73 @@
+# comfyui_dora_dynamic_lora
+
+Custom ComfyUI node that loads **DoRA LoRAs** (and regular LoRAs) when the LoRA file’s module keys
+don’t match ComfyUI’s built-in key map (common with **OneTrainer / Flux2** training exports).
+
+This node also includes **Power LoRA Loader-style stacking**: add multiple LoRAs inside a single node.
+
+ComfyUI already supports DoRA math (it reads `*.dora_scale` and applies weight decomposition).
+This node does **not** re-implement DoRA — it fixes **key mapping** so those tensors actually load.
+
+## Main symptom this fixes (Flux.2 Klein 9B etc.)
+
+When the LoRA weights fail to map/load, a common visible result is a **pink/magenta output image** (or otherwise
+obviously broken output), even though the workflow “runs”.
+
+Logs usually include lots of lines like:
+
+`lora key not loaded: transformer....linear.dora_scale`
+
+Meaning: the DoRA/LoRA tensors exist in the file, but ComfyUI can’t map them to real model weights.
+
+In particular, **Flux/Flux2 in ComfyUI uses `Modulation.lin`**, while some trainers export keys as
+`...modulation...linear...` — so the loader must translate `.linear -> .lin` for those modules.
+
+## What it does
+
+1. Loads the LoRA file and normalizes formats via `comfy.lora_convert.convert_lora`.
+2. Builds ComfyUI’s standard `key_map` (so all built-in mapping logic stays intact).
+3. Extracts “base module names” from the LoRA file (e.g. `...linear` before `.lora_up.weight`, `.dora_scale`, etc.).
+4. Applies a Flux2/OneTrainer compatibility transform before mapping:
+   - renames `transformer.time_guidance_embed.*` to `transformer.time_text_embed.*`
+   - broadcasts global modulation blocks into per-block targets ComfyUI maps (`transformer_blocks.*.norm1*`, `single_transformer_blocks.*.norm.linear`)
+5. For bases missing in `key_map`, it dynamically matches them to `model/clip.state_dict()` keys by suffix.
+   - Includes `.linear -> .lin` rewrites for modulation layers.
+6. Calls ComfyUI’s `comfy.lora.load_lora(...)` to produce patches and applies them to cloned model/clip.
+
+## Install
+
+Place this folder here:
+
+`ComfyUI/custom_nodes/comfyui_dora_dynamic_lora/`
+
+Then restart ComfyUI.
+
+## Node
+
+**DoRA Power LoRA Loader (DoRA + Flux2/OneTrainer key-fix)**  
+Category: `loaders`
+
+Features:
+- Add **multiple LoRAs inside one node** (Power LoRA Loader style).
+- Each row has:
+  - enabled toggle
+  - LoRA name (dropdown)
+  - model strength
+  - clip strength
+- Global options:
+  - stack enabled
+  - verbose logging
+  - log missing/unloaded keys
+
+## Notes / limitations
+
+- The dynamic matcher is best-effort. If multiple model weights share the same suffix, it picks the shortest match
+  and prefers keys containing `diffusion_model.`.
+- If you suspect wrong mapping, enable `verbose` and inspect the `map: <base> -> <weight>` logs.
+
+## Troubleshooting
+
+- Still seeing “lora key not loaded”:
+  - enable `verbose = true` and `log_unloaded_keys = true`
+  - check which bases are unresolved in logs
+  - if the unresolved bases have a consistent prefix mismatch, extend `_candidate_base_variants()` in `nodes.py`.

--- a/ComfyUI/custom_nodes/comfyui_dora_dynamic_lora/__init__.py
+++ b/ComfyUI/custom_nodes/comfyui_dora_dynamic_lora/__init__.py
@@ -1,9 +1,12 @@
-from .nodes import DoraDynamicLoraLoader
+from .nodes import DoraPowerLoraLoader
+
+# Tell ComfyUI to load our frontend extension.
+WEB_DIRECTORY = "./web"
 
 NODE_CLASS_MAPPINGS = {
-    "DoRA Dynamic LoRA Loader": DoraDynamicLoraLoader,
+    "DoRA Power LoRA Loader": DoraPowerLoraLoader,
 }
 
 NODE_DISPLAY_NAME_MAPPINGS = {
-    "DoRA Dynamic LoRA Loader": "DoRA Dynamic LoRA Loader (fix OneTrainer/Flux keys)",
+    "DoRA Power LoRA Loader": "DoRA Power LoRA Loader (DoRA + Flux2/OneTrainer key-fix)",
 }

--- a/ComfyUI/custom_nodes/comfyui_dora_dynamic_lora/nodes.py
+++ b/ComfyUI/custom_nodes/comfyui_dora_dynamic_lora/nodes.py
@@ -1,5 +1,6 @@
 import logging
-from typing import Dict, Iterable, List, Optional, Set, Tuple
+import re
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple, Union
 
 import comfy.lora
 import comfy.lora_convert
@@ -7,6 +8,39 @@ import comfy.utils
 import folder_paths
 
 _LOG = logging.getLogger(__name__)
+
+# --------------------------------------------------------------------------------------
+# Flexible optional inputs (Power LoRA Loader-style)
+# --------------------------------------------------------------------------------------
+
+
+class AnyType(str):
+    # ComfyUI type checks typically use != comparisons; returning False makes this "match anything".
+    def __ne__(self, __value: object) -> bool:  # noqa: D401
+        return False
+
+
+any_type = (AnyType("*"),)
+
+
+class FlexibleOptionalInputType(dict):
+    """
+    Dict-like object that claims it contains any key, and returns a fallback type spec for unknown keys.
+    This enables dynamic widgets / arbitrary optional inputs (rgthree Power LoRA Loader pattern).
+    """
+
+    def __init__(self, fallback_type, data: Union[dict, None] = None):
+        super().__init__(data or {})
+        self._fallback_type = fallback_type
+
+    def __contains__(self, key: object) -> bool:
+        return True
+
+    def __getitem__(self, key: str):
+        if dict.__contains__(self, key):
+            return dict.__getitem__(self, key)
+        return self._fallback_type
+
 
 # Key suffixes we treat as "belongs to base module X"
 _BASE_SUFFIXES = [
@@ -33,6 +67,191 @@ _BASE_SUFFIXES = [
     ".set_weight",
     ".reshape_weight",
 ]
+
+
+def _delete_prefix_keys(lora_sd: Dict[str, Any], prefix: str) -> int:
+    """
+    Deletes all keys that start with prefix.
+    Returns number of keys deleted.
+    """
+    to_del = [k for k in lora_sd.keys() if k.startswith(prefix)]
+    for k in to_del:
+        lora_sd.pop(k, None)
+    return len(to_del)
+
+
+def _rename_prefix_keys(lora_sd: Dict[str, Any], from_prefix: str, to_prefix: str, delete_from: bool = False) -> int:
+    """
+    Rename all keys that start with from_prefix to to_prefix + rest.
+    Returns number of keys created.
+    """
+    created = 0
+    keys = list(lora_sd.keys())
+    for k in keys:
+        if not k.startswith(from_prefix):
+            continue
+        nk = to_prefix + k[len(from_prefix) :]
+        if nk not in lora_sd:
+            lora_sd[nk] = lora_sd[k]
+            created += 1
+        if delete_from:
+            lora_sd.pop(k, None)
+    return created
+
+
+def _clone_base_block(lora_sd: Dict[str, Any], from_base: str, to_base: str) -> int:
+    """
+    Clone all entries under from_base.* to to_base.* (by prefix), preserving suffixes.
+    Returns number of keys created.
+    """
+    created = 0
+    prefix = from_base + "."
+    keys = list(lora_sd.keys())
+    for k in keys:
+        if not k.startswith(prefix):
+            continue
+        nk = to_base + k[len(from_base) :]
+        if nk in lora_sd:
+            continue
+        lora_sd[nk] = lora_sd[k]
+        created += 1
+    return created
+
+
+def _infer_flux_block_counts(model_sd_keys: Optional[Set[str]]) -> Tuple[int, int]:
+    """
+    Infer (n_double, n_single) from diffusion_model.* block keys.
+    Fallback if model_config isn't accessible.
+    """
+    if not model_sd_keys:
+        return (0, 0)
+
+    re_double = re.compile(r"^diffusion_model\.double_blocks\.(\d+)\.")
+    re_single = re.compile(r"^diffusion_model\.single_blocks\.(\d+)\.")
+    max_d = -1
+    max_s = -1
+    for k in model_sd_keys:
+        m = re_double.match(k)
+        if m:
+            i = int(m.group(1))
+            if i > max_d:
+                max_d = i
+            continue
+        m = re_single.match(k)
+        if m:
+            i = int(m.group(1))
+            if i > max_s:
+                max_s = i
+    return (max_d + 1 if max_d >= 0 else 0, max_s + 1 if max_s >= 0 else 0)
+
+
+def _get_unet_config_counts(model) -> Tuple[int, int]:
+    """
+    Best-effort read of Flux unet_config depth from the live model instance.
+    Returns (depth, depth_single_blocks) or (0,0) if unavailable.
+    """
+    try:
+        core = getattr(model, "model", None)
+        cfg = getattr(core, "model_config", None)
+        unet_cfg = getattr(cfg, "unet_config", None)
+        if isinstance(unet_cfg, dict):
+            d = int(unet_cfg.get("depth", 0) or 0)
+            s = int(unet_cfg.get("depth_single_blocks", 0) or 0)
+            return (d, s)
+        # dict-like / attr-like fallback
+        d = int(getattr(unet_cfg, "depth", 0) or 0)
+        s = int(getattr(unet_cfg, "depth_single_blocks", 0) or 0)
+        return (d, s)
+    except Exception:
+        return (0, 0)
+
+
+def _apply_flux2_onetrainer_dora_compat(
+    lora_sd: Dict[str, Any],
+    model,
+    model_sd_keys: Optional[Set[str]],
+    verbose: bool = False,
+) -> None:
+    """
+    Flux2 / OneTrainer DoRA compat:
+      1) rename time_guidance_embed -> time_text_embed (ComfyUI/diffusers mapping expects time_text_embed.*)
+      2) broadcast global modulation LoRAs (double_stream_modulation_*/single_stream_modulation)
+         onto per-block diffusers keys that ComfyUI actually maps:
+           - transformer_blocks.{i}.norm1.linear
+           - transformer_blocks.{i}.norm1_context.linear
+           - single_transformer_blocks.{i}.norm.linear
+    """
+    # 1) time_guidance_embed -> time_text_embed
+    # Only do it if the source prefix exists and the target prefix doesn't already exist (avoid double-mapping).
+    if any(k.startswith("transformer.time_guidance_embed.") for k in lora_sd.keys()) and not any(
+        k.startswith("transformer.time_text_embed.") for k in lora_sd.keys()
+    ):
+        n = _rename_prefix_keys(
+            lora_sd,
+            "transformer.time_guidance_embed.",
+            "transformer.time_text_embed.",
+            delete_from=True,
+        )
+        if verbose:
+            _LOG.info("[DoRA Power LoRA Loader] flux2 compat: renamed %s keys time_guidance_embed -> time_text_embed", n)
+
+    # Determine block counts
+    depth, depth_single = _get_unet_config_counts(model)
+    if depth == 0 and depth_single == 0:
+        depth, depth_single = _infer_flux_block_counts(model_sd_keys)
+    if verbose:
+        _LOG.info("[DoRA Power LoRA Loader] flux2 compat: inferred blocks: double=%s single=%s", depth, depth_single)
+
+    # 2) Broadcast global modulations if present
+    # Source bases from OneTrainer export (the ones you logged as missing).
+    src_img = "transformer.double_stream_modulation_img.linear"
+    src_txt = "transformer.double_stream_modulation_txt.linear"
+    src_single = "transformer.single_stream_modulation.linear"
+
+    # Only broadcast if those bases exist in the LoRA file.
+    have_img = any(k.startswith(src_img + ".") for k in lora_sd.keys())
+    have_txt = any(k.startswith(src_txt + ".") for k in lora_sd.keys())
+    have_single = any(k.startswith(src_single + ".") for k in lora_sd.keys())
+
+    if have_img and depth > 0:
+        created = 0
+        for i in range(depth):
+            dst = f"transformer.transformer_blocks.{i}.norm1.linear"
+            created += _clone_base_block(lora_sd, src_img, dst)
+        if verbose:
+            _LOG.info(
+                "[DoRA Power LoRA Loader] flux2 compat: broadcast %s -> transformer_blocks.*.norm1.linear (keys=%s)",
+                src_img,
+                created,
+            )
+        # prevent always-missing spam for the original, unmapped keys
+        _delete_prefix_keys(lora_sd, src_img + ".")
+
+    if have_txt and depth > 0:
+        created = 0
+        for i in range(depth):
+            dst = f"transformer.transformer_blocks.{i}.norm1_context.linear"
+            created += _clone_base_block(lora_sd, src_txt, dst)
+        if verbose:
+            _LOG.info(
+                "[DoRA Power LoRA Loader] flux2 compat: broadcast %s -> transformer_blocks.*.norm1_context.linear (keys=%s)",
+                src_txt,
+                created,
+            )
+        _delete_prefix_keys(lora_sd, src_txt + ".")
+
+    if have_single and depth_single > 0:
+        created = 0
+        for i in range(depth_single):
+            dst = f"transformer.single_transformer_blocks.{i}.norm.linear"
+            created += _clone_base_block(lora_sd, src_single, dst)
+        if verbose:
+            _LOG.info(
+                "[DoRA Power LoRA Loader] flux2 compat: broadcast %s -> single_transformer_blocks.*.norm.linear (keys=%s)",
+                src_single,
+                created,
+            )
+        _delete_prefix_keys(lora_sd, src_single + ".")
 
 
 def _extract_lora_bases(keys: Iterable[str]) -> Set[str]:
@@ -71,6 +290,18 @@ def _candidate_base_variants(base: str) -> List[str]:
         if base.startswith(prefix):
             variants.append(base[len(prefix) :])
 
+    # Flux/Flux2 trainer vs ComfyUI naming rewrite.
+    # ComfyUI's Modulation uses `lin`, while some trainers export `linear`.
+    rewrite_variants: List[str] = []
+    for v in variants:
+        # .linear -> .lin (end or segment)
+        if v.endswith(".linear"):
+            rewrite_variants.append(v[: -len(".linear")] + ".lin")
+        if ".linear." in v:
+            rewrite_variants.append(v.replace(".linear.", ".lin."))
+
+    variants.extend(rewrite_variants)
+
     # De-dup while preserving order.
     out: List[str] = []
     seen: Set[str] = set()
@@ -105,6 +336,7 @@ def _find_weight_key_for_base(sd_keys: Set[str], sd_key_list: List[str], base: s
         exact_try.extend(
             [
                 f"{variant}.weight",
+                f"{variant}.lin.weight",  # extra safety if variant already ends with ".linear" and rewrite didn't trigger
                 f"diffusion_model.{variant}.weight",
                 f"diffusion_model.transformer.{variant}.weight",
                 f"transformer.{variant}.weight",
@@ -161,46 +393,122 @@ def _extend_key_map_with_dynamic_matches(
             key_map[base] = found
             added += 1
             if verbose:
-                _LOG.info("[DoRA Dynamic LoRA Loader] map: %s -> %s", base, found)
+                _LOG.info("[DoRA Power LoRA Loader] map: %s -> %s", base, found)
         else:
             unresolved.append(base)
             if verbose:
-                _LOG.warning("[DoRA Dynamic LoRA Loader] unresolved LoRA base: %s", base)
+                _LOG.warning("[DoRA Power LoRA Loader] unresolved LoRA base: %s", base)
 
     return added, unresolved
 
 
-class DoraDynamicLoraLoader:
+def _parse_lora_stack_kwargs(kwargs: Dict[str, Any]) -> List[Dict[str, Any]]:
     """
-    Drop-in LoRA loader that:
-    - keeps standard ComfyUI key_map generation,
-    - adds dynamic suffix-based mapping for bases in the LoRA file,
-    - then uses comfy.lora.load_lora so DoRA works as core implements it.
+    Supports two input conventions:
+
+    1) rgthree-style:
+       kwargs contains keys like LORA_1, LORA_2... whose values are dicts:
+         { on: bool, lora: str, strength: float, strengthTwo?: float }
+
+    2) our simple-per-field style (used by this node's JS UI):
+       lora_{i}_enabled, lora_{i}_name, lora_{i}_strength_model, lora_{i}_strength_clip
+
+    Returns a normalized list of entries:
+      { on, lora, strength_model, strength_clip }
+    """
+    entries: List[Dict[str, Any]] = []
+
+    # 1) rgthree-style dict widgets
+    for k, v in kwargs.items():
+        ku = str(k).upper()
+        if not ku.startswith("LORA_"):
+            continue
+        if not isinstance(v, dict):
+            continue
+        if "lora" not in v:
+            continue
+        strength_model = v.get("strength", 0.0)
+        strength_clip = v.get("strengthTwo", None)
+        if strength_clip is None:
+            strength_clip = strength_model
+        entries.append(
+            {
+                "on": bool(v.get("on", True)),
+                "lora": v.get("lora"),
+                "strength_model": float(strength_model),
+                "strength_clip": float(strength_clip),
+            }
+        )
+
+    # 2) our per-field convention
+    idx_re = re.compile(r"^lora_(\d+)_name$", re.IGNORECASE)
+    indices: Set[int] = set()
+    for k in kwargs.keys():
+        m = idx_re.match(str(k))
+        if m:
+            indices.add(int(m.group(1)))
+
+    for i in sorted(indices):
+        name = kwargs.get(f"lora_{i}_name")
+        if name is None or name in ("", "None", "NONE"):
+            continue
+        enabled = kwargs.get(f"lora_{i}_enabled", True)
+        sm = kwargs.get(f"lora_{i}_strength_model", kwargs.get(f"lora_{i}_strength", 0.0))
+        sc = kwargs.get(f"lora_{i}_strength_clip", kwargs.get(f"lora_{i}_strength_two", None))
+        if sc is None:
+            sc = sm
+        entries.append(
+            {
+                "on": bool(enabled),
+                "lora": name,
+                "strength_model": float(sm),
+                "strength_clip": float(sc),
+            }
+        )
+
+    return entries
+
+
+class DoraPowerLoraLoader:
+    """
+    Power LoRA Loader-style stack + DoRA/Flux2 key-fix loader.
+
+    - Accepts a dynamic number of LoRAs (single node, like rgthree Power Lora Loader)
+    - Fixes Flux/Flux2 naming mismatches (e.g. `.linear` vs `.lin`, time guidance embed naming)
+    - Uses ComfyUI's core DoRA implementation (comfy.lora.load_lora)
     """
 
     @classmethod
     def INPUT_TYPES(cls):
-        loras = ["None"] + folder_paths.get_filename_list("loras")
         return {
             "required": {
                 "model": ("MODEL",),
                 "clip": ("CLIP",),
-                "lora_name": (loras,),
-                "strength_model": ("FLOAT", {"default": 1.0, "min": -10.0, "max": 10.0, "step": 0.05}),
-                "strength_clip": ("FLOAT", {"default": 1.0, "min": -10.0, "max": 10.0, "step": 0.05}),
-                "verbose": ("BOOLEAN", {"default": False}),
-                "log_unloaded_keys": ("BOOLEAN", {"default": False}),
-            }
+            },
+            # Dynamic/stack inputs injected by the JS UI (and/or by other frontends).
+            "optional": FlexibleOptionalInputType(any_type),
+            "hidden": {},
         }
 
     RETURN_TYPES = ("MODEL", "CLIP")
-    FUNCTION = "load"
+    RETURN_NAMES = ("MODEL", "CLIP")
+    FUNCTION = "load_loras"
     CATEGORY = "loaders"
 
-    def load(self, model, clip, lora_name, strength_model, strength_clip, verbose=False, log_unloaded_keys=False):
-        if lora_name in (None, "None", ""):
-            return (model, clip)
-
+    def _load_one(
+        self,
+        model,
+        clip,
+        lora_name: str,
+        strength_model: float,
+        strength_clip: float,
+        verbose: bool,
+        log_unloaded_keys: bool,
+        model_sd_keys: Optional[Set[str]],
+        model_sd_list: Optional[List[str]],
+        clip_sd_keys: Optional[Set[str]],
+        clip_sd_list: Optional[List[str]],
+    ):
         lora_path = folder_paths.get_full_path("loras", lora_name)
         if not lora_path:
             raise FileNotFoundError(f"LoRA not found: {lora_name}")
@@ -213,10 +521,20 @@ class DoraDynamicLoraLoader:
             lora_sd = comfy.utils.load_torch_file(lora_path)
         lora_sd = comfy.lora_convert.convert_lora(lora_sd)
 
+        # Flux2/OneTrainer DoRA compat: rewrite + broadcast missing modules into keys ComfyUI maps.
+        # This fixes cases where critical dora_scale/lora_up/down tensors never map/load.
+        if model is not None:
+            _apply_flux2_onetrainer_dora_compat(
+                lora_sd=lora_sd,
+                model=model,
+                model_sd_keys=model_sd_keys,
+                verbose=verbose,
+            )
+
         # Extract base module names from file keys.
         lora_bases = _extract_lora_bases(lora_sd.keys())
         if verbose:
-            _LOG.info("[DoRA Dynamic LoRA Loader] bases in file: %s", len(lora_bases))
+            _LOG.info("[DoRA Power LoRA Loader] %s: bases in file: %s", lora_name, len(lora_bases))
 
         # Start with standard ComfyUI key map.
         key_map: Dict[str, str] = {}
@@ -225,21 +543,7 @@ class DoraDynamicLoraLoader:
         if clip is not None:
             key_map = comfy.lora.model_lora_keys_clip(clip.cond_stage_model, key_map)
 
-        # Prepare state_dict key sets/lists for dynamic matching.
-        model_sd_keys = model_sd_list = None
-        clip_sd_keys = clip_sd_list = None
-
-        if model is not None:
-            model_state_dict = model.model.state_dict()
-            model_sd_list = list(model_state_dict.keys())
-            model_sd_keys = set(model_sd_list)
-
-        if clip is not None:
-            clip_state_dict = clip.cond_stage_model.state_dict()
-            clip_sd_list = list(clip_state_dict.keys())
-            clip_sd_keys = set(clip_sd_list)
-
-        # Extend map with missing bases from the file.
+        # Extend map with missing bases from the file (includes Flux/Flux2 rewrites in _candidate_base_variants()).
         added, unresolved = _extend_key_map_with_dynamic_matches(
             key_map=key_map,
             lora_bases=lora_bases,
@@ -252,7 +556,8 @@ class DoraDynamicLoraLoader:
 
         if verbose:
             _LOG.info(
-                "[DoRA Dynamic LoRA Loader] dynamic mappings added: %s, unresolved: %s",
+                "[DoRA Power LoRA Loader] %s: dynamic mappings added: %s, unresolved: %s",
+                lora_name,
                 added,
                 len(unresolved),
             )
@@ -267,17 +572,67 @@ class DoraDynamicLoraLoader:
             except TypeError:
                 loaded = comfy.lora.load_lora(lora_sd, key_map)
 
-        # Apply patches to clones (same pattern as comfy.sd.load_lora_for_models).
+        # Apply patches to provided model/clip (already cloned by caller).
+        if model is not None:
+            model.add_patches(loaded, strength_model)
+        if clip is not None:
+            clip.add_patches(loaded, strength_clip)
+
+        return model, clip
+
+    def load_loras(self, model, clip, **kwargs):
+        # Global controls (provided by JS UI; also safe if absent)
+        stack_enabled = bool(kwargs.get("stack_enabled", True))
+        verbose = bool(kwargs.get("verbose", False))
+        log_unloaded_keys = bool(kwargs.get("log_unloaded_keys", False))
+
+        if not stack_enabled:
+            return (model, clip)
+
+        entries = _parse_lora_stack_kwargs(kwargs)
+        if not entries:
+            return (model, clip)
+
+        # Clone once, then apply multiple loras onto the same patched instances.
         new_model = model.clone() if model is not None else None
         new_clip = clip.clone() if clip is not None else None
 
-        loaded_model_keys = set(new_model.add_patches(loaded, strength_model)) if new_model is not None else set()
-        loaded_clip_keys = set(new_clip.add_patches(loaded, strength_clip)) if new_clip is not None else set()
+        # Prepare state_dict key sets/lists once for dynamic matching.
+        model_sd_keys = model_sd_list = None
+        clip_sd_keys = clip_sd_list = None
 
-        # Optional warning for patches that did not land anywhere.
-        if verbose:
-            for key in loaded.keys():
-                if (key not in loaded_model_keys) and (key not in loaded_clip_keys):
-                    _LOG.warning("[DoRA Dynamic LoRA Loader] patch not applied to model/clip: %s", key)
+        if new_model is not None:
+            model_state_dict = new_model.model.state_dict()
+            model_sd_list = list(model_state_dict.keys())
+            model_sd_keys = set(model_sd_list)
+
+        if new_clip is not None:
+            clip_state_dict = new_clip.cond_stage_model.state_dict()
+            clip_sd_list = list(clip_state_dict.keys())
+            clip_sd_keys = set(clip_sd_list)
+
+        for e in entries:
+            lora_name = e.get("lora")
+            if not lora_name or lora_name in ("None", "NONE"):
+                continue
+            if not e.get("on", True):
+                continue
+            sm = float(e.get("strength_model", 0.0))
+            sc = float(e.get("strength_clip", sm))
+            if sm == 0.0 and sc == 0.0:
+                continue
+            new_model, new_clip = self._load_one(
+                new_model,
+                new_clip,
+                lora_name=lora_name,
+                strength_model=sm,
+                strength_clip=sc,
+                verbose=verbose,
+                log_unloaded_keys=log_unloaded_keys,
+                model_sd_keys=model_sd_keys,
+                model_sd_list=model_sd_list,
+                clip_sd_keys=clip_sd_keys,
+                clip_sd_list=clip_sd_list,
+            )
 
         return (new_model, new_clip)

--- a/ComfyUI/custom_nodes/comfyui_dora_dynamic_lora/web/dora_power_lora_loader.js
+++ b/ComfyUI/custom_nodes/comfyui_dora_dynamic_lora/web/dora_power_lora_loader.js
@@ -1,0 +1,203 @@
+import { app } from "../../scripts/app.js";
+
+const NODE_CLASS = "DoRA Power LoRA Loader";
+const EXT_NAME = "comfyui_dora_dynamic_lora.power_lora_loader";
+
+let _cachedLoras = null;
+let _cachedLorasPromise = null;
+
+async function fetchLoras() {
+  if (_cachedLoras) return _cachedLoras;
+  if (_cachedLorasPromise) return _cachedLorasPromise;
+
+  _cachedLorasPromise = (async () => {
+    try {
+      // Use ComfyUI's object_info endpoint to read the lora dropdown values from the built-in LoraLoader node.
+      const resp = await fetch("/object_info/LoraLoader");
+      const json = await resp.json();
+      const nodeInfo = json?.LoraLoader ?? json?.[Object.keys(json || {})[0]];
+      const spec = nodeInfo?.input?.required?.lora_name;
+      const values = Array.isArray(spec) ? spec[0] : null;
+      const loras = Array.isArray(values) ? values.slice() : [];
+      // Normalize "None"
+      const out = ["None", ...loras.filter((x) => x && x !== "None" && x !== "NONE")];
+      _cachedLoras = out;
+      return out;
+    } catch (e) {
+      console.warn(`[${EXT_NAME}] Failed to fetch loras via /object_info/LoraLoader`, e);
+      _cachedLoras = ["None"];
+      return _cachedLoras;
+    } finally {
+      _cachedLorasPromise = null;
+    }
+  })();
+
+  return _cachedLorasPromise;
+}
+
+function removeAllWidgets(node) {
+  if (!node.widgets) return;
+  while (node.widgets.length) node.removeWidget(0);
+}
+
+function makeRowDefaults() {
+  return {
+    enabled: true,
+    name: "None",
+    strengthModel: 1.0,
+    strengthClip: 1.0,
+  };
+}
+
+function parseRowsFromWidgetValues(widgetsValues) {
+  // Our serialized widgets are:
+  //   per-row: enabled, name, strengthModel, strengthClip  (4)
+  //   globals: stack_enabled, verbose, log_unloaded_keys   (3)
+  const vals = Array.isArray(widgetsValues) ? widgetsValues : [];
+  const GLOBALS = 3;
+  const PER_ROW = 4;
+  const rows = [];
+
+  if (vals.length < GLOBALS) return { rows, globals: { stack_enabled: true, verbose: false, log_unloaded_keys: false } };
+  const rowsCount = Math.max(0, Math.floor((vals.length - GLOBALS) / PER_ROW));
+  let idx = 0;
+  for (let i = 0; i < rowsCount; i++) {
+    const r = makeRowDefaults();
+    r.enabled = Boolean(vals[idx++]);
+    r.name = typeof vals[idx] === "string" ? vals[idx] : (vals[idx] ?? "None");
+    idx++;
+    r.strengthModel = Number(vals[idx++]);
+    r.strengthClip = Number(vals[idx++]);
+    rows.push(r);
+  }
+  const globals = {
+    stack_enabled: Boolean(vals[idx++]),
+    verbose: Boolean(vals[idx++]),
+    log_unloaded_keys: Boolean(vals[idx++]),
+  };
+  return { rows, globals };
+}
+
+function buildUI(node, rows, globals, loraValues) {
+  removeAllWidgets(node);
+
+  node._doraRows = rows || [];
+  node._doraGlobals = globals || { stack_enabled: true, verbose: false, log_unloaded_keys: false };
+
+  const loras = Array.isArray(loraValues) ? loraValues : ["None"];
+
+  // Rows
+  node._doraRows.forEach((row, i) => {
+    const n = i + 1;
+
+    const wEnabled = node.addWidget("toggle", `lora_${n}_enabled`, !!row.enabled, (v) => (row.enabled = !!v));
+    wEnabled.label = `LoRA ${n} Enabled`;
+
+    const wName = node.addWidget("combo", `lora_${n}_name`, row.name ?? "None", (v) => (row.name = v), {
+      values: loras,
+    });
+    wName.label = `LoRA ${n}`;
+
+    const wSm = node.addWidget(
+      "number",
+      `lora_${n}_strength_model`,
+      Number.isFinite(row.strengthModel) ? row.strengthModel : 1.0,
+      (v) => (row.strengthModel = Number(v)),
+      { min: -10.0, max: 10.0, step: 0.05 }
+    );
+    wSm.label = `Strength (Model)`;
+
+    const wSc = node.addWidget(
+      "number",
+      `lora_${n}_strength_clip`,
+      Number.isFinite(row.strengthClip) ? row.strengthClip : (Number.isFinite(row.strengthModel) ? row.strengthModel : 1.0),
+      (v) => (row.strengthClip = Number(v)),
+      { min: -10.0, max: 10.0, step: 0.05 }
+    );
+    wSc.label = `Strength (Clip)`;
+
+    const wRemove = node.addWidget("button", `lora_${n}_remove`, "✖ Remove", () => {
+      node._doraRows.splice(i, 1);
+      // Rebuild with current cached loras (or "None")
+      buildUI(node, node._doraRows, node._doraGlobals, _cachedLoras || ["None"]);
+      node.setDirtyCanvas(true, true);
+    });
+    wRemove.serialize = false;
+  });
+
+  // Add row button
+  const wAdd = node.addWidget("button", "add_lora", "➕ Add LoRA", () => {
+    node._doraRows.push(makeRowDefaults());
+    buildUI(node, node._doraRows, node._doraGlobals, _cachedLoras || ["None"]);
+    node.setDirtyCanvas(true, true);
+  });
+  wAdd.serialize = false;
+
+  // Globals (serialized)
+  const wStackEnabled = node.addWidget(
+    "toggle",
+    "stack_enabled",
+    !!node._doraGlobals.stack_enabled,
+    (v) => (node._doraGlobals.stack_enabled = !!v)
+  );
+  wStackEnabled.label = "Stack Enabled";
+
+  const wVerbose = node.addWidget("toggle", "verbose", !!node._doraGlobals.verbose, (v) => (node._doraGlobals.verbose = !!v));
+  wVerbose.label = "Verbose";
+
+  const wLogMissing = node.addWidget(
+    "toggle",
+    "log_unloaded_keys",
+    !!node._doraGlobals.log_unloaded_keys,
+    (v) => (node._doraGlobals.log_unloaded_keys = !!v)
+  );
+  wLogMissing.label = "Log Unloaded Keys";
+
+  // Ensure node is tall enough
+  const size = node.computeSize();
+  node.size[0] = Math.max(node.size[0], size[0]);
+  node.size[1] = Math.max(node.size[1], size[1]);
+}
+
+app.registerExtension({
+  name: EXT_NAME,
+  async beforeRegisterNodeDef(nodeType, nodeData) {
+    if (nodeData?.name !== NODE_CLASS) return;
+
+    const origOnNodeCreated = nodeType.prototype.onNodeCreated;
+    nodeType.prototype.onNodeCreated = function () {
+      const r = origOnNodeCreated?.apply(this, arguments);
+      // Default: one row
+      const rows = [makeRowDefaults()];
+      const globals = { stack_enabled: true, verbose: false, log_unloaded_keys: false };
+      buildUI(this, rows, globals, _cachedLoras || ["None"]);
+      // async populate lora dropdown
+      fetchLoras().then((loras) => {
+        buildUI(this, this._doraRows || rows, this._doraGlobals || globals, loras);
+        this.setDirtyCanvas(true, true);
+      });
+      return r;
+    };
+
+    // Rebuild from saved workflow widget values (so rows persist across save/load)
+    const origConfigure = nodeType.prototype.configure;
+    nodeType.prototype.configure = function (info) {
+      // Do NOT call origConfigure first, because it would try to apply widgets_values to widgets we haven't created yet.
+      // Instead: reconstruct rows based on widgets_values length, create widgets, then apply values by assignment.
+      const widgetsValues = info?.widgets_values;
+      const parsed = parseRowsFromWidgetValues(widgetsValues);
+      const rows = parsed.rows.length ? parsed.rows : [makeRowDefaults()];
+      const globals = parsed.globals || { stack_enabled: true, verbose: false, log_unloaded_keys: false };
+      buildUI(this, rows, globals, _cachedLoras || ["None"]);
+
+      // Now let the base configure handle position/size/etc (it won't re-apply widgets_values meaningfully now).
+      const r = origConfigure?.call(this, info);
+
+      fetchLoras().then((loras) => {
+        buildUI(this, this._doraRows || rows, this._doraGlobals || globals, loras);
+        this.setDirtyCanvas(true, true);
+      });
+      return r;
+    };
+  },
+});

--- a/ComfyUI/custom_nodes/comfyui_dora_dynamic_lora/web/index.js
+++ b/ComfyUI/custom_nodes/comfyui_dora_dynamic_lora/web/index.js
@@ -1,0 +1,1 @@
+import "./dora_power_lora_loader.js";


### PR DESCRIPTION
### Motivation
- Fix LoRA/DoRA weight mapping failures (common with OneTrainer/Flux2 exports) that produce broken outputs by dynamically mapping/export-key variants to ComfyUI model keys. 
- Provide a single-node Power LoRA Loader-style UI to stack multiple LoRAs in one node and expose verbose/logging controls for troubleshooting. 

### Description
- Adds a new node implementation `DoraPowerLoraLoader` (in `nodes.py`) that supports stacking multiple LoRAs, flexible optional inputs, and a normalized parsing of different frontend input conventions. 
- Implements Flux2/OneTrainer compatibility transforms including `transformer.time_guidance_embed -> transformer.time_text_embed`, broadcasting global modulation blocks to per-block keys, and `.linear -> .lin` rewrites to match ComfyUI modulation naming. 
- Introduces dynamic suffix-based matching to extend ComfyUI `key_map` at runtime when LoRA base names do not directly match model/clip state dict keys, with best-effort heuristics and logging. 
- Uses ComfyUI internals (`comfy.lora_convert.convert_lora`, `comfy.lora.load_lora`) with fallbacks for older signatures, clones `model`/`clip` once and applies patches per-LoRA with separate model/clip strengths, and preserves verbose/logging options. 
- Adds frontend assets under `web/` to provide a dynamic JS UI (`dora_power_lora_loader.js`) that builds per-row LoRA widgets, persists rows across save/load, populates LoRA dropdowns by querying the built-in `LoraLoader`, and registers an extension entry (`web/index.js`). 
- Updates `__init__.py` to expose the new node name/display string and include the `WEB_DIRECTORY` so the UI is loaded, and adds a `README.md` documenting installation, behavior, and troubleshooting. 

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6108edba483208e21047cd4f02f3a)