### PR TITLE
Add backend LoRA list API and refreshable frontend dropdown

### DIFF
--- a/ComfyUI/custom_nodes/comfyui_dora_dynamic_lora/__init__.py
+++ b/ComfyUI/custom_nodes/comfyui_dora_dynamic_lora/__init__.py
@@ -1,5 +1,17 @@
 from .nodes import DoraPowerLoraLoader
 
+# Backend API for frontend LoRA dropdown (avoids relying on /object_info variants).
+import folder_paths
+from aiohttp import web
+from server import PromptServer
+
+
+@PromptServer.instance.routes.get("/dora_dynamic_lora/loras")
+async def dora_dynamic_lora_list_loras(request):
+    # Return plain list of filenames from ComfyUI's "loras" folder_paths category.
+    # Frontend will prepend "None".
+    return web.json_response(folder_paths.get_filename_list("loras"))
+
 # Tell ComfyUI to load our frontend extension.
 WEB_DIRECTORY = "./web"
 

--- a/ComfyUI/custom_nodes/comfyui_dora_dynamic_lora/web/dora_power_lora_loader.js
+++ b/ComfyUI/custom_nodes/comfyui_dora_dynamic_lora/web/dora_power_lora_loader.js
@@ -2,9 +2,15 @@ import { app } from "../../scripts/app.js";
 
 const NODE_CLASS = "DoRA Power LoRA Loader";
 const EXT_NAME = "comfyui_dora_dynamic_lora.power_lora_loader";
+const LORA_API = "/dora_dynamic_lora/loras";
 
 let _cachedLoras = null;
 let _cachedLorasPromise = null;
+
+function invalidateLorasCache() {
+  _cachedLoras = null;
+  _cachedLorasPromise = null;
+}
 
 async function fetchLoras() {
   if (_cachedLoras) return _cachedLoras;
@@ -12,21 +18,40 @@ async function fetchLoras() {
 
   _cachedLorasPromise = (async () => {
     try {
-      // Use ComfyUI's object_info endpoint to read the lora dropdown values from the built-in LoraLoader node.
-      const resp = await fetch("/object_info/LoraLoader");
-      const json = await resp.json();
-      const nodeInfo = json?.LoraLoader ?? json?.[Object.keys(json || {})[0]];
-      const spec = nodeInfo?.input?.required?.lora_name;
-      const values = Array.isArray(spec) ? spec[0] : null;
-      const loras = Array.isArray(values) ? values.slice() : [];
-      // Normalize "None"
-      const out = ["None", ...loras.filter((x) => x && x !== "None" && x !== "NONE")];
+      let loras = null;
+
+      // 1) Preferred: our custom backend endpoint (stable across ComfyUI versions).
+      try {
+        const r = await fetch(LORA_API, { cache: "no-store" });
+        if (r.ok) {
+          const j = await r.json();
+          if (Array.isArray(j)) loras = j;
+        }
+      } catch (_) {}
+
+      // 2) Fallback: some builds expose /object_info (all nodes) but not /object_info/<NodeName>
+      if (!Array.isArray(loras)) {
+        try {
+          const r = await fetch("/object_info", { cache: "no-store" });
+          if (r.ok) {
+            const json = await r.json();
+            const nodeInfo = json?.LoraLoader;
+            const spec = nodeInfo?.input?.required?.lora_name;
+            const values = Array.isArray(spec) ? spec[0] : null;
+            if (Array.isArray(values)) loras = values.slice();
+          }
+        } catch (_) {}
+      }
+
+      // Normalize
+      const list = Array.isArray(loras) ? loras : [];
+      const out = ["None", ...list.filter((x) => x && x !== "None" && x !== "NONE")];
       _cachedLoras = out;
       return out;
     } catch (e) {
-      console.warn(`[${EXT_NAME}] Failed to fetch loras via /object_info/LoraLoader`, e);
-      _cachedLoras = ["None"];
-      return _cachedLoras;
+      console.warn(`[${EXT_NAME}] Failed to fetch LoRAs`, e);
+      // Don't permanently cache failure; allow refresh/retry.
+      return ["None"];
     } finally {
       _cachedLorasPromise = null;
     }
@@ -85,6 +110,16 @@ function buildUI(node, rows, globals, loraValues) {
   node._doraGlobals = globals || { stack_enabled: true, verbose: false, log_unloaded_keys: false };
 
   const loras = Array.isArray(loraValues) ? loraValues : ["None"];
+
+  // Refresh button (helps if new LoRAs are added without restarting)
+  const wRefresh = node.addWidget("button", "refresh_loras", "↻ Refresh LoRAs", () => {
+    invalidateLorasCache();
+    fetchLoras().then((newList) => {
+      buildUI(node, node._doraRows || [], node._doraGlobals || globals, newList);
+      node.setDirtyCanvas(true, true);
+    });
+  });
+  wRefresh.serialize = false;
 
   // Rows
   node._doraRows.forEach((row, i) => {


### PR DESCRIPTION
### Motivation
- The LoRA dropdown relied on variant `/object_info` endpoints that are inconsistent across ComfyUI builds, causing the dropdown to show only `None`; a stable backend API and a refresh UI control are needed so the dropdown can reliably list files from the `loras` folder.

### Description
- Added a backend route at `/dora_dynamic_lora/loras` that returns `folder_paths.get_filename_list("loras")` via `PromptServer.instance.routes` so the frontend has a stable source of LoRA filenames.
- Updated the frontend `fetchLoras()` logic to prefer the new `LORA_API` endpoint, fall back to `/object_info` only if needed, normalize results with `"None"` prepended, and avoid permanently caching failures.
- Added `invalidateLorasCache()` and a `↻ Refresh LoRAs` button in the node UI that forces a refetch and rebuilds the widgets so new LoRAs appear without restarting the backend or browser.
- Kept compatibility behavior to handle older ComfyUI builds while improving robustness across versions.

### Testing
- Programmatically verified the modified files contain the new backend route and the updated frontend logic by inspecting the updated file contents, which confirmed the expected changes succeeded.
- Attempted an automated browser check using Playwright to capture the UI after the change, but the run failed with `net::ERR_EMPTY_RESPONSE` because ComfyUI was not serving locally at `127.0.0.1:8188` during the test, so UI rendering could not be validated in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a618e6e9908320a568420d322da854)