### PR TITLE
Persist DoRA Power LoRA loader state via node properties

### DIFF
--- a/ComfyUI/custom_nodes/comfyui_dora_dynamic_lora/web/dora_power_lora_loader.js
+++ b/ComfyUI/custom_nodes/comfyui_dora_dynamic_lora/web/dora_power_lora_loader.js
@@ -61,8 +61,13 @@ async function fetchLoras() {
 }
 
 function removeAllWidgets(node) {
-  if (!node.widgets) return;
-  while (node.widgets.length) node.removeWidget(0);
+  // Be resilient across ComfyUI/LiteGraph variants.
+  if (!node.widgets) {
+    node.widgets = [];
+    return;
+  }
+  // Some builds don't expose removeWidget; clearing array works.
+  node.widgets.length = 0;
 }
 
 function makeRowDefaults() {
@@ -103,90 +108,159 @@ function parseRowsFromWidgetValues(widgetsValues) {
   return { rows, globals };
 }
 
+function normalizeState(state) {
+  const rows = Array.isArray(state?.rows) ? state.rows : [];
+  const globals = state?.globals && typeof state.globals === "object" ? state.globals : {};
+  return {
+    rows: rows.length ? rows.map((r) => ({
+      enabled: !!r.enabled,
+      name: typeof r.name === "string" ? r.name : "None",
+      strengthModel: Number.isFinite(+r.strengthModel) ? +r.strengthModel : 1.0,
+      strengthClip: Number.isFinite(+r.strengthClip) ? +r.strengthClip : (Number.isFinite(+r.strengthModel) ? +r.strengthModel : 1.0),
+    })) : [makeRowDefaults()],
+    globals: {
+      stack_enabled: globals.stack_enabled !== undefined ? !!globals.stack_enabled : true,
+      verbose: globals.verbose !== undefined ? !!globals.verbose : false,
+      log_unloaded_keys: globals.log_unloaded_keys !== undefined ? !!globals.log_unloaded_keys : false,
+    },
+  };
+}
+
+function getStateFromNode(node) {
+  const p = node?.properties?.dora_power_lora;
+  if (p && typeof p === "object") return normalizeState(p);
+  return normalizeState({ rows: [makeRowDefaults()], globals: { stack_enabled: true, verbose: false, log_unloaded_keys: false } });
+}
+
+function setStateOnNode(node, state) {
+  if (!node.properties) node.properties = {};
+  node.properties.dora_power_lora = normalizeState(state);
+}
+
+function noSerialize(widget) {
+  if (!widget) return widget;
+  widget.serialize = false;
+  widget.options = widget.options || {};
+  widget.options.serialize = false;
+  return widget;
+}
+
 function buildUI(node, rows, globals, loraValues) {
   removeAllWidgets(node);
 
   node._doraRows = rows || [];
   node._doraGlobals = globals || { stack_enabled: true, verbose: false, log_unloaded_keys: false };
+  setStateOnNode(node, { rows: node._doraRows, globals: node._doraGlobals });
 
   const loras = Array.isArray(loraValues) ? loraValues : ["None"];
 
   // Refresh button (helps if new LoRAs are added without restarting)
-  const wRefresh = node.addWidget("button", "refresh_loras", "↻ Refresh LoRAs", () => {
+  const wRefresh = node.addWidget("button", "↻ Refresh LoRAs", null, () => {
     invalidateLorasCache();
     fetchLoras().then((newList) => {
       buildUI(node, node._doraRows || [], node._doraGlobals || globals, newList);
       node.setDirtyCanvas(true, true);
     });
   });
-  wRefresh.serialize = false;
+  noSerialize(wRefresh);
 
   // Rows
   node._doraRows.forEach((row, i) => {
     const n = i + 1;
 
-    const wEnabled = node.addWidget("toggle", `lora_${n}_enabled`, !!row.enabled, (v) => (row.enabled = !!v));
+    const wEnabled = node.addWidget("toggle", `LoRA ${n} Enabled`, !!row.enabled, (v) => {
+      row.enabled = !!v;
+      setStateOnNode(node, { rows: node._doraRows, globals: node._doraGlobals });
+    });
     wEnabled.label = `LoRA ${n} Enabled`;
+    noSerialize(wEnabled);
 
-    const wName = node.addWidget("combo", `lora_${n}_name`, row.name ?? "None", (v) => (row.name = v), {
+    const wName = node.addWidget("combo", `LoRA ${n}`, row.name ?? "None", (v) => {
+      row.name = v;
+      setStateOnNode(node, { rows: node._doraRows, globals: node._doraGlobals });
+    }, {
       values: loras,
     });
     wName.label = `LoRA ${n}`;
+    noSerialize(wName);
 
     const wSm = node.addWidget(
       "number",
-      `lora_${n}_strength_model`,
+      `Strength (Model) ${n}`,
       Number.isFinite(row.strengthModel) ? row.strengthModel : 1.0,
-      (v) => (row.strengthModel = Number(v)),
+      (v) => {
+        row.strengthModel = Number(v);
+        setStateOnNode(node, { rows: node._doraRows, globals: node._doraGlobals });
+      },
       { min: -10.0, max: 10.0, step: 0.05 }
     );
     wSm.label = `Strength (Model)`;
+    noSerialize(wSm);
 
     const wSc = node.addWidget(
       "number",
-      `lora_${n}_strength_clip`,
+      `Strength (Clip) ${n}`,
       Number.isFinite(row.strengthClip) ? row.strengthClip : (Number.isFinite(row.strengthModel) ? row.strengthModel : 1.0),
-      (v) => (row.strengthClip = Number(v)),
+      (v) => {
+        row.strengthClip = Number(v);
+        setStateOnNode(node, { rows: node._doraRows, globals: node._doraGlobals });
+      },
       { min: -10.0, max: 10.0, step: 0.05 }
     );
     wSc.label = `Strength (Clip)`;
+    noSerialize(wSc);
 
-    const wRemove = node.addWidget("button", `lora_${n}_remove`, "✖ Remove", () => {
+    const wRemove = node.addWidget("button", `✖ Remove LoRA ${n}`, null, () => {
       node._doraRows.splice(i, 1);
+      if (!node._doraRows.length) node._doraRows.push(makeRowDefaults());
+      setStateOnNode(node, { rows: node._doraRows, globals: node._doraGlobals });
       // Rebuild with current cached loras (or "None")
       buildUI(node, node._doraRows, node._doraGlobals, _cachedLoras || ["None"]);
       node.setDirtyCanvas(true, true);
     });
-    wRemove.serialize = false;
+    noSerialize(wRemove);
   });
 
   // Add row button
-  const wAdd = node.addWidget("button", "add_lora", "➕ Add LoRA", () => {
+  const wAdd = node.addWidget("button", "➕ Add LoRA", null, () => {
     node._doraRows.push(makeRowDefaults());
+    setStateOnNode(node, { rows: node._doraRows, globals: node._doraGlobals });
     buildUI(node, node._doraRows, node._doraGlobals, _cachedLoras || ["None"]);
     node.setDirtyCanvas(true, true);
   });
-  wAdd.serialize = false;
+  noSerialize(wAdd);
 
   // Globals (serialized)
   const wStackEnabled = node.addWidget(
     "toggle",
     "stack_enabled",
     !!node._doraGlobals.stack_enabled,
-    (v) => (node._doraGlobals.stack_enabled = !!v)
+    (v) => {
+      node._doraGlobals.stack_enabled = !!v;
+      setStateOnNode(node, { rows: node._doraRows, globals: node._doraGlobals });
+    }
   );
   wStackEnabled.label = "Stack Enabled";
+  noSerialize(wStackEnabled);
 
-  const wVerbose = node.addWidget("toggle", "verbose", !!node._doraGlobals.verbose, (v) => (node._doraGlobals.verbose = !!v));
+  const wVerbose = node.addWidget("toggle", "verbose", !!node._doraGlobals.verbose, (v) => {
+    node._doraGlobals.verbose = !!v;
+    setStateOnNode(node, { rows: node._doraRows, globals: node._doraGlobals });
+  });
   wVerbose.label = "Verbose";
+  noSerialize(wVerbose);
 
   const wLogMissing = node.addWidget(
     "toggle",
     "log_unloaded_keys",
     !!node._doraGlobals.log_unloaded_keys,
-    (v) => (node._doraGlobals.log_unloaded_keys = !!v)
+    (v) => {
+      node._doraGlobals.log_unloaded_keys = !!v;
+      setStateOnNode(node, { rows: node._doraRows, globals: node._doraGlobals });
+    }
   );
   wLogMissing.label = "Log Unloaded Keys";
+  noSerialize(wLogMissing);
 
   // Ensure node is tall enough
   const size = node.computeSize();
@@ -202,37 +276,76 @@ app.registerExtension({
     const origOnNodeCreated = nodeType.prototype.onNodeCreated;
     nodeType.prototype.onNodeCreated = function () {
       const r = origOnNodeCreated?.apply(this, arguments);
-      // Default: one row
-      const rows = [makeRowDefaults()];
-      const globals = { stack_enabled: true, verbose: false, log_unloaded_keys: false };
-      buildUI(this, rows, globals, _cachedLoras || ["None"]);
+      // Default persisted state
+      const state = getStateFromNode(this);
+      buildUI(this, state.rows, state.globals, _cachedLoras || ["None"]);
       // async populate lora dropdown
       fetchLoras().then((loras) => {
-        buildUI(this, this._doraRows || rows, this._doraGlobals || globals, loras);
+        const st = getStateFromNode(this);
+        buildUI(this, st.rows, st.globals, loras);
         this.setDirtyCanvas(true, true);
       });
       return r;
     };
 
-    // Rebuild from saved workflow widget values (so rows persist across save/load)
+    // Make workflow loading safe:
+    // - NEVER allow base configure to try to apply widgets_values (it causes "Widget not found" and aborts workflow load)
+    // - Load/save state via node.properties.dora_power_lora instead of widgets_values.
     const origConfigure = nodeType.prototype.configure;
     nodeType.prototype.configure = function (info) {
-      // Do NOT call origConfigure first, because it would try to apply widgets_values to widgets we haven't created yet.
-      // Instead: reconstruct rows based on widgets_values length, create widgets, then apply values by assignment.
-      const widgetsValues = info?.widgets_values;
-      const parsed = parseRowsFromWidgetValues(widgetsValues);
-      const rows = parsed.rows.length ? parsed.rows : [makeRowDefaults()];
-      const globals = parsed.globals || { stack_enabled: true, verbose: false, log_unloaded_keys: false };
-      buildUI(this, rows, globals, _cachedLoras || ["None"]);
+      try {
+        // 1) Restore state from properties if present (new format)
+        let state = null;
+        if (info?.properties?.dora_power_lora) {
+          state = normalizeState(info.properties.dora_power_lora);
+        } else if (Array.isArray(info?.widgets_values)) {
+          // 2) Backward compat: old workflows saved widget values
+          const parsed = parseRowsFromWidgetValues(info.widgets_values);
+          state = normalizeState({ rows: parsed.rows, globals: parsed.globals });
+        } else {
+          state = normalizeState(null);
+        }
+        setStateOnNode(this, state);
 
-      // Now let the base configure handle position/size/etc (it won't re-apply widgets_values meaningfully now).
-      const r = origConfigure?.call(this, info);
+        // Call base configure but strip widgets_values to prevent workflow load aborts.
+        if (origConfigure) {
+          const safeInfo = info ? { ...info } : info;
+          if (safeInfo) safeInfo.widgets_values = [];
+          origConfigure.call(this, safeInfo);
+        }
 
-      fetchLoras().then((loras) => {
-        buildUI(this, this._doraRows || rows, this._doraGlobals || globals, loras);
-        this.setDirtyCanvas(true, true);
-      });
-      return r;
+        // Build UI from restored state
+        buildUI(this, state.rows, state.globals, _cachedLoras || ["None"]);
+
+        // async populate lora dropdown
+        fetchLoras().then((loras) => {
+          const st = getStateFromNode(this);
+          buildUI(this, st.rows, st.globals, loras);
+          this.setDirtyCanvas(true, true);
+        });
+      } catch (e) {
+        console.warn(`[${EXT_NAME}] configure failed (swallowed to prevent workflow abort)`, e);
+        try {
+          if (origConfigure) {
+            const safeInfo = info ? { ...info } : info;
+            if (safeInfo) safeInfo.widgets_values = [];
+            origConfigure.call(this, safeInfo);
+          }
+        } catch (_) {}
+      }
+      return this;
+    };
+
+    // Ensure future saves don't store widgets_values (we store our state in properties instead).
+    const origOnSerialize = nodeType.prototype.onSerialize;
+    nodeType.prototype.onSerialize = function (o) {
+      try {
+        if (origOnSerialize) origOnSerialize.call(this, o);
+      } catch (_) {}
+      o.properties = o.properties || {};
+      o.properties.dora_power_lora = getStateFromNode(this);
+      // prevent "Widget not found" across versions
+      o.widgets_values = [];
     };
   },
 });


### PR DESCRIPTION
### Motivation
- Prevent workflow load failures caused by legacy `widgets_values` deserialization and cross-version widget mismatches. 
- Make the dynamic LoRA rows and global toggles persist reliably across save/load and across ComfyUI/LiteGraph variants. 
- Avoid relying on widget-array serialization so the UI remains compatible with different ComfyUI builds and future changes.

### Description
- Replace widget-clearing logic with a resilient implementation that handles missing `removeWidget` and different `node.widgets` shapes. 
- Add normalized state helpers `normalizeState`, `getStateFromNode`, and `setStateOnNode`, and a centralized `noSerialize` helper to mark transient widgets as non-serialized. 
- Update `buildUI` and all widget callbacks to persist edits into `node.properties.dora_power_lora` and to avoid serializing per-row widgets as `widgets_values`. 
- Rework node lifecycle hooks so `onNodeCreated` restores from `properties`, `configure` restores from `properties` (with backward compatibility for legacy `widgets_values`) and strips `widgets_values` before calling base `configure`, and `onSerialize` writes `dora_power_lora` into `o.properties` while clearing `o.widgets_values`.

### Testing
- Ran repository inspections and diffs via `git diff` and file listing commands to verify the patch was applied successfully; these checks succeeded. 
- Displayed the patched file content with `nl -ba` to validate the inserted functions and flow changes; this succeeded. 
- Attempted a UI smoke check via a Playwright `page.goto` screenshot, which failed with `net::ERR_EMPTY_RESPONSE` because no running UI server was reachable, so runtime UI validation was not possible in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a61e4574948320b47948822e5e05c8)