### PR TITLE
DoRA Power LoRA Loader: broadcast auto-scaling and UI/state robustness improvements

### DIFF
--- a/ComfyUI/custom_nodes/comfyui_dora_dynamic_lora/nodes.py
+++ b/ComfyUI/custom_nodes/comfyui_dora_dynamic_lora/nodes.py
@@ -6,6 +6,7 @@ import comfy.lora
 import comfy.lora_convert
 import comfy.utils
 import folder_paths
+import torch
 
 _LOG = logging.getLogger(__name__)
 
@@ -68,6 +69,30 @@ _BASE_SUFFIXES = [
     ".reshape_weight",
 ]
 
+_SCALEABLE_SUFFIXES = (
+    ".lora_up.weight",
+    ".lora_down.weight",
+    ".lora_A.weight",
+    ".lora_B.weight",
+    ".lora_A.default.weight",
+    ".lora_B.default.weight",
+    "_lora.up.weight",
+    "_lora.down.weight",
+    ".lora.up.weight",
+    ".lora.down.weight",
+    ".lora_linear_layer.up.weight",
+    ".lora_linear_layer.down.weight",
+    ".alpha",
+    ".dora_scale",
+    ".diff",
+    ".diff_b",
+    ".set_weight",
+    ".reshape_weight",
+    # mochi-style (no .weight suffix)
+    ".lora_A",
+    ".lora_B",
+)
+
 
 def _delete_prefix_keys(lora_sd: Dict[str, Any], prefix: str) -> int:
     """
@@ -99,7 +124,7 @@ def _rename_prefix_keys(lora_sd: Dict[str, Any], from_prefix: str, to_prefix: st
     return created
 
 
-def _clone_base_block(lora_sd: Dict[str, Any], from_base: str, to_base: str) -> int:
+def _clone_base_block(lora_sd: Dict[str, Any], from_base: str, to_base: str, scale: float = 1.0) -> int:
     """
     Clone all entries under from_base.* to to_base.* (by prefix), preserving suffixes.
     Returns number of keys created.
@@ -113,7 +138,12 @@ def _clone_base_block(lora_sd: Dict[str, Any], from_base: str, to_base: str) -> 
         nk = to_base + k[len(from_base) :]
         if nk in lora_sd:
             continue
-        lora_sd[nk] = lora_sd[k]
+        v = lora_sd[k]
+        if scale != 1.0 and isinstance(v, torch.Tensor) and k.endswith(_SCALEABLE_SUFFIXES):
+            # clone() to avoid sharing tensor storage across many broadcasted keys
+            lora_sd[nk] = (v * scale).clone()
+        else:
+            lora_sd[nk] = v
         created += 1
     return created
 
@@ -171,6 +201,8 @@ def _apply_flux2_onetrainer_dora_compat(
     model,
     model_sd_keys: Optional[Set[str]],
     verbose: bool = False,
+    broadcast_auto_scale: bool = True,
+    broadcast_scale: float = 1.0,
 ) -> None:
     """
     Flux2 / OneTrainer DoRA compat:
@@ -202,6 +234,21 @@ def _apply_flux2_onetrainer_dora_compat(
     if verbose:
         _LOG.info("[DoRA Power LoRA Loader] flux2 compat: inferred blocks: double=%s single=%s", depth, depth_single)
 
+    # Broadcasting the same LoRA onto many per-block targets can easily blow up (pink output / NaNs).
+    # Auto-scale reduces the per-target delta so total effect is closer to the original "global module" intent.
+    depth_d = max(1, int(depth) or 1)
+    depth_s = max(1, int(depth_single) or 1)
+    scale_d = float(broadcast_scale) / float(depth_d) if broadcast_auto_scale else float(broadcast_scale)
+    scale_s = float(broadcast_scale) / float(depth_s) if broadcast_auto_scale else float(broadcast_scale)
+    if verbose:
+        _LOG.info(
+            "[DoRA Power LoRA Loader] flux2 compat: broadcast scales: double=%s single=%s (auto=%s base=%s)",
+            scale_d,
+            scale_s,
+            broadcast_auto_scale,
+            broadcast_scale,
+        )
+
     # 2) Broadcast global modulations if present
     # Source bases from OneTrainer export (the ones you logged as missing).
     src_img = "transformer.double_stream_modulation_img.linear"
@@ -217,7 +264,7 @@ def _apply_flux2_onetrainer_dora_compat(
         created = 0
         for i in range(depth):
             dst = f"transformer.transformer_blocks.{i}.norm1.linear"
-            created += _clone_base_block(lora_sd, src_img, dst)
+            created += _clone_base_block(lora_sd, src_img, dst, scale=scale_d)
         if verbose:
             _LOG.info(
                 "[DoRA Power LoRA Loader] flux2 compat: broadcast %s -> transformer_blocks.*.norm1.linear (keys=%s)",
@@ -231,7 +278,7 @@ def _apply_flux2_onetrainer_dora_compat(
         created = 0
         for i in range(depth):
             dst = f"transformer.transformer_blocks.{i}.norm1_context.linear"
-            created += _clone_base_block(lora_sd, src_txt, dst)
+            created += _clone_base_block(lora_sd, src_txt, dst, scale=scale_d)
         if verbose:
             _LOG.info(
                 "[DoRA Power LoRA Loader] flux2 compat: broadcast %s -> transformer_blocks.*.norm1_context.linear (keys=%s)",
@@ -244,7 +291,7 @@ def _apply_flux2_onetrainer_dora_compat(
         created = 0
         for i in range(depth_single):
             dst = f"transformer.single_transformer_blocks.{i}.norm.linear"
-            created += _clone_base_block(lora_sd, src_single, dst)
+            created += _clone_base_block(lora_sd, src_single, dst, scale=scale_s)
         if verbose:
             _LOG.info(
                 "[DoRA Power LoRA Loader] flux2 compat: broadcast %s -> single_transformer_blocks.*.norm.linear (keys=%s)",
@@ -504,6 +551,8 @@ class DoraPowerLoraLoader:
         strength_clip: float,
         verbose: bool,
         log_unloaded_keys: bool,
+        broadcast_auto_scale: bool,
+        broadcast_scale: float,
         model_sd_keys: Optional[Set[str]],
         model_sd_list: Optional[List[str]],
         clip_sd_keys: Optional[Set[str]],
@@ -529,6 +578,8 @@ class DoraPowerLoraLoader:
                 model=model,
                 model_sd_keys=model_sd_keys,
                 verbose=verbose,
+                broadcast_auto_scale=broadcast_auto_scale,
+                broadcast_scale=broadcast_scale,
             )
 
         # Extract base module names from file keys.
@@ -573,10 +624,35 @@ class DoraPowerLoraLoader:
                 loaded = comfy.lora.load_lora(lora_sd, key_map)
 
         # Apply patches to provided model/clip (already cloned by caller).
+        applied_m = []
+        applied_c = []
         if model is not None:
-            model.add_patches(loaded, strength_model)
+            try:
+                applied_m = model.add_patches(loaded, strength_model) or []
+            except Exception:
+                model.add_patches(loaded, strength_model)
         if clip is not None:
-            clip.add_patches(loaded, strength_clip)
+            try:
+                applied_c = clip.add_patches(loaded, strength_clip) or []
+            except Exception:
+                clip.add_patches(loaded, strength_clip)
+
+        if verbose:
+            def _n(x):
+                try:
+                    return len(x)
+                except Exception:
+                    return 0
+
+            _LOG.info(
+                "[DoRA Power LoRA Loader] %s: patches=%s applied(model)=%s applied(clip)=%s strengths(m/c)=%s/%s",
+                lora_name,
+                _n(loaded),
+                _n(applied_m),
+                _n(applied_c),
+                strength_model,
+                strength_clip,
+            )
 
         return model, clip
 
@@ -585,6 +661,11 @@ class DoraPowerLoraLoader:
         stack_enabled = bool(kwargs.get("stack_enabled", True))
         verbose = bool(kwargs.get("verbose", False))
         log_unloaded_keys = bool(kwargs.get("log_unloaded_keys", False))
+        broadcast_auto_scale = bool(kwargs.get("broadcast_auto_scale", True))
+        try:
+            broadcast_scale = float(kwargs.get("broadcast_scale", 1.0))
+        except Exception:
+            broadcast_scale = 1.0
 
         if not stack_enabled:
             return (model, clip)
@@ -629,6 +710,8 @@ class DoraPowerLoraLoader:
                 strength_clip=sc,
                 verbose=verbose,
                 log_unloaded_keys=log_unloaded_keys,
+                broadcast_auto_scale=broadcast_auto_scale,
+                broadcast_scale=broadcast_scale,
                 model_sd_keys=model_sd_keys,
                 model_sd_list=model_sd_list,
                 clip_sd_keys=clip_sd_keys,

--- a/ComfyUI/custom_nodes/comfyui_dora_dynamic_lora/web/dora_power_lora_loader.js
+++ b/ComfyUI/custom_nodes/comfyui_dora_dynamic_lora/web/dora_power_lora_loader.js
@@ -61,12 +61,7 @@ async function fetchLoras() {
 }
 
 function removeAllWidgets(node) {
-  // Be resilient across ComfyUI/LiteGraph variants.
-  if (!node.widgets) {
-    node.widgets = [];
-    return;
-  }
-  // Some builds don't expose removeWidget; clearing array works.
+  node.widgets = node.widgets || [];
   node.widgets.length = 0;
 }
 
@@ -79,8 +74,9 @@ function makeRowDefaults() {
   };
 }
 
+// Back-compat for old workflows that saved widgets_values.
 function parseRowsFromWidgetValues(widgetsValues) {
-  // Our serialized widgets are:
+  // old serialized layout:
   //   per-row: enabled, name, strengthModel, strengthClip  (4)
   //   globals: stack_enabled, verbose, log_unloaded_keys   (3)
   const vals = Array.isArray(widgetsValues) ? widgetsValues : [];
@@ -88,7 +84,10 @@ function parseRowsFromWidgetValues(widgetsValues) {
   const PER_ROW = 4;
   const rows = [];
 
-  if (vals.length < GLOBALS) return { rows, globals: { stack_enabled: true, verbose: false, log_unloaded_keys: false } };
+  if (vals.length < GLOBALS) {
+    return { rows: [], globals: { stack_enabled: true, verbose: false, log_unloaded_keys: false } };
+  }
+
   const rowsCount = Math.max(0, Math.floor((vals.length - GLOBALS) / PER_ROW));
   let idx = 0;
   for (let i = 0; i < rowsCount; i++) {
@@ -108,127 +107,157 @@ function parseRowsFromWidgetValues(widgetsValues) {
   return { rows, globals };
 }
 
-function normalizeState(state) {
-  const rows = Array.isArray(state?.rows) ? state.rows : [];
-  const globals = state?.globals && typeof state.globals === "object" ? state.globals : {};
+function defaultState() {
   return {
-    rows: rows.length ? rows.map((r) => ({
-      enabled: !!r.enabled,
-      name: typeof r.name === "string" ? r.name : "None",
-      strengthModel: Number.isFinite(+r.strengthModel) ? +r.strengthModel : 1.0,
-      strengthClip: Number.isFinite(+r.strengthClip) ? +r.strengthClip : (Number.isFinite(+r.strengthModel) ? +r.strengthModel : 1.0),
-    })) : [makeRowDefaults()],
+    rows: [makeRowDefaults()],
     globals: {
-      stack_enabled: globals.stack_enabled !== undefined ? !!globals.stack_enabled : true,
-      verbose: globals.verbose !== undefined ? !!globals.verbose : false,
-      log_unloaded_keys: globals.log_unloaded_keys !== undefined ? !!globals.log_unloaded_keys : false,
+      stack_enabled: true,
+      verbose: false,
+      log_unloaded_keys: false,
+      broadcast_auto_scale: true,
+      broadcast_scale: 1.0,
     },
   };
 }
 
-function getStateFromNode(node) {
-  const p = node?.properties?.dora_power_lora;
-  if (p && typeof p === "object") return normalizeState(p);
-  return normalizeState({ rows: [makeRowDefaults()], globals: { stack_enabled: true, verbose: false, log_unloaded_keys: false } });
+function sanitizeState(st) {
+  const s = st && typeof st === "object" ? st : defaultState();
+  const rowsIn = Array.isArray(s.rows) ? s.rows : [];
+  const globalsIn = s.globals && typeof s.globals === "object" ? s.globals : {};
+
+  const rows = rowsIn.length
+    ? rowsIn.map((r) => ({
+        enabled: !!r.enabled,
+        name: typeof r.name === "string" ? r.name : "None",
+        strengthModel: Number.isFinite(+r.strengthModel) ? +r.strengthModel : 1.0,
+        strengthClip: Number.isFinite(+r.strengthClip) ? +r.strengthClip : (Number.isFinite(+r.strengthModel) ? +r.strengthModel : 1.0),
+      }))
+    : [makeRowDefaults()];
+
+  const globals = {
+    stack_enabled: globalsIn.stack_enabled !== undefined ? !!globalsIn.stack_enabled : true,
+    verbose: globalsIn.verbose !== undefined ? !!globalsIn.verbose : false,
+    log_unloaded_keys: globalsIn.log_unloaded_keys !== undefined ? !!globalsIn.log_unloaded_keys : false,
+    broadcast_auto_scale: globalsIn.broadcast_auto_scale !== undefined ? !!globalsIn.broadcast_auto_scale : true,
+    broadcast_scale: Number.isFinite(+globalsIn.broadcast_scale) ? +globalsIn.broadcast_scale : 1.0,
+  };
+
+  return { rows, globals };
 }
 
-function setStateOnNode(node, state) {
-  if (!node.properties) node.properties = {};
-  node.properties.dora_power_lora = normalizeState(state);
+function getState(node) {
+  node.properties = node.properties || {};
+  const st = node.properties.dora_power_lora;
+  return sanitizeState(st);
 }
 
-function noSerialize(widget) {
-  if (!widget) return widget;
-  widget.serialize = false;
+function setState(node, st) {
+  node.properties = node.properties || {};
+  node.properties.dora_power_lora = sanitizeState(st);
+}
+
+function setButtonCallback(widget, cb) {
+  // ComfyUI/LiteGraph variants differ; force callback into the widget object.
+  if (!widget) return;
+  widget.callback = cb;
   widget.options = widget.options || {};
-  widget.options.serialize = false;
-  return widget;
+  widget.options.callback = cb;
 }
 
-function buildUI(node, rows, globals, loraValues) {
+function rebuild(node) {
+  const st = getState(node);
+  const lorasNow = _cachedLoras || ["None"];
+  buildUI(node, st, lorasNow);
+  fetchLoras().then((loras) => {
+    buildUI(node, getState(node), loras);
+    node.setDirtyCanvas(true, true);
+  });
+}
+
+function buildUI(node, state, loraValues) {
+  const st = sanitizeState(state);
+  setState(node, st);
   removeAllWidgets(node);
 
-  node._doraRows = rows || [];
-  node._doraGlobals = globals || { stack_enabled: true, verbose: false, log_unloaded_keys: false };
-  setStateOnNode(node, { rows: node._doraRows, globals: node._doraGlobals });
+  node._doraRows = st.rows;
+  node._doraGlobals = st.globals;
 
   const loras = Array.isArray(loraValues) ? loraValues : ["None"];
 
   // Refresh button (helps if new LoRAs are added without restarting)
-  const wRefresh = node.addWidget("button", "↻ Refresh LoRAs", null, () => {
+  const wRefresh = node.addWidget("button", "refresh_loras", "↻ Refresh LoRAs");
+  setButtonCallback(wRefresh, () => {
     invalidateLorasCache();
-    fetchLoras().then((newList) => {
-      buildUI(node, node._doraRows || [], node._doraGlobals || globals, newList);
-      node.setDirtyCanvas(true, true);
-    });
+    rebuild(node);
   });
-  noSerialize(wRefresh);
+  wRefresh.serialize = false;
 
   // Rows
   node._doraRows.forEach((row, i) => {
     const n = i + 1;
 
-    const wEnabled = node.addWidget("toggle", `LoRA ${n} Enabled`, !!row.enabled, (v) => {
+    const wEnabled = node.addWidget("toggle", `lora_${n}_enabled`, !!row.enabled, (v) => {
       row.enabled = !!v;
-      setStateOnNode(node, { rows: node._doraRows, globals: node._doraGlobals });
+      setState(node, { rows: node._doraRows, globals: node._doraGlobals });
     });
     wEnabled.label = `LoRA ${n} Enabled`;
-    noSerialize(wEnabled);
 
-    const wName = node.addWidget("combo", `LoRA ${n}`, row.name ?? "None", (v) => {
-      row.name = v;
-      setStateOnNode(node, { rows: node._doraRows, globals: node._doraGlobals });
-    }, {
+    const wName = node.addWidget("combo", `lora_${n}_name`, row.name ?? "None", (v) => (row.name = v), {
       values: loras,
     });
     wName.label = `LoRA ${n}`;
-    noSerialize(wName);
+    // ensure state persists
+    const _origNameCb = wName.callback;
+    wName.callback = (v) => {
+      if (_origNameCb) _origNameCb(v);
+      setState(node, { rows: node._doraRows, globals: node._doraGlobals });
+    };
 
     const wSm = node.addWidget(
       "number",
-      `Strength (Model) ${n}`,
+      `lora_${n}_strength_model`,
       Number.isFinite(row.strengthModel) ? row.strengthModel : 1.0,
       (v) => {
         row.strengthModel = Number(v);
-        setStateOnNode(node, { rows: node._doraRows, globals: node._doraGlobals });
+        setState(node, { rows: node._doraRows, globals: node._doraGlobals });
       },
       { min: -10.0, max: 10.0, step: 0.05 }
     );
     wSm.label = `Strength (Model)`;
-    noSerialize(wSm);
 
     const wSc = node.addWidget(
       "number",
-      `Strength (Clip) ${n}`,
+      `lora_${n}_strength_clip`,
       Number.isFinite(row.strengthClip) ? row.strengthClip : (Number.isFinite(row.strengthModel) ? row.strengthModel : 1.0),
       (v) => {
         row.strengthClip = Number(v);
-        setStateOnNode(node, { rows: node._doraRows, globals: node._doraGlobals });
+        setState(node, { rows: node._doraRows, globals: node._doraGlobals });
       },
       { min: -10.0, max: 10.0, step: 0.05 }
     );
     wSc.label = `Strength (Clip)`;
-    noSerialize(wSc);
 
-    const wRemove = node.addWidget("button", `✖ Remove LoRA ${n}`, null, () => {
+    const wRemove = node.addWidget("button", `lora_${n}_remove`, "✖ Remove");
+    setButtonCallback(wRemove, () => {
       node._doraRows.splice(i, 1);
       if (!node._doraRows.length) node._doraRows.push(makeRowDefaults());
-      setStateOnNode(node, { rows: node._doraRows, globals: node._doraGlobals });
+      setState(node, { rows: node._doraRows, globals: node._doraGlobals });
       // Rebuild with current cached loras (or "None")
-      buildUI(node, node._doraRows, node._doraGlobals, _cachedLoras || ["None"]);
+      buildUI(node, getState(node), _cachedLoras || ["None"]);
       node.setDirtyCanvas(true, true);
     });
-    noSerialize(wRemove);
+    wRemove.serialize = false;
   });
 
   // Add row button
-  const wAdd = node.addWidget("button", "➕ Add LoRA", null, () => {
+  const wAdd = node.addWidget("button", "add_lora", "➕ Add LoRA");
+  setButtonCallback(wAdd, () => {
     node._doraRows.push(makeRowDefaults());
-    setStateOnNode(node, { rows: node._doraRows, globals: node._doraGlobals });
-    buildUI(node, node._doraRows, node._doraGlobals, _cachedLoras || ["None"]);
+    setState(node, { rows: node._doraRows, globals: node._doraGlobals });
+    buildUI(node, getState(node), _cachedLoras || ["None"]);
     node.setDirtyCanvas(true, true);
   });
-  noSerialize(wAdd);
+  wAdd.serialize = false;
 
   // Globals (serialized)
   const wStackEnabled = node.addWidget(
@@ -237,18 +266,16 @@ function buildUI(node, rows, globals, loraValues) {
     !!node._doraGlobals.stack_enabled,
     (v) => {
       node._doraGlobals.stack_enabled = !!v;
-      setStateOnNode(node, { rows: node._doraRows, globals: node._doraGlobals });
+      setState(node, { rows: node._doraRows, globals: node._doraGlobals });
     }
   );
   wStackEnabled.label = "Stack Enabled";
-  noSerialize(wStackEnabled);
 
   const wVerbose = node.addWidget("toggle", "verbose", !!node._doraGlobals.verbose, (v) => {
     node._doraGlobals.verbose = !!v;
-    setStateOnNode(node, { rows: node._doraRows, globals: node._doraGlobals });
+    setState(node, { rows: node._doraRows, globals: node._doraGlobals });
   });
   wVerbose.label = "Verbose";
-  noSerialize(wVerbose);
 
   const wLogMissing = node.addWidget(
     "toggle",
@@ -256,11 +283,33 @@ function buildUI(node, rows, globals, loraValues) {
     !!node._doraGlobals.log_unloaded_keys,
     (v) => {
       node._doraGlobals.log_unloaded_keys = !!v;
-      setStateOnNode(node, { rows: node._doraRows, globals: node._doraGlobals });
+      setState(node, { rows: node._doraRows, globals: node._doraGlobals });
     }
   );
   wLogMissing.label = "Log Unloaded Keys";
-  noSerialize(wLogMissing);
+
+  const wAutoScale = node.addWidget(
+    "toggle",
+    "broadcast_auto_scale",
+    !!node._doraGlobals.broadcast_auto_scale,
+    (v) => {
+      node._doraGlobals.broadcast_auto_scale = !!v;
+      setState(node, { rows: node._doraRows, globals: node._doraGlobals });
+    }
+  );
+  wAutoScale.label = "Auto-scale broadcast (fix pink/NaNs)";
+
+  const wScale = node.addWidget(
+    "number",
+    "broadcast_scale",
+    Number.isFinite(node._doraGlobals.broadcast_scale) ? node._doraGlobals.broadcast_scale : 1.0,
+    (v) => {
+      node._doraGlobals.broadcast_scale = Number(v);
+      setState(node, { rows: node._doraRows, globals: node._doraGlobals });
+    },
+    { min: 0.0, max: 64.0, step: 0.05 }
+  );
+  wScale.label = "Broadcast scale";
 
   // Ensure node is tall enough
   const size = node.computeSize();
@@ -276,59 +325,55 @@ app.registerExtension({
     const origOnNodeCreated = nodeType.prototype.onNodeCreated;
     nodeType.prototype.onNodeCreated = function () {
       const r = origOnNodeCreated?.apply(this, arguments);
-      // Default persisted state
-      const state = getStateFromNode(this);
-      buildUI(this, state.rows, state.globals, _cachedLoras || ["None"]);
-      // async populate lora dropdown
-      fetchLoras().then((loras) => {
-        const st = getStateFromNode(this);
-        buildUI(this, st.rows, st.globals, loras);
-        this.setDirtyCanvas(true, true);
-      });
+      rebuild(this);
       return r;
     };
 
     // Make workflow loading safe:
-    // - NEVER allow base configure to try to apply widgets_values (it causes "Widget not found" and aborts workflow load)
-    // - Load/save state via node.properties.dora_power_lora instead of widgets_values.
+    // - NEVER let base configure apply widgets_values to our dynamic widget list.
+    // - Persist state in node.properties.dora_power_lora.
     const origConfigure = nodeType.prototype.configure;
     nodeType.prototype.configure = function (info) {
       try {
-        // 1) Restore state from properties if present (new format)
-        let state = null;
+        // 1) Use new persisted state if present
+        let st = null;
         if (info?.properties?.dora_power_lora) {
-          state = normalizeState(info.properties.dora_power_lora);
-        } else if (Array.isArray(info?.widgets_values)) {
-          // 2) Backward compat: old workflows saved widget values
-          const parsed = parseRowsFromWidgetValues(info.widgets_values);
-          state = normalizeState({ rows: parsed.rows, globals: parsed.globals });
+          st = sanitizeState(info.properties.dora_power_lora);
         } else {
-          state = normalizeState(null);
+          // Back-compat: migrate old widgets_values into properties once.
+          if (Array.isArray(info?.widgets_values) && info.widgets_values.length) {
+            const parsed = parseRowsFromWidgetValues(info.widgets_values);
+            st = sanitizeState({
+              rows: parsed.rows,
+              globals: {
+                ...parsed.globals,
+                // new fields default
+                broadcast_auto_scale: true,
+                broadcast_scale: 1.0,
+              },
+            });
+          } else {
+            st = defaultState();
+          }
         }
-        setStateOnNode(this, state);
+        setState(this, st);
 
-        // Call base configure but strip widgets_values to prevent workflow load aborts.
+        // 2) Call base configure with widgets_values removed so it cannot abort workflow loading.
         if (origConfigure) {
           const safeInfo = info ? { ...info } : info;
-          if (safeInfo) safeInfo.widgets_values = [];
-          origConfigure.call(this, safeInfo);
+          if (safeInfo) delete safeInfo.widgets_values;
+          try {
+            origConfigure.call(this, safeInfo);
+          } catch (_) {}
         }
 
-        // Build UI from restored state
-        buildUI(this, state.rows, state.globals, _cachedLoras || ["None"]);
-
-        // async populate lora dropdown
-        fetchLoras().then((loras) => {
-          const st = getStateFromNode(this);
-          buildUI(this, st.rows, st.globals, loras);
-          this.setDirtyCanvas(true, true);
-        });
+        rebuild(this);
       } catch (e) {
         console.warn(`[${EXT_NAME}] configure failed (swallowed to prevent workflow abort)`, e);
         try {
           if (origConfigure) {
             const safeInfo = info ? { ...info } : info;
-            if (safeInfo) safeInfo.widgets_values = [];
+            if (safeInfo) delete safeInfo.widgets_values;
             origConfigure.call(this, safeInfo);
           }
         } catch (_) {}
@@ -336,15 +381,14 @@ app.registerExtension({
       return this;
     };
 
-    // Ensure future saves don't store widgets_values (we store our state in properties instead).
+    // Ensure saves never include widgets_values (avoids "Widget not found" on future loads).
     const origOnSerialize = nodeType.prototype.onSerialize;
     nodeType.prototype.onSerialize = function (o) {
       try {
         if (origOnSerialize) origOnSerialize.call(this, o);
       } catch (_) {}
       o.properties = o.properties || {};
-      o.properties.dora_power_lora = getStateFromNode(this);
-      // prevent "Widget not found" across versions
+      o.properties.dora_power_lora = getState(this);
       o.widgets_values = [];
     };
   },


### PR DESCRIPTION
### Motivation
- Fix Flux2/OneTrainer DoRA compatibility where broadcasting global modulation LoRAs onto per-block keys can blow up (pink output / NaNs) by applying configurable scaling during broadcast.
- Provide UI controls and persisted state for the broadcast scaling and keep backward compatibility with older serialized workflows that used `widgets_values`.
- Make the dynamic widget list resilient across ComfyUI/LiteGraph variants and avoid workflow load aborts caused by base code applying `widgets_values` to dynamic widgets.

### Description
- Add `torch` import, a `_SCALEABLE_SUFFIXES` list, and extend `_clone_base_block` to apply a `scale` parameter and clone scaled tensors when broadcasting using `torch` arithmetic to avoid shared storage.
- Add `broadcast_auto_scale` and `broadcast_scale` parameters to `_apply_flux2_onetrainer_dora_compat` and compute per-depth broadcast scales (auto-dividing by block counts when enabled), then pass scales into each `_clone_base_block` call.
- Capture `model.add_patches` / `clip.add_patches` return values safely and emit verbose logging about number of patches loaded/applied and strengths when `verbose` is enabled.
- Update the web UI (`dora_power_lora_loader.js`) to sanitize and persist state in `node.properties.dora_power_lora`, migrate old `widgets_values` layouts, add controls for `broadcast_auto_scale` and `broadcast_scale`, make widget callbacks/serialization robust across engine variants, and ensure `configure`/`onSerialize` never allow base `widgets_values` to abort workflow loads.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6215d126c8320be00de80a28701d3)