### PR TITLE
Fix mixed positional/kwargs handling in DoRA weight_decompose wrapper

### DIFF
--- a/ComfyUI/custom_nodes/comfyui_dora_dynamic_lora/nodes.py
+++ b/ComfyUI/custom_nodes/comfyui_dora_dynamic_lora/nodes.py
@@ -39,17 +39,32 @@ def _patch_comfy_weight_decompose() -> None:
             wa_base._dora_weight_decompose_first_call_logged = True
             _LOG.warning("[DoRA Power LoRA Loader] weight_decompose_fixed invoked (DoRA normalization patch active).")
 
-        # support both positional and keyword calling styles
-        if args and len(args) >= 7:
-            dora_scale, weight, lora_diff, alpha, strength, intermediate_dtype, function = args[:7]
+        # Support:
+        #  - fully positional: (dora_scale, weight, lora_diff, alpha, strength, intermediate_dtype, function)
+        #  - fully keyword
+        #  - mixed: first 4 required positionals, rest via kwargs (common pattern)
+        dora_scale = None
+        weight = None
+        lora_diff = None
+        alpha = None
+
+        if len(args) >= 4:
+            dora_scale, weight, lora_diff, alpha = args[:4]
         else:
-            dora_scale = kwargs["dora_scale"]
-            weight = kwargs["weight"]
-            lora_diff = kwargs["lora_diff"]
-            alpha = kwargs["alpha"]
-            strength = kwargs.get("strength", 1.0)
-            intermediate_dtype = kwargs.get("intermediate_dtype", weight.dtype)
-            function = kwargs["function"]
+            dora_scale = kwargs.get("dora_scale")
+            weight = kwargs.get("weight")
+            lora_diff = kwargs.get("lora_diff")
+            alpha = kwargs.get("alpha")
+
+        if dora_scale is None or weight is None or lora_diff is None or alpha is None:
+            raise TypeError("weight_decompose_fixed missing required arguments (dora_scale, weight, lora_diff, alpha)")
+
+        # remaining args (optional) can be positional 4.. or kwargs
+        strength = args[4] if len(args) >= 5 else kwargs.get("strength", 1.0)
+        intermediate_dtype = args[5] if len(args) >= 6 else kwargs.get("intermediate_dtype", getattr(weight, "dtype", torch.float32))
+        function = args[6] if len(args) >= 7 else kwargs.get("function")
+        if function is None:
+            raise TypeError("weight_decompose_fixed missing required argument 'function'")
 
         # cast magnitude vector to device/dtype used for intermediate math
         dora_scale_local = comfy.model_management.cast_to_device(dora_scale, weight.device, intermediate_dtype)


### PR DESCRIPTION
### Motivation
- Ensure the `weight_decompose_fixed` wrapper supports the mixed calling style used by ComfyUI where the first four required arguments can be passed positionally and remaining optional arguments via keywords.  
- Avoid `KeyError` when callers omit optional kwargs and provide some args positionally, and surface clear `TypeError` messages for missing required arguments.

### Description
- Update argument parsing in `weight_decompose_fixed` to always take the first four required positionals if present and otherwise fall back to `kwargs` for `dora_scale`, `weight`, `lora_diff`, and `alpha`.  
- Fill optional parameters `strength`, `intermediate_dtype`, and `function` from remaining positional slots when present or from `kwargs` when not.  
- Add explicit `TypeError` checks for missing required arguments and for a missing `function` to produce clearer error messages instead of `KeyError`.  
- Preserve the existing device/dtype casting and weight decomposition logic after the new argument-handling block.

### Testing
- No automated repository tests were run, per the instruction to not execute repository tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a65b6153c48320a0f74410907b9a05)