### PR TITLE
Fix fp32 intermediate_dtype patch for bound-method calculate_weight

### DIFF
--- a/ComfyUI/custom_nodes/comfyui_dora_dynamic_lora/nodes.py
+++ b/ComfyUI/custom_nodes/comfyui_dora_dynamic_lora/nodes.py
@@ -326,19 +326,29 @@ def _patch_comfy_lora_calculate_weight_fp32() -> None:
             param_names = list(sig.parameters.keys())
             has_intermediate = "intermediate_dtype" in sig.parameters
             idx_intermediate = param_names.index("intermediate_dtype") if has_intermediate else -1
+
+            # calculate_weight is an instance method; callers pass args *without* the leading
+            # `self`. When patching by positional index, compensate for the missing self slot so
+            # we overwrite the actual intermediate_dtype argument instead of original_weight.
+            idx_intermediate_call = idx_intermediate
+            if has_intermediate and param_names and param_names[0] == "self":
+                idx_intermediate_call = idx_intermediate - 1
         except Exception:
             sig = None
             has_intermediate = False
             idx_intermediate = -1
+            idx_intermediate_call = -1
 
         def calculate_weight_fixed(self, *args, **kwargs):
             a = list(args)
 
             if has_intermediate and idx_intermediate >= 0:
-                if len(a) > idx_intermediate:
-                    a[idx_intermediate] = torch.float32
-                if len(a) <= idx_intermediate:
-                    kwargs["intermediate_dtype"] = torch.float32
+                # Always force fp32 intermediate dtype.
+                kwargs["intermediate_dtype"] = torch.float32
+
+                # If intermediate_dtype was provided positionally, overwrite the correct slot.
+                if idx_intermediate_call >= 0 and len(a) > idx_intermediate_call:
+                    a[idx_intermediate_call] = torch.float32
             else:
                 for i, v in enumerate(a):
                     if isinstance(v, torch.dtype):


### PR DESCRIPTION
### Motivation
- Prevent LoRA intermediate products from being computed in low-precision due to the patch overwriting the wrong positional argument when `calculate_weight` is called as a bound method, which can cause flush-to-zero behavior and zeroed LoRA deltas.
- Ensure the patch reliably forces `intermediate_dtype=torch.float32` across Comfy variants so small matmul products are preserved during LoRA delta computation.

### Description
- Adjusted `_patch_comfy_lora_calculate_weight_fp32()` to compute a call-time index `idx_intermediate_call` that compensates for the omitted `self` parameter in bound method calls. 
- Always sets `kwargs["intermediate_dtype"] = torch.float32` when the signature exposes `intermediate_dtype`, and overwrite the positional slot at `idx_intermediate_call` if the argument was passed positionally. 
- Preserved the fallback behavior for variants without `intermediate_dtype` by coercing positional `torch.dtype` arguments to `torch.float32`. 
- Change applied in `ComfyUI/custom_nodes/comfyui_dora_dynamic_lora/nodes.py` where adapter classes in `comfy.weight_adapter.lora` are wrapped to use the fixed behavior.

### Testing
- Compiled the modified module with `python -m py_compile ComfyUI/custom_nodes/comfyui_dora_dynamic_lora/nodes.py` and the compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7031c21808320b119d0cec89bb150)