### PR TITLE
Fix duplicate intermediate_dtype forwarding in LoRA fp32 patch

### DIFF
--- a/ComfyUI/custom_nodes/comfyui_dora_dynamic_lora/nodes.py
+++ b/ComfyUI/custom_nodes/comfyui_dora_dynamic_lora/nodes.py
@@ -343,12 +343,16 @@ def _patch_comfy_lora_calculate_weight_fp32() -> None:
             a = list(args)
 
             if has_intermediate and idx_intermediate >= 0:
-                # Always force fp32 intermediate dtype.
-                kwargs["intermediate_dtype"] = torch.float32
-
-                # If intermediate_dtype was provided positionally, overwrite the correct slot.
+                # If intermediate_dtype was provided positionally, overwrite that slot and
+                # DO NOT also pass it as a kwarg (would be "multiple values").
                 if idx_intermediate_call >= 0 and len(a) > idx_intermediate_call:
                     a[idx_intermediate_call] = torch.float32
+                    # If upstream also set it as a kwarg, drop it to avoid duplicates.
+                    if "intermediate_dtype" in kwargs:
+                        kwargs.pop("intermediate_dtype", None)
+                else:
+                    # Otherwise, force via kwarg.
+                    kwargs["intermediate_dtype"] = torch.float32
             else:
                 for i, v in enumerate(a):
                     if isinstance(v, torch.dtype):


### PR DESCRIPTION
### Motivation

- The wrapper that forces `intermediate_dtype=torch.float32` could pass `intermediate_dtype` both positionally and as a kwarg, causing `TypeError: got multiple values for argument 'intermediate_dtype'`.
- Ensure the patch forces fp32 intermediates without producing duplicate-argument errors across Comfy variants.

### Description

- Update `_patch_comfy_lora_calculate_weight_fp32()` in `ComfyUI/custom_nodes/comfyui_dora_dynamic_lora/nodes.py` to only set `kwargs["intermediate_dtype"]` when the positional slot is not present.
- If `intermediate_dtype` is provided positionally, overwrite that positional slot with `torch.float32` and remove any duplicate `intermediate_dtype` kwarg.
- Preserve the existing fallback behavior that replaces any positional `torch.dtype` arguments with `torch.float32` when the signature does not expose an `intermediate_dtype` parameter.

### Testing

- No repository automated tests were run per instructions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7052add388320bd278e407f91e3a8)