### PR TITLE
Update README, rename node to DoRA Power LoRA Loader, and streamline UI row controls

### DIFF
--- a/ComfyUI/custom_nodes/comfyui_dora_dynamic_lora/__init__.py
+++ b/ComfyUI/custom_nodes/comfyui_dora_dynamic_lora/__init__.py
@@ -20,5 +20,5 @@ NODE_CLASS_MAPPINGS = {
 }
 
 NODE_DISPLAY_NAME_MAPPINGS = {
-    "DoRA Power LoRA Loader": "DoRA Power LoRA Loader (DoRA + Flux2/OneTrainer key-fix)",
+    "DoRA Power LoRA Loader": "DoRA Power LoRA Loader",
 }

--- a/ComfyUI/custom_nodes/comfyui_dora_dynamic_lora/web/dora_power_lora_loader.js
+++ b/ComfyUI/custom_nodes/comfyui_dora_dynamic_lora/web/dora_power_lora_loader.js
@@ -77,14 +77,14 @@ function makeRowDefaults() {
 // Back-compat for old workflows that saved widgets_values.
 function parseRowsFromWidgetValues(widgetsValues) {
   // legacy serialized layouts:
-  //   per-row: enabled, name, strengthModel, strengthClip  (4)
+  //   compact per-row: enabled, name, strengthModel  (3)
+  //   old per-row: enabled, name, strengthModel, strengthClip  (4)
   //   globals v1: stack_enabled, verbose, log_unloaded_keys   (3)
   //   globals v2: v1 + dora_decompose_debug, dora_decompose_debug_n,
   //               dora_decompose_debug_stack_depth, dora_slice_fix (7)
   const vals = Array.isArray(widgetsValues) ? widgetsValues : [];
-  const PER_ROW = 4;
 
-  const parseWithGlobals = (GLOBALS) => {
+  const parseWithLayout = (PER_ROW, GLOBALS) => {
     if (vals.length < GLOBALS) return null;
     if ((vals.length - GLOBALS) % PER_ROW !== 0) return null;
 
@@ -97,9 +97,13 @@ function parseRowsFromWidgetValues(widgetsValues) {
       const nm = vals[idx++];
       r.name = typeof nm === "string" ? nm : (nm ?? "None");
       const sm = Number(vals[idx++]);
-      const sc = Number(vals[idx++]);
       r.strengthModel = sm;
-      r.strengthClip = sc;
+      if (PER_ROW === 4) {
+        const sc = Number(vals[idx++]);
+        r.strengthClip = Number.isFinite(sc) ? sc : sm;
+      } else {
+        r.strengthClip = sm;
+      }
       outRows.push(r);
     }
 
@@ -131,12 +135,17 @@ function parseRowsFromWidgetValues(widgetsValues) {
     return true;
   };
 
-  // Prefer v1 when ambiguous (e.g. len=7 can be one-row v1 or zero-row v2).
-  const v1 = parseWithGlobals(3);
-  if (looksValid(v1)) return v1;
+  const layouts = [
+    [4, 3],
+    [4, 7],
+    [3, 3],
+    [3, 7],
+  ];
 
-  const v2 = parseWithGlobals(7);
-  if (looksValid(v2)) return v2;
+  for (const [perRow, globals] of layouts) {
+    const parsed = parseWithLayout(perRow, globals);
+    if (looksValid(parsed)) return parsed;
+  }
 
   return { rows: [], globals: { stack_enabled: true, verbose: false, log_unloaded_keys: false } };
 }
@@ -250,12 +259,12 @@ function buildUI(node, state, loraValues) {
       row.enabled = !!v;
       setState(node, { rows: node._doraRows, globals: node._doraGlobals });
     });
-    wEnabled.label = `LoRA ${n} Enabled`;
+    wEnabled.label = `LoRA ${n}`;
 
     const wName = node.addWidget("combo", `lora_${n}_name`, row.name ?? "None", (v) => (row.name = v), {
       values: loras,
     });
-    wName.label = `LoRA ${n}`;
+    wName.label = `Name`;
     // ensure state persists
     const _origNameCb = wName.callback;
     wName.callback = (v) => {
@@ -273,19 +282,7 @@ function buildUI(node, state, loraValues) {
       },
       { min: -10.0, max: 10.0, step: 0.05 }
     );
-    wSm.label = `Strength (Model)`;
-
-    const wSc = node.addWidget(
-      "number",
-      `lora_${n}_strength_clip`,
-      Number.isFinite(row.strengthClip) ? row.strengthClip : (Number.isFinite(row.strengthModel) ? row.strengthModel : 1.0),
-      (v) => {
-        row.strengthClip = Number(v);
-        setState(node, { rows: node._doraRows, globals: node._doraGlobals });
-      },
-      { min: -10.0, max: 10.0, step: 0.05 }
-    );
-    wSc.label = `Strength (Clip)`;
+    wSm.label = `Weight`;
 
     const wRemove = node.addWidget("button", `lora_${n}_remove`, "✖ Remove");
     setButtonCallback(wRemove, () => {
@@ -369,7 +366,7 @@ function buildUI(node, state, loraValues) {
       setState(node, { rows: node._doraRows, globals: node._doraGlobals });
     }
   );
-  wAutoScale.label = "Auto-scale broadcast (fix pink/NaNs)";
+  wAutoScale.label = "Auto-scale broadcast";
 
   const wScale = node.addWidget(
     "number",

--- a/README.md
+++ b/README.md
@@ -1,73 +1,173 @@
 # comfyui_dora_dynamic_lora
 
-Custom ComfyUI node that loads **DoRA LoRAs** (and regular LoRAs) when the LoRA file’s module keys
-don’t match ComfyUI’s built-in key map (common with **OneTrainer / Flux2** training exports).
+Custom ComfyUI node that loads and stacks **regular LoRAs and DoRA LoRAs**, with additional Flux/Flux2 + OneTrainer
+compatibility and DoRA stability fixes.
 
-This node also includes **Power LoRA Loader-style stacking**: add multiple LoRAs inside a single node.
+This repo contains two distinct parts:
 
-ComfyUI already supports DoRA math (it reads `*.dora_scale` and applies weight decomposition).
-This node does **not** re-implement DoRA — it fixes **key mapping** so those tensors actually load.
+1) **A Power LoRA Loader-style node** (multiple LoRAs in one node, per-LoRA strengths).
+2) **Targeted ComfyUI patches and transforms** needed for Flux/Flux2 DoRA LoRAs to apply correctly and avoid known
+   failure modes.
 
-## Main symptom this fixes (Flux.2 Klein 9B etc.)
+## Confirmed adaLN swap-scale alignment fix (Flux2 DoRA)
 
-When the LoRA weights fail to map/load, a common visible result is a **pink/magenta output image** (or otherwise
-obviously broken output), even though the workflow “runs”.
+A known Flux2 DoRA failure mode is fixed by aligning DoRA’s magnitude vector (`dora_scale`) with the same permutation
+ComfyUI applies to the LoRA delta for **adaLN_modulation** weights.
 
-Logs usually include lots of lines like:
+Implementation:
 
-`lora key not loaded: transformer....linear.dora_scale`
+- This repo patches `comfy.weight_adapter.base.weight_decompose`.
+- When ComfyUI applies a `swap_scale_shift` function to the delta (used for adaLN_modulation weights), the patch
+  applies that *same* transform to `dora_scale` before computing the DoRA scaling.
+- Node toggle: **“DoRA adaLN swap_scale_shift fix”** (`dora_adaln_swap_fix`, default **ON**).
 
-Meaning: the DoRA/LoRA tensors exist in the file, but ComfyUI can’t map them to real model weights.
+## Other fixes and compatibility layers
 
-In particular, **Flux/Flux2 in ComfyUI uses `Modulation.lin`**, while some trainers export keys as
-`...modulation...linear...` — so the loader must translate `.linear -> .lin` for those modules.
+### 1) Correct DoRA normalization (norm(V) in fp32)
 
-## What it does
+This repo patches `comfy.weight_adapter.base.weight_decompose` to:
 
-1. Loads the LoRA file and normalizes formats via `comfy.lora_convert.convert_lora`.
-2. Builds ComfyUI’s standard `key_map` (so all built-in mapping logic stays intact).
-3. Extracts “base module names” from the LoRA file (e.g. `...linear` before `.lora_up.weight`, `.dora_scale`, etc.).
-4. Applies a Flux2/OneTrainer compatibility transform before mapping:
-   - renames `transformer.time_guidance_embed.*` to `transformer.time_text_embed.*`
-   - broadcasts global modulation blocks into per-block targets ComfyUI maps (`transformer_blocks.*.norm1*`, `single_transformer_blocks.*.norm.linear`)
-5. For bases missing in `key_map`, it dynamically matches them to `model/clip.state_dict()` keys by suffix.
-   - Includes `.linear -> .lin` rewrites for modulation layers.
-6. Calls ComfyUI’s `comfy.lora.load_lora(...)` to produce patches and applies them to cloned model/clip.
+- Perform DoRA math in **fp32**.
+- Normalize using the norm of the **updated weight** `V = W + Δ` (where `Δ` is the LoRA delta after applying
+  `alpha`), rather than normalizing against the base weight.
+
+### 2) Slice-aware `dora_scale` for sliced/offset patches (Flux2 qkv)
+
+Flux/Flux2 key maps can include **sliced targets** (e.g. qkv packed weights). In those cases, ComfyUI applies LoRA to
+only a slice of a weight tensor. This repo’s `weight_decompose` patch includes an optional **slice fix** that slices
+`dora_scale` to the matching offset/length when possible.
+
+Node toggle: **“DoRA slice-fix for offset patches (Flux2)”** (`dora_slice_fix`, default **ON**).
+
+### 3) Force fp32 intermediates when building `lora_diff`
+
+This repo patches `comfy.weight_adapter.lora.*.calculate_weight()` to force `intermediate_dtype=torch.float32`.
+This is specifically to avoid mixed-precision paths flushing very small intermediate products to zero while building
+`lora_diff`.
+
+### 4) OneTrainer “Apply on output axis (DoRA only)” direction-matrix fix
+
+Some OneTrainer exports store the direction matrices (`lora_up`/`lora_down`, or `lora_A`/`lora_B`) in a layout that
+does not match the destination weight (swapped and/or transposed). This repo compares the shapes against the mapped
+destination weight and applies one of the following fixes when it matches a known pattern:
+
+- swap `up` and `down`
+- transpose one or both matrices
+
+This fix runs automatically when a base has `*.dora_scale` and corresponding direction matrices.
+
+### 5) Flux2 / OneTrainer key compatibility transforms
+
+Before mapping/loading, the loader may transform the LoRA state dict:
+
+- Rename `transformer.time_guidance_embed.*` → `transformer.time_text_embed.*` (only if the target prefix is not
+  already present).
+- Broadcast OneTrainer’s **global modulation** LoRAs onto the **per-block** keys ComfyUI maps, using the current
+  model’s `key_map` to discover the actual targets.
+
+Broadcast controls:
+
+- **Broadcast OneTrainer modulation LoRAs** (`broadcast_modulations`, default **ON**)
+- **Include DoRA dora_scale in broadcast** (`broadcast_include_dora_scale`, default **OFF**)
+- **Auto-scale broadcast** (`broadcast_auto_scale`, default **ON**) — divides `broadcast_scale` by the number of
+  broadcast targets.
+- **Broadcast scale** (`broadcast_scale`, default `1.0`)
+
+### 6) Dynamic key mapping (suffix matching + `.linear → .lin`)
+
+After building ComfyUI’s standard key map via:
+
+- `comfy.lora.model_lora_keys_unet(...)`
+- `comfy.lora.model_lora_keys_clip(...)`
+
+…this node extends it for any base modules present in the LoRA file but missing from the map. It matches bases to
+`model.state_dict()` / `clip.state_dict()` keys by suffix, including these built-in variants:
+
+- stripping common prefixes (`diffusion_model.`, `model.`, `transformer.`, etc.)
+- rewriting Flux naming differences: `.linear` ↔ `.lin`
+
+If multiple candidates match, it picks the shortest match and prefers candidates containing `diffusion_model.`.
+
+### 7) `convert_lora` bypass when it zeroes direction matrices
+
+The loader normally runs `comfy.lora_convert.convert_lora(...)`. It also computes stats on direction matrices before
+and after conversion. If conversion turns a non-zero set of `.lora_up.weight` tensors into all zeros, it reloads the
+file and bypasses conversion for that LoRA.
+
+### 8) Diagnostics: NaN/Inf checks + quantization warnings
+
+The loader emits warnings when:
+
+- The LoRA file contains NaN/Inf tensors.
+- The loaded patches contain NaN/Inf tensors.
+- A quantized/mixed-precision base model is detected in the UNet `state_dict()` and the LoRA contains DoRA tensors
+  (`*.dora_scale`).
 
 ## Install
 
-Place this folder here:
+Copy the folder into:
 
 `ComfyUI/custom_nodes/comfyui_dora_dynamic_lora/`
 
-Then restart ComfyUI.
+Restart ComfyUI.
 
 ## Node
 
-**DoRA Power LoRA Loader (DoRA + Flux2/OneTrainer key-fix)**  
+**DoRA Power LoRA Loader**  
 Category: `loaders`
 
-Features:
-- Add **multiple LoRAs inside one node** (Power LoRA Loader style).
-- Each row has:
-  - enabled toggle
-  - LoRA name (dropdown)
-  - model strength
-  - clip strength
-- Global options:
-  - stack enabled
-  - verbose logging
-  - log missing/unloaded keys
+### Per-LoRA rows
 
-## Notes / limitations
+Each row has:
 
-- The dynamic matcher is best-effort. If multiple model weights share the same suffix, it picks the shortest match
-  and prefers keys containing `diffusion_model.`.
-- If you suspect wrong mapping, enable `verbose` and inspect the `map: <base> -> <weight>` logs.
+- Enabled toggle
+- LoRA name (dropdown; loaded from `/dora_dynamic_lora/loras`)
+- Weight (applies to Model/CLIP)
+
+### Global options
+
+- Stack Enabled
+- Verbose
+- Log Unloaded Keys
+- Broadcast OneTrainer modulation LoRAs
+- Include DoRA dora_scale in broadcast
+- Auto-scale broadcast
+- Broadcast scale
+- DoRA slice-fix for offset patches (Flux2)
+- DoRA adaLN swap_scale_shift fix
+- DoRA decompose debug logs
+- DoRA debug lines
+- DoRA debug stack depth
+
+## How it applies LoRAs (high level)
+
+For each enabled row:
+
+1) Load the LoRA file (safe_load when supported).
+2) Optionally bypass `convert_lora` if it zeroes direction matrices.
+3) Apply Flux2/OneTrainer compatibility transforms (rename + optional broadcast).
+4) Build ComfyUI key map for UNet and CLIP, then extend it with dynamic suffix matches.
+5) Apply OneTrainer output-axis direction-matrix fix (when applicable).
+6) Call `comfy.lora.load_lora(...)` and apply patches via `model.add_patches(...)` / `clip.add_patches(...)`.
+
+## Important implementation detail
+
+This custom node **monkey-patches** ComfyUI internals at import time:
+
+- `comfy.weight_adapter.base.weight_decompose`
+- `comfy.weight_adapter.lora.*.calculate_weight` (classes that expose it)
+
+These patches affect DoRA/LoRA application in the running ComfyUI process, not only this node.
 
 ## Troubleshooting
 
-- Still seeing “lora key not loaded”:
-  - enable `verbose = true` and `log_unloaded_keys = true`
-  - check which bases are unresolved in logs
-  - if the unresolved bases have a consistent prefix mismatch, extend `_candidate_base_variants()` in `nodes.py`.
+- Flux2 DoRA instability:
+  - ensure **DoRA adaLN swap_scale_shift fix** is enabled (`dora_adaln_swap_fix`)
+  - check logs for NaN/Inf warnings (LoRA tensors or loaded patches)
+- LoRA loads but has almost no effect:
+  - in verbose mode, the loader warns if **all** `.lora_up` direction matrices are zero in the file (training/export
+    issue, not loader)
+- Suspected mapping problems:
+  - enable **Verbose** and **Log Unloaded Keys** and inspect:
+    - `map: <base> -> <weight>` lines
+    - `unresolved LoRA base:` lines


### PR DESCRIPTION
### Motivation

- Clarify documentation and remove wording that incorrectly framed the auto-scale option as a specific “pink/NaNs” fix while describing the actual adaLN alignment behavior.  
- Present the node with a shorter, consistent display name and reduce per-row UI footprint to match a compact Power LoRA Loader-style interface.  
- Preserve backwards compatibility for older workflows that serialized rows with separate Model/Clip strengths.  

### Description

- Rewrote `README.md` with the requested documentation, renaming the pink-focused claim to an explicit "adaLN swap-scale alignment fix" and expanding the explanation of DoRA/Flux2/OneTrainer compatibility and patches.  
- Changed the node display mapping so the node is shown simply as `DoRA Power LoRA Loader` and updated related display strings.  
- Simplified the frontend row UI (`web/dora_power_lora_loader.js`) to use a single per-row `Weight` control (applies to Model/CLIP), shortened labels, and removed the separate Clip strength widget.  
- Added compact/legacy parsing support in the frontend so both the new 3-field per-row layout and older 4-field layouts are recognized when loading saved workflows.  

### Testing

- Verified Python files compile with `python -m py_compile ComfyUI/custom_nodes/comfyui_dora_dynamic_lora/__init__.py ComfyUI/custom_nodes/comfyui_dora_dynamic_lora/nodes.py` (succeeded).  
- Validated the frontend JS with `node --check ComfyUI/custom_nodes/comfyui_dora_dynamic_lora/web/dora_power_lora_loader.js` (succeeded).  
- Attempted to capture a UI screenshot via Playwright against a local ComfyUI server (`http://127.0.0.1:8188`), but the server was not reachable in this environment (`net::ERR_EMPTY_RESPONSE`), so no screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7435c661c8320a6da3d027a701513)