### PR TITLE
Align DoRA A/B handling with Diffusers FLUX conventions

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -1437,12 +1437,12 @@ def _log_lora_direction_stats(tag: str, lora_sd: Dict[str, Any], verbose: bool) 
         return
     suffix_groups = (
         (".lora_up.weight", ".lora_down.weight"),
-        (".lora_A.weight", ".lora_B.weight"),
-        (".lora_A.default.weight", ".lora_B.default.weight"),
+        (".lora_B.weight", ".lora_A.weight"),
+        (".lora_B.default.weight", ".lora_A.default.weight"),
         ("_lora.up.weight", "_lora.down.weight"),
         (".lora.up.weight", ".lora.down.weight"),
         (".lora_linear_layer.up.weight", ".lora_linear_layer.down.weight"),
-        (".lora_A", ".lora_B"),
+        (".lora_B", ".lora_A"),
     )
     for up_s, down_s in suffix_groups:
         ups = [v for k, v in lora_sd.items() if str(k).endswith(up_s) and isinstance(v, torch.Tensor)]
@@ -1540,12 +1540,12 @@ def _fix_onetrainer_output_axis_dora_mats(
     sd_clip = clip_state_dict or {}
     pair_suffixes = (
         (".lora_up.weight", ".lora_down.weight"),
-        (".lora_A.weight", ".lora_B.weight"),
-        (".lora_A.default.weight", ".lora_B.default.weight"),
+        (".lora_B.weight", ".lora_A.weight"),
+        (".lora_B.default.weight", ".lora_A.default.weight"),
         ("_lora.up.weight", "_lora.down.weight"),
         (".lora.up.weight", ".lora.down.weight"),
         (".lora_linear_layer.up.weight", ".lora_linear_layer.down.weight"),
-        (".lora_A", ".lora_B"),
+        (".lora_B", ".lora_A"),
     )
     fixed = 0
     checked = 0

--- a/nodes.py
+++ b/nodes.py
@@ -531,6 +531,17 @@ _UP_ONLY_SCALE_SUFFIXES = (
     ".lora_A",
 )
 
+_LORA_DIRECTION_SUFFIX_PAIRS = (
+    (".lora_up.weight", ".lora_down.weight"),
+    (".lora_B.weight", ".lora_A.weight"),
+    (".lora_B.default.weight", ".lora_A.default.weight"),
+    ("_lora.up.weight", "_lora.down.weight"),
+    (".lora.up.weight", ".lora.down.weight"),
+    (".lora_linear_layer.up.weight", ".lora_linear_layer.down.weight"),
+    # mochi-style (no .weight suffix)
+    (".lora_B", ".lora_A"),
+)
+
 # Only broadcast true LoRA "delta" parameters.
 # IMPORTANT: do NOT broadcast DoRA-only params like dora_scale / w_norm / b_norm by default.
 _BROADCAST_DELTA_SUFFIXES = (
@@ -1435,15 +1446,7 @@ def _log_lora_direction_stats(tag: str, lora_sd: Dict[str, Any], verbose: bool) 
     """Targeted stats for direction matrices (up/down). Helps distinguish 'missing/ignored' vs 'all zeros'."""
     if not verbose:
         return
-    suffix_groups = (
-        (".lora_up.weight", ".lora_down.weight"),
-        (".lora_B.weight", ".lora_A.weight"),
-        (".lora_B.default.weight", ".lora_A.default.weight"),
-        ("_lora.up.weight", "_lora.down.weight"),
-        (".lora.up.weight", ".lora.down.weight"),
-        (".lora_linear_layer.up.weight", ".lora_linear_layer.down.weight"),
-        (".lora_B", ".lora_A"),
-    )
+    suffix_groups = _LORA_DIRECTION_SUFFIX_PAIRS
     for up_s, down_s in suffix_groups:
         ups = [v for k, v in lora_sd.items() if str(k).endswith(up_s) and isinstance(v, torch.Tensor)]
         downs = [v for k, v in lora_sd.items() if str(k).endswith(down_s) and isinstance(v, torch.Tensor)]
@@ -1538,15 +1541,7 @@ def _fix_onetrainer_output_axis_dora_mats(
     """
     sd_model = model_state_dict or {}
     sd_clip = clip_state_dict or {}
-    pair_suffixes = (
-        (".lora_up.weight", ".lora_down.weight"),
-        (".lora_B.weight", ".lora_A.weight"),
-        (".lora_B.default.weight", ".lora_A.default.weight"),
-        ("_lora.up.weight", "_lora.down.weight"),
-        (".lora.up.weight", ".lora.down.weight"),
-        (".lora_linear_layer.up.weight", ".lora_linear_layer.down.weight"),
-        (".lora_B", ".lora_A"),
-    )
+    pair_suffixes = _LORA_DIRECTION_SUFFIX_PAIRS
     fixed = 0
     checked = 0
     examples: List[str] = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "dora-dynamic-lora-loader"
 description = "A ComfyUI custom node that loads and stacks regular LoRAs and DoRA LoRAs with Flux/Flux2 and OneTrainer compatibility fixes."
-version = "1.0.8"
+version = "1.0.9"
 license = { file = "LICENSE" }
 
 [project.urls]


### PR DESCRIPTION
Summary
- swap the A/B suffix ordering used when logging direction stats so Diffusers-style FLUX keys keep their intended orientation
- apply the same suffix ordering correction during the OneTrainer output-axis DoRA mat fix so properly oriented pairs are no longer inverted
Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized LoRA orientation mapping to reduce repetition and improve maintainability; no change to behavior or public interfaces.

* **Chore**
  * Project version bumped to 1.0.9.

* **Bug Fixes**
  * No runtime behavior changes; existing LoRA orientation handling remains correct.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->