### PR TITLE
Fix auto-strength reporting and UI state handling

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -1,4 +1,6 @@
 import logging
+import json
+import math
 import inspect
 import re
 import sys
@@ -721,6 +723,37 @@ def _auto_strength_get_analysis_load_device(model: Any, clip: Any = None) -> Any
                 if cpu_fallback is None:
                     cpu_fallback = device
     return cpu_fallback
+
+
+def _auto_strength_safe_number(value: Any) -> Optional[float]:
+    try:
+        v = float(value)
+    except Exception:
+        return None
+    if not math.isfinite(v):
+        return None
+    return v
+
+
+def _auto_strength_describe_device(value: Any) -> str:
+    device = _torch_device_or_none(value)
+    if device is not None:
+        return str(device)
+    if value is None:
+        return "cpu"
+    try:
+        return str(value)
+    except Exception:
+        return "unknown"
+
+
+def _auto_strength_json_dumps(value: Any, *, pretty: bool = False) -> str:
+    kwargs = {"ensure_ascii": False, "sort_keys": False}
+    if pretty:
+        kwargs["indent"] = 2
+    else:
+        kwargs["separators"] = (",", ":")
+    return json.dumps(value, **kwargs)
 
 
 def _src_has_dora_params(lora_sd: Dict[str, Any], base: str) -> bool:
@@ -1987,7 +2020,7 @@ def _auto_strength_measure_base_delta(
         )
 
 
-def _auto_strength_compute_base_targets(
+def _auto_strength_analyze_base_targets(
     lora_sd: Dict[str, Any],
     lora_bases: Iterable[str],
     key_map: Dict[str, Any],
@@ -2001,9 +2034,10 @@ def _auto_strength_compute_base_targets(
     ratio_ceiling: float,
     logical_groups: Optional[Dict[str, Tuple[str, float]]] = None,
     verbose: bool = False,
-) -> Dict[str, float]:
+) -> Tuple[Dict[str, float], Dict[str, Any]]:
     """
-    Compute per-base target strengths.
+    Compute per-base target strengths and preserve a structured report that matches
+    the loader's real logical-group-aware measurement model.
 
     Invariants:
       - auto-strength must modulate the same *linear delta* that standard LoRA and
@@ -2027,7 +2061,11 @@ def _auto_strength_compute_base_targets(
     base_cohorts: Dict[str, Tuple[str, str]] = {}
     base_norms: Dict[str, float] = {}
     base_logical_ids: Dict[str, str] = {}
+    base_logical_scales: Dict[str, float] = {}
     logical_norms: Dict[Tuple[str, str, str], float] = {}
+    logical_members: Dict[Tuple[str, str, str], List[str]] = {}
+    skipped_zero_strength_members: Dict[Tuple[str, str, str], List[str]] = {}
+    skipped_zero_strength_bases: List[str] = []
     targets: Dict[str, float] = {}
 
     for base in lora_bases:
@@ -2042,8 +2080,6 @@ def _auto_strength_compute_base_targets(
         base_cohorts[base] = cohort
         global_strength = float(strength_model if group == "model" else strength_clip)
         targets[base] = global_strength
-        if abs(global_strength) < _AUTO_STRENGTH_EPS:
-            continue
 
         logical_id = base
         logical_scale = 1.0
@@ -2058,6 +2094,15 @@ def _auto_strength_compute_base_targets(
         if not (logical_scale > _AUTO_STRENGTH_EPS):
             logical_scale = 1.0
         base_logical_ids[base] = logical_id
+        base_logical_scales[base] = logical_scale
+        logical_key = (cohort[0], cohort[1], logical_id)
+
+        if abs(global_strength) < _AUTO_STRENGTH_EPS:
+            skipped_zero_strength_members.setdefault(logical_key, []).append(base)
+            skipped_zero_strength_bases.append(base)
+            continue
+
+        logical_members.setdefault(logical_key, []).append(base)
 
         norm = _auto_strength_measure_base_delta(
             lora_sd=lora_sd,
@@ -2073,7 +2118,6 @@ def _auto_strength_compute_base_targets(
             continue
         base_norms[base] = norm
         logical_norm = float(norm / logical_scale)
-        logical_key = (cohort[0], cohort[1], logical_id)
         logical_norms[logical_key] = logical_norm
         grouped_norms.setdefault(cohort, {}).setdefault(logical_id, []).append(logical_norm)
 
@@ -2104,40 +2148,183 @@ def _auto_strength_compute_base_targets(
         ratio = max(ratio_floor, min(ratio_ceiling, ratio))
         targets[base] = float(global_strength * ratio)
 
+    measured = len(base_norms)
+    total = len(base_groups)
+    analyzable = sum(len(v) for v in logical_members.values())
+    measured_logical = sum(1 for logical_key in logical_members.keys() if logical_norms.get(logical_key, 0.0) > _AUTO_STRENGTH_EPS)
+
+    cohorts_report: List[Dict[str, Any]] = []
+    for cohort in sorted(set(base_cohorts.values())):
+        group, family = cohort
+        cohort_members = [k for k in logical_members.keys() if k[0] == group and k[1] == family]
+        measured_members = [k for k in cohort_members if logical_norms.get(k, 0.0) > _AUTO_STRENGTH_EPS]
+        total_bases = sum(len(logical_members.get(k, [])) for k in cohort_members)
+        measured_bases = sum(sum(1 for base in logical_members.get(k, []) if base in base_norms) for k in cohort_members)
+        skipped_bases = sum(
+            len(skipped_zero_strength_members.get(k, []))
+            for k in skipped_zero_strength_members.keys()
+            if k[0] == group and k[1] == family
+        )
+        cohorts_report.append(
+            {
+                "group": group,
+                "family": family,
+                "mean_norm": _auto_strength_safe_number(group_means.get(cohort)),
+                "logical_count": len(cohort_members),
+                "measured_logical_count": len(measured_members),
+                "base_count": total_bases,
+                "skipped_zero_strength_base_count": skipped_bases,
+                "measured_base_count": measured_bases,
+            }
+        )
+
+    logical_reports: List[Dict[str, Any]] = []
+    for logical_key, members in logical_members.items():
+        group, family, logical_id = logical_key
+        global_strength = float(strength_model if group == "model" else strength_clip)
+        logical_norm = logical_norms.get(logical_key)
+        cohort_mean = group_means.get((group, family))
+        ratio_raw = None
+        ratio_applied = None
+        if logical_norm is not None and cohort_mean is not None and logical_norm > _AUTO_STRENGTH_EPS:
+            ratio_raw = float(cohort_mean / logical_norm)
+            ratio_applied = float(max(ratio_floor, min(ratio_ceiling, ratio_raw)))
+        fallback_to_global = ratio_applied is None
+        target_strength = float(global_strength if fallback_to_global else global_strength * ratio_applied)
+        bases_report = []
+        measured_base_count = 0
+        for base in sorted(members):
+            base_target = float(targets.get(base, global_strength))
+            base_ratio = None
+            if abs(global_strength) > _AUTO_STRENGTH_EPS:
+                base_ratio = float(base_target / global_strength)
+            if base in base_norms:
+                measured_base_count += 1
+            bases_report.append(
+                {
+                    "base": base,
+                    "norm": _auto_strength_safe_number(base_norms.get(base)),
+                    "logical_scale": _auto_strength_safe_number(base_logical_scales.get(base, 1.0)),
+                    "measured": base in base_norms,
+                    "ratio_applied": _auto_strength_safe_number(base_ratio),
+                    "target_strength": base_target,
+                }
+            )
+
+        logical_reports.append(
+            {
+                "group": group,
+                "family": family,
+                "logical_id": logical_id,
+                "fanout": len(members),
+                "measured_base_count": measured_base_count,
+                "mean_norm": _auto_strength_safe_number(logical_norm),
+                "cohort_mean_norm": _auto_strength_safe_number(cohort_mean),
+                "ratio_raw": _auto_strength_safe_number(ratio_raw),
+                "ratio_applied": _auto_strength_safe_number(ratio_applied),
+                "global_strength": global_strength,
+                "target_strength": target_strength,
+                "fallback_to_global": fallback_to_global,
+                "bases": bases_report,
+            }
+        )
+
+    logical_reports.sort(
+        key=lambda item: (
+            -abs((_auto_strength_safe_number(item.get("ratio_applied")) or 1.0) - 1.0),
+            str(item.get("group") or ""),
+            str(item.get("family") or ""),
+            str(item.get("logical_id") or ""),
+        )
+    )
+
+    report = {
+        "schema": 1,
+        "kind": "dora_auto_strength_report",
+        "analysis_device_mode": str(analysis_device_mode),
+        "analysis_load_device": _auto_strength_describe_device(analysis_load_device),
+        "strength_model": float(strength_model),
+        "strength_clip": float(strength_clip),
+        "ratio_floor": ratio_floor,
+        "ratio_ceiling": ratio_ceiling,
+        "mapped_bases": total,
+        "analyzable_bases": analyzable,
+        "measured_bases": measured,
+        "logical_groups_total": len(logical_members),
+        "logical_groups_measured": measured_logical,
+        "logical_groups_skipped_zero_strength": len(skipped_zero_strength_members),
+        "cohorts": cohorts_report,
+        "logical_groups": logical_reports,
+        "skipped_zero_strength_bases": sorted(skipped_zero_strength_bases),
+        "unmeasured_bases": sorted(
+            base for base in base_groups.keys()
+            if base not in base_norms and base not in skipped_zero_strength_bases
+        ),
+    }
+
     if verbose:
-        measured = len(base_norms)
-        measured_logical = sum(1 for v in logical_norms.values() if v > _AUTO_STRENGTH_EPS)
-        total = len(base_groups)
         cohort_summary = {
             f"{group}/{family}": mean
             for (group, family), mean in sorted(group_means.items())
         }
         _LOG.info(
-            "[DoRA Power LoRA Loader] auto-strength: measured %s/%s mapped bases (%s logical groups) (cohort_means=%s ratio_floor=%s ratio_ceiling=%s)",
+            "[DoRA Power LoRA Loader] auto-strength: measured %s/%s mapped bases (%s/%s logical groups) (cohort_means=%s ratio_floor=%s ratio_ceiling=%s)",
             measured,
             total,
             measured_logical,
+            len(logical_members),
             cohort_summary,
             ratio_floor,
             ratio_ceiling,
         )
-        sample = sorted(targets.items())[:20]
-        for base, target in sample:
-            norm = base_norms.get(base)
-            logical_id = base_logical_ids.get(base, base)
+        sample = logical_reports[:20]
+        for item in sample:
             _LOG.info(
-                "[DoRA Power LoRA Loader] auto-strength: base=%s logical=%s group=%s family=%s norm=%s target=%s",
-                base,
-                logical_id,
-                base_groups.get(base),
-                base_families.get(base),
-                norm,
-                target,
+                "[DoRA Power LoRA Loader] auto-strength: logical=%s group=%s family=%s fanout=%s mean_norm=%s cohort_mean=%s ratio=%s target=%s",
+                item.get("logical_id"),
+                item.get("group"),
+                item.get("family"),
+                item.get("fanout"),
+                item.get("mean_norm"),
+                item.get("cohort_mean_norm"),
+                item.get("ratio_applied"),
+                item.get("target_strength"),
             )
 
+    return targets, report
+
+
+def _auto_strength_compute_base_targets(
+    lora_sd: Dict[str, Any],
+    lora_bases: Iterable[str],
+    key_map: Dict[str, Any],
+    model_state_dict: Optional[Dict[str, Any]],
+    clip_state_dict: Optional[Dict[str, Any]],
+    analysis_device_mode: str,
+    analysis_load_device: Any,
+    strength_model: float,
+    strength_clip: float,
+    ratio_floor: float,
+    ratio_ceiling: float,
+    logical_groups: Optional[Dict[str, Tuple[str, float]]] = None,
+    verbose: bool = False,
+) -> Dict[str, float]:
+    targets, _ = _auto_strength_analyze_base_targets(
+        lora_sd=lora_sd,
+        lora_bases=lora_bases,
+        key_map=key_map,
+        model_state_dict=model_state_dict,
+        clip_state_dict=clip_state_dict,
+        analysis_device_mode=analysis_device_mode,
+        analysis_load_device=analysis_load_device,
+        strength_model=strength_model,
+        strength_clip=strength_clip,
+        ratio_floor=ratio_floor,
+        ratio_ceiling=ratio_ceiling,
+        logical_groups=logical_groups,
+        verbose=verbose,
+    )
     return targets
-
-
 def _auto_strength_targets_to_ratios(
     base_strengths: Dict[str, float],
     key_map: Dict[str, Any],
@@ -2788,6 +2975,105 @@ def _parse_lora_stack_kwargs(kwargs: Dict[str, Any]) -> List[Dict[str, Any]]:
     return entries
 
 
+
+def _auto_strength_report_line_for_group(item: Dict[str, Any]) -> str:
+    logical_id = str(item.get("logical_id") or "?")
+    fanout = int(item.get("fanout") or 0)
+    ratio = _auto_strength_safe_number(item.get("ratio_applied"))
+    target = _auto_strength_safe_number(item.get("target_strength"))
+    mean_norm = _auto_strength_safe_number(item.get("mean_norm"))
+    cohort_mean = _auto_strength_safe_number(item.get("cohort_mean_norm"))
+    if ratio is None:
+        ratio_text = "global"
+    else:
+        ratio_text = f"{ratio:.3f}x"
+    target_text = "?" if target is None else f"{target:.4f}"
+    norm_text = "?" if mean_norm is None else f"{mean_norm:.6g}"
+    cohort_text = "?" if cohort_mean is None else f"{cohort_mean:.6g}"
+    return (
+        f"    - {item.get('group')}/{item.get('family')} :: {logical_id} "
+        f"(fanout={fanout}, ratio={ratio_text}, target={target_text}, norm={norm_text}, cohort={cohort_text})"
+    )
+
+
+def _build_auto_strength_row_text_report(row: Dict[str, Any]) -> str:
+    idx = int(row.get("row_index", 0)) + 1
+    lora_name = str(row.get("lora_name") or "None")
+    status = str(row.get("status") or "unknown")
+    lines = [f"[{idx}] {lora_name}", f"  Status           : {status}"]
+    if row.get("status_detail"):
+        lines.append(f"  Detail           : {row.get('status_detail')}")
+    lines.append(f"  Strength model   : {float(row.get('strength_model', 0.0)):.4f}")
+    lines.append(f"  Strength clip    : {float(row.get('strength_clip', 0.0)):.4f}")
+
+    report = row.get("report") if isinstance(row.get("report"), dict) else None
+    if report is None:
+        return "\n".join(lines)
+
+    lines.extend(
+        [
+            f"  Analysis device  : {report.get('analysis_device_mode')} (load_device={report.get('analysis_load_device')})",
+            f"  Ratio window     : {float(report.get('ratio_floor', 0.0)):.4f} .. {float(report.get('ratio_ceiling', 0.0)):.4f}",
+            f"  Bases            : mapped={int(report.get('mapped_bases', 0))} analyzable={int(report.get('analyzable_bases', 0))} measured={int(report.get('measured_bases', 0))}",
+            f"  Logical groups   : total={int(report.get('logical_groups_total', 0))} measured={int(report.get('logical_groups_measured', 0))} skipped_zero_strength={int(report.get('logical_groups_skipped_zero_strength', 0))}",
+            "  Cohorts:",
+        ]
+    )
+    cohorts = report.get("cohorts") if isinstance(report.get("cohorts"), list) else []
+    if cohorts:
+        for cohort in cohorts:
+            mean_norm = _auto_strength_safe_number(cohort.get("mean_norm"))
+            mean_text = "?" if mean_norm is None else f"{mean_norm:.6g}"
+            lines.append(
+                "    - {group}/{family}: mean={mean} logical={logical} measured_logical={measured_logical} bases={bases} measured_bases={measured_bases} skipped_zero_strength_bases={skipped}".format(
+                    group=cohort.get("group"),
+                    family=cohort.get("family"),
+                    mean=mean_text,
+                    logical=int(cohort.get("logical_count", 0)),
+                    measured_logical=int(cohort.get("measured_logical_count", 0)),
+                    bases=int(cohort.get("base_count", 0)),
+                    measured_bases=int(cohort.get("measured_base_count", 0)),
+                    skipped=int(cohort.get("skipped_zero_strength_base_count", 0)),
+                )
+            )
+    else:
+        lines.append("    - none")
+
+    logical_groups = report.get("logical_groups") if isinstance(report.get("logical_groups"), list) else []
+    lines.append("  Largest ratio deviations:")
+    if logical_groups:
+        for item in logical_groups[:12]:
+            lines.append(_auto_strength_report_line_for_group(item))
+        remaining = len(logical_groups) - min(12, len(logical_groups))
+        if remaining > 0:
+            lines.append(f"    - ... {remaining} more logical groups in JSON report")
+    else:
+        lines.append("    - none")
+
+    return "\n".join(lines)
+
+
+def _build_auto_strength_stack_text_report(stack_report: Dict[str, Any]) -> str:
+    rows = stack_report.get("rows") if isinstance(stack_report.get("rows"), list) else []
+    analyzed = sum(1 for row in rows if row.get("status") == "analyzed" and isinstance(row.get("report"), dict))
+    lines = [
+        "DoRA Power LoRA Loader — auto-strength analysis report",
+        f"Node auto-strength enabled : {bool(stack_report.get('auto_strength_enabled', False))}",
+        f"Requested device           : {stack_report.get('auto_strength_device', 'auto')}",
+        f"Ratio window              : {float(stack_report.get('ratio_floor', 0.0)):.4f} .. {float(stack_report.get('ratio_ceiling', 0.0)):.4f}",
+        f"Rows total/analyzed       : {len(rows)}/{analyzed}",
+    ]
+    if not rows:
+        lines.append("No active LoRA rows were processed.")
+        return "\n".join(lines)
+
+    lines.append("")
+    for idx, row in enumerate(rows):
+        if idx > 0:
+            lines.append("-" * 88)
+        lines.append(_build_auto_strength_row_text_report(row))
+    return "\n".join(lines)
+
 class DoraPowerLoraLoader:
     """
     Power LoRA Loader-style stack + DoRA/Flux2 key-fix loader.
@@ -2832,8 +3118,8 @@ class DoraPowerLoraLoader:
             "hidden": {},
         }
 
-    RETURN_TYPES = ("MODEL", "CLIP")
-    RETURN_NAMES = ("MODEL", "CLIP")
+    RETURN_TYPES = ("MODEL", "CLIP", "STRING", "STRING")
+    RETURN_NAMES = ("MODEL", "CLIP", "auto_strength_report_json", "analysis_report")
     FUNCTION = "load_loras"
     CATEGORY = "loaders"
 
@@ -2863,6 +3149,7 @@ class DoraPowerLoraLoader:
         auto_strength_ratio_floor: float,
         auto_strength_ratio_ceiling: float,
     ):
+        auto_strength_report: Optional[Dict[str, Any]] = None
         lora_path = folder_paths.get_full_path("loras", lora_name)
         if not lora_path:
             raise FileNotFoundError(f"LoRA not found: {lora_name}")
@@ -3013,7 +3300,7 @@ class DoraPowerLoraLoader:
         _log_lora_direction_stats(lora_name + " (post-fix)", lora_sd, verbose=verbose)
 
         if auto_strength_enabled and (abs(float(strength_model)) > _AUTO_STRENGTH_EPS or abs(float(strength_clip)) > _AUTO_STRENGTH_EPS):
-            base_strengths = _auto_strength_compute_base_targets(
+            base_strengths, auto_strength_report = _auto_strength_analyze_base_targets(
                 lora_sd=lora_sd,
                 lora_bases=lora_bases,
                 key_map=key_map,
@@ -3089,7 +3376,7 @@ class DoraPowerLoraLoader:
             if isinstance(applied_c, list) and applied_c:
                 _LOG.info("[DoRA Power LoRA Loader] %s: sample applied(clip) keys: %s", lora_name, applied_c[:10])
 
-        return model, clip
+        return model, clip, auto_strength_report
 
     def load_loras(self, model, clip, **kwargs):
         # Global controls (provided by JS UI; also safe if absent)
@@ -3138,12 +3425,48 @@ class DoraPowerLoraLoader:
             adaln_swap_fix=dora_adaln_swap_fix,
         )
 
+        report_rows: List[Dict[str, Any]] = []
+
         if not stack_enabled:
-            return (model, clip)
+            stack_report = {
+                "schema": 1,
+                "kind": "dora_power_lora_auto_strength_stack_report",
+                "auto_strength_enabled": auto_strength_enabled,
+                "auto_strength_device": auto_strength_device,
+                "ratio_floor": auto_strength_ratio_floor,
+                "ratio_ceiling": auto_strength_ratio_ceiling,
+                "rows": report_rows,
+            }
+            report_json = _auto_strength_json_dumps(stack_report, pretty=True)
+            report_text = _build_auto_strength_stack_text_report(stack_report)
+            return {
+                "result": (model, clip, report_json, report_text),
+                "ui": {
+                    "auto_strength_report_json": (report_json,),
+                    "analysis_report": (report_text,),
+                },
+            }
 
         entries = _parse_lora_stack_kwargs(kwargs)
         if not entries:
-            return (model, clip)
+            stack_report = {
+                "schema": 1,
+                "kind": "dora_power_lora_auto_strength_stack_report",
+                "auto_strength_enabled": auto_strength_enabled,
+                "auto_strength_device": auto_strength_device,
+                "ratio_floor": auto_strength_ratio_floor,
+                "ratio_ceiling": auto_strength_ratio_ceiling,
+                "rows": report_rows,
+            }
+            report_json = _auto_strength_json_dumps(stack_report, pretty=True)
+            report_text = _build_auto_strength_stack_text_report(stack_report)
+            return {
+                "result": (model, clip, report_json, report_text),
+                "ui": {
+                    "auto_strength_report_json": (report_json,),
+                    "analysis_report": (report_text,),
+                },
+            }
 
         # Clone once, then apply multiple loras onto the same patched instances.
         new_model = model.clone() if model is not None else None
@@ -3173,17 +3496,48 @@ class DoraPowerLoraLoader:
                     "[DoRA Power LoRA Loader] auto-strength: requested analysis device 'gpu' but no usable accelerator load_device was found; falling back to cpu"
                 )
 
-        for e in entries:
+        for row_index, e in enumerate(entries):
             lora_name = e.get("lora")
+            row_info: Dict[str, Any] = {
+                "row_index": row_index,
+                "enabled": bool(e.get("on", True)),
+                "lora_name": str(lora_name or "None"),
+            }
             if not lora_name or lora_name in ("None", "NONE"):
+                row_info.update({
+                    "status": "empty",
+                    "status_detail": "No LoRA selected.",
+                    "strength_model": 0.0,
+                    "strength_clip": 0.0,
+                })
+                report_rows.append(row_info)
                 continue
             if not e.get("on", True):
+                sm_disabled = float(e.get("strength_model", 0.0))
+                sc_disabled = float(e.get("strength_clip", sm_disabled))
+                row_info.update({
+                    "status": "disabled_row",
+                    "status_detail": "Row toggle is off.",
+                    "strength_model": sm_disabled,
+                    "strength_clip": sc_disabled,
+                })
+                report_rows.append(row_info)
                 continue
             sm = float(e.get("strength_model", 0.0))
             sc = float(e.get("strength_clip", sm))
-            if sm == 0.0 and sc == 0.0:
+            row_info.update({
+                "strength_model": sm,
+                "strength_clip": sc,
+            })
+            if abs(sm) <= _AUTO_STRENGTH_EPS and abs(sc) <= _AUTO_STRENGTH_EPS:
+                row_info.update({
+                    "status": "zero_strength",
+                    "status_detail": "Both model and clip strengths are zero or below analysis epsilon.",
+                })
+                report_rows.append(row_info)
                 continue
-            new_model, new_clip = self._load_one(
+
+            new_model, new_clip, auto_strength_report = self._load_one(
                 new_model,
                 new_clip,
                 lora_name=lora_name,
@@ -3208,5 +3562,41 @@ class DoraPowerLoraLoader:
                 auto_strength_ratio_floor=auto_strength_ratio_floor,
                 auto_strength_ratio_ceiling=auto_strength_ratio_ceiling,
             )
+            did_analyze = isinstance(auto_strength_report, dict)
+            if did_analyze:
+                status = "analyzed"
+                detail = "Auto-strength report generated."
+            elif auto_strength_enabled:
+                status = "auto_strength_skipped"
+                detail = "Auto-strength was enabled, but no analysis report was generated."
+            else:
+                status = "applied_without_auto_strength"
+                detail = "LoRA applied without auto-strength analysis."
 
-        return (new_model, new_clip)
+            row_info.update(
+                {
+                    "status": status,
+                    "status_detail": detail,
+                    "report": auto_strength_report if did_analyze else None,
+                }
+            )
+            report_rows.append(row_info)
+
+        stack_report = {
+            "schema": 1,
+            "kind": "dora_power_lora_auto_strength_stack_report",
+            "auto_strength_enabled": auto_strength_enabled,
+            "auto_strength_device": auto_strength_device,
+            "ratio_floor": auto_strength_ratio_floor,
+            "ratio_ceiling": auto_strength_ratio_ceiling,
+            "rows": report_rows,
+        }
+        report_json = _auto_strength_json_dumps(stack_report, pretty=True)
+        report_text = _build_auto_strength_stack_text_report(stack_report)
+        return {
+            "result": (new_model, new_clip, report_json, report_text),
+            "ui": {
+                "auto_strength_report_json": (report_json,),
+                "analysis_report": (report_text,),
+            },
+        }

--- a/web/dora_power_lora_loader.js
+++ b/web/dora_power_lora_loader.js
@@ -1,4 +1,5 @@
 import { app } from "../../scripts/app.js";
+import { api } from "../../scripts/api.js";
 
 const NODE_CLASS = "DoRA Power LoRA Loader";
 const EXT_NAME = "comfyui_dora_dynamic_lora.power_lora_loader";
@@ -96,6 +97,91 @@ function drawRoundedRect(ctx, x, y, w, h, r) {
   ctx.arcTo(x, y + h, x, y, rr);
   ctx.arcTo(x, y, x + w, y, rr);
   ctx.closePath();
+}
+
+function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, value));
+}
+
+function formatNumber(value, digits = 3) {
+  const n = Number(value);
+  if (!Number.isFinite(n)) return "—";
+  return n.toFixed(digits);
+}
+
+function fitText(ctx, text, maxWidth) {
+  const s = String(text ?? "");
+  if (maxWidth <= 8 || !s) return "";
+  if (ctx.measureText(s).width <= maxWidth) return s;
+  let out = s;
+  while (out.length > 3 && ctx.measureText(`${out}…`).width > maxWidth) {
+    out = out.slice(0, -1);
+  }
+  return out.length ? `${out}…` : "";
+}
+
+function parseExecutionOutputValue(output, key) {
+  const value = output?.[key];
+  if (Array.isArray(value)) return value[0] ?? null;
+  return typeof value === "string" ? value : null;
+}
+
+function clearExecutionReport(node) {
+  if (!node) return;
+  node._doraAutoStrengthReport = null;
+  node._doraAutoStrengthReportJson = "";
+  node._doraAutoStrengthReportText = "";
+  node._doraAutoStrengthExpanded = {};
+  node.setDirtyCanvas?.(true, true);
+}
+
+function isTargetNodeInstance(node) {
+  return !!node && (node.type === NODE_CLASS || node.comfyClass === NODE_CLASS || node.title === NODE_CLASS);
+}
+
+function applyExecutionReportToNode(node, reportJson, reportText) {
+  if (!node) return;
+  let parsed = null;
+  if (typeof reportJson === "string" && reportJson.trim()) {
+    try {
+      parsed = JSON.parse(reportJson);
+    } catch (err) {
+      console.warn(`[${EXT_NAME}] Failed to parse auto-strength report JSON`, err);
+    }
+  }
+  node._doraAutoStrengthReport = parsed;
+  node._doraAutoStrengthReportJson = typeof reportJson === "string" ? reportJson : "";
+  node._doraAutoStrengthReportText = typeof reportText === "string" ? reportText : "";
+  node._doraAutoStrengthExpanded = node._doraAutoStrengthExpanded || {};
+  const size = typeof node.computeSize === "function" ? node.computeSize() : null;
+  if (Array.isArray(size) && size.length >= 2) {
+    node.size[0] = Math.max(node.size[0], size[0]);
+    node.size[1] = Math.max(node.size[1], size[1]);
+  }
+  node.setDirtyCanvas?.(true, true);
+}
+
+let _executionListenerInstalled = false;
+function installExecutionListener() {
+  if (_executionListenerInstalled) return;
+  _executionListenerInstalled = true;
+  if (!api?.addEventListener) return;
+
+  api.addEventListener("executed", (event) => {
+    const detail = event?.detail || event || {};
+    const output = detail?.output || {};
+    const reportJson = parseExecutionOutputValue(output, "auto_strength_report_json");
+    const reportText = parseExecutionOutputValue(output, "analysis_report");
+    if (typeof reportJson !== "string" && typeof reportText !== "string") return;
+
+    const rawNodeId = detail?.display_node ?? detail?.node;
+    const nodeId = Number(rawNodeId);
+    const graph = app.graph;
+    const node = Number.isFinite(nodeId) && graph?.getNodeById ? graph.getNodeById(nodeId) : null;
+    if (!isTargetNodeInstance(node)) return;
+
+    applyExecutionReportToNode(node, reportJson, reportText);
+  });
 }
 
 function removeAllWidgets(node) {
@@ -281,6 +367,7 @@ function setState(node, st) {
 
 function persistNodeState(node) {
   setState(node, { rows: node._doraRows || [], globals: node._doraGlobals || {} });
+  clearExecutionReport(node);
 }
 
 function setButtonCallback(widget, cb) {
@@ -722,6 +809,235 @@ class DoraLoraRowWidget {
   }
 }
 
+class DoraAutoStrengthReportWidget {
+  constructor(name, parentNode) {
+    this.name = name;
+    this.type = "custom";
+    this.parentNode = parentNode;
+    this.last_y = 0;
+    this.hitAreas = [];
+  }
+
+  serializeValue() {
+    return null;
+  }
+
+  _rows() {
+    const rows = this.parentNode?._doraAutoStrengthReport?.rows;
+    return Array.isArray(rows) ? rows : [];
+  }
+
+  _displayRows() {
+    return this._rows().filter((row) => row && typeof row === "object");
+  }
+
+  computeSize(width) {
+    const rows = this._displayRows();
+    let height = 72;
+    if (!rows.length) return [width || 320, height];
+    for (const row of rows) {
+      const analyzed = row.status === "analyzed" && Array.isArray(row.report?.logical_groups);
+      const logicalGroups = analyzed ? row.report.logical_groups : [];
+      const expanded = !!this.parentNode?._doraAutoStrengthExpanded?.[row.row_index];
+      const shown = analyzed ? (expanded ? logicalGroups.length : Math.min(6, logicalGroups.length)) : 0;
+      height += analyzed ? 92 + shown * 20 + (logicalGroups.length > shown ? 18 : 0) : 68;
+      height += 10;
+    }
+    return [width || 320, height];
+  }
+
+  draw(ctx, node, width, posY, height) {
+    this.last_y = posY;
+    this.hitAreas = [];
+    const colors = getThemeColors();
+    const x = HORIZ_MARGIN;
+    const cardWidth = width - HORIZ_MARGIN * 2;
+    const report = this.parentNode?._doraAutoStrengthReport;
+    const rows = this._displayRows();
+    const analyzedRows = rows.filter((row) => row?.status === "analyzed" && Array.isArray(row.report?.logical_groups));
+
+    ctx.save();
+    ctx.font = "12px Arial";
+    ctx.textBaseline = "middle";
+
+    drawRoundedRect(ctx, x, posY + 2, cardWidth, 58, 8);
+    ctx.fillStyle = "#14171c";
+    ctx.fill();
+    ctx.strokeStyle = colors.outline;
+    ctx.stroke();
+
+    ctx.fillStyle = colors.text;
+    ctx.font = "bold 12px Arial";
+    ctx.textAlign = "left";
+    ctx.fillText("Auto-strength analysis", x + 12, posY + 20);
+
+    ctx.font = "11px Arial";
+    ctx.fillStyle = colors.secondary;
+    if (!report) {
+      const autoEnabled = node._doraGlobals?.auto_strength_enabled === true;
+      ctx.fillText(
+        autoEnabled ? "Run the node to populate the logical-group auto-strength report." : "Enable auto-strength and run the node to see the report.",
+        x + 12,
+        posY + 40
+      );
+      ctx.restore();
+      return;
+    }
+
+    const summary = [
+      `rows ${rows.length}`,
+      `analyzed ${analyzedRows.length}`,
+      `device ${report.auto_strength_device ?? "auto"}`,
+      `window ${formatNumber(report.ratio_floor, 2)}–${formatNumber(report.ratio_ceiling, 2)}`,
+    ].join("  ·  ");
+    ctx.fillText(summary, x + 12, posY + 40);
+
+    let y = posY + 68;
+    for (const row of rows) {
+      const analyzed = row.status === "analyzed" && Array.isArray(row.report?.logical_groups);
+      const logicalGroups = analyzed ? row.report.logical_groups : [];
+      const expanded = !!this.parentNode?._doraAutoStrengthExpanded?.[row.row_index];
+      const shown = analyzed ? (expanded ? logicalGroups.length : Math.min(6, logicalGroups.length)) : 0;
+      const cardHeight = analyzed ? 92 + shown * 20 + (logicalGroups.length > shown ? 18 : 0) : 68;
+
+      drawRoundedRect(ctx, x, y, cardWidth, cardHeight, 8);
+      ctx.fillStyle = "#101318";
+      ctx.fill();
+      ctx.strokeStyle = colors.outline;
+      ctx.stroke();
+
+      this.hitAreas.push({
+        x,
+        y,
+        w: cardWidth,
+        h: 28,
+        rowIndex: row.row_index,
+        toggleable: analyzed,
+      });
+
+      ctx.fillStyle = colors.text;
+      ctx.font = "bold 12px Arial";
+      const toggleGlyph = analyzed ? (expanded ? "▾" : "▸") : "•";
+      ctx.fillText(`${toggleGlyph} ${fitText(ctx, row.lora_name || "None", cardWidth - 150)}`, x + 12, y + 16);
+
+      const badge = analyzed
+        ? `${row.report.analyzable_bases ?? row.report.mapped_bases}/${row.report.measured_bases} bases`
+        : String(row.status_detail || row.status || "");
+      ctx.textAlign = "right";
+      ctx.font = "11px Arial";
+      ctx.fillStyle = colors.secondary;
+      ctx.fillText(fitText(ctx, badge, 180), x + cardWidth - 12, y + 16);
+      ctx.textAlign = "left";
+
+      ctx.strokeStyle = "#2a2f39";
+      ctx.beginPath();
+      ctx.moveTo(x + 12, y + 30);
+      ctx.lineTo(x + cardWidth - 12, y + 30);
+      ctx.stroke();
+
+      ctx.fillStyle = colors.secondary;
+      if (!analyzed) {
+        const line = `${row.status || "unknown"} · model ${formatNumber(row.strength_model, 2)} · clip ${formatNumber(row.strength_clip, 2)}`;
+        ctx.fillText(fitText(ctx, line, cardWidth - 24), x + 12, y + 48);
+        y += cardHeight + 10;
+        continue;
+      }
+
+      const topLine = [
+        `model ${formatNumber(row.strength_model, 2)}`,
+        `clip ${formatNumber(row.strength_clip, 2)}`,
+        `${row.report.logical_groups_measured}/${row.report.logical_groups_total} logical`,
+        `load ${row.report.analysis_load_device}`,
+      ].join("  ·  ");
+      ctx.fillText(fitText(ctx, topLine, cardWidth - 24), x + 12, y + 48);
+
+      const cohortNames = Array.isArray(row.report?.cohorts)
+        ? row.report.cohorts.map((cohort) => `${cohort.group}/${cohort.family}`).join("  ·  ")
+        : "";
+      ctx.fillText(fitText(ctx, cohortNames, cardWidth - 24), x + 12, y + 66);
+
+      const floor = Number.isFinite(+row.report?.ratio_floor) ? +row.report.ratio_floor : 0;
+      const ceiling = Number.isFinite(+row.report?.ratio_ceiling) ? +row.report.ratio_ceiling : 1;
+      const denom = Math.max(1e-6, ceiling - floor);
+      const labelWidth = Math.min(220, Math.max(150, Math.floor(cardWidth * 0.4)));
+      const ratioWidth = 54;
+      const barX = x + 12 + labelWidth;
+      const barW = Math.max(64, cardWidth - 24 - labelWidth - ratioWidth);
+      const center = barX + ((clamp(1, floor, ceiling) - floor) / denom) * barW;
+
+      let rowY = y + 88;
+      ctx.font = "11px Arial";
+      for (let i = 0; i < shown; i++) {
+        const item = logicalGroups[i];
+        const ratio = Number(item?.ratio_applied);
+        const validRatio = Number.isFinite(ratio);
+        const ratioText = validRatio ? `${ratio.toFixed(2)}×` : "global";
+        const itemLabel = `${item?.logical_id ?? "?"} ×${item?.fanout ?? 1}`;
+
+        ctx.fillStyle = colors.text;
+        ctx.textAlign = "left";
+        ctx.fillText(fitText(ctx, itemLabel, labelWidth - 8), x + 12, rowY);
+
+        drawRoundedRect(ctx, barX, rowY - 6, barW, 12, 6);
+        ctx.fillStyle = "#0b1020";
+        ctx.fill();
+        ctx.strokeStyle = "#2a2f39";
+        ctx.stroke();
+
+        ctx.strokeStyle = "#7c8597";
+        ctx.beginPath();
+        ctx.moveTo(center, rowY - 7);
+        ctx.lineTo(center, rowY + 7);
+        ctx.stroke();
+
+        const px = validRatio ? barX + ((clamp(ratio, floor, ceiling) - floor) / denom) * barW : center;
+        if (Math.abs(px - center) > 1) {
+          const fillX = Math.min(center, px);
+          const fillW = Math.max(1, Math.abs(px - center));
+          drawRoundedRect(ctx, fillX, rowY - 4, fillW, 8, 4);
+          ctx.fillStyle = px >= center ? "#4f8cff" : "#e3a33b";
+          ctx.fill();
+        }
+        ctx.beginPath();
+        ctx.fillStyle = validRatio ? (px >= center ? "#bcd4ff" : "#ffd08a") : colors.secondary;
+        ctx.arc(px, rowY, 3, 0, Math.PI * 2);
+        ctx.fill();
+
+        ctx.textAlign = "right";
+        ctx.fillStyle = colors.secondary;
+        ctx.fillText(ratioText, x + cardWidth - 12, rowY);
+        rowY += 20;
+      }
+
+      if (logicalGroups.length > shown) {
+        ctx.textAlign = "left";
+        ctx.fillStyle = colors.secondary;
+        ctx.fillText(`click header to ${expanded ? "collapse" : `expand all ${logicalGroups.length}`} logical groups`, x + 12, rowY + 2);
+      }
+
+      y += cardHeight + 10;
+    }
+
+    ctx.restore();
+  }
+
+  mouse(event, pos) {
+    if (event.type !== "pointerdown") return false;
+    const mx = pos[0];
+    const my = pos[1];
+    for (const hit of this.hitAreas) {
+      if (mx >= hit.x && mx <= hit.x + hit.w && my >= hit.y && my <= hit.y + hit.h) {
+        if (!hit.toggleable) return true;
+        const expanded = this.parentNode._doraAutoStrengthExpanded || (this.parentNode._doraAutoStrengthExpanded = {});
+        expanded[hit.rowIndex] = !expanded[hit.rowIndex];
+        this.parentNode.setDirtyCanvas?.(true, true);
+        return true;
+      }
+    }
+    return false;
+  }
+}
+
 function buildUI(node, state, loraValues) {
   const st = sanitizeState(state);
   setState(node, st);
@@ -945,6 +1261,14 @@ function buildUI(node, state, loraValues) {
   );
   wAutoStrengthCeiling.label = "Auto-strength ratio ceiling";
 
+  const wAutoStrengthReport = new DoraAutoStrengthReportWidget("auto_strength_visualization", node);
+  if (typeof node.addCustomWidget === "function") {
+    node.addCustomWidget(wAutoStrengthReport);
+  } else {
+    node.widgets.push(wAutoStrengthReport);
+  }
+  wAutoStrengthReport.serialize = false;
+
   const size = node.computeSize();
   node.size[0] = Math.max(node.size[0], size[0]);
   node.size[1] = Math.max(node.size[1], size[1]);
@@ -953,6 +1277,7 @@ function buildUI(node, state, loraValues) {
 app.registerExtension({
   name: EXT_NAME,
   async beforeRegisterNodeDef(nodeType, nodeData) {
+    installExecutionListener();
     const nodeName = nodeData?.name ?? "";
     const displayName = nodeData?.display_name ?? "";
     const comfyClass = nodeType?.comfyClass ?? "";


### PR DESCRIPTION
## Summary
- Add a structured auto-strength analysis report with JSON-safe numeric serialization
- Track truthful row status and separate analyzable, measured, and skipped zero-strength bases
- Reset cached execution reports on edits and refresh the node canvas immediately
- Surface the new report data in the frontend card summary and row details

## Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Auto-strength analysis now generates comprehensive diagnostic reports showing per-LoRA and logical-group strength breakdowns
  * Added interactive canvas widget to visualize auto-strength analysis results with expandable summary sections
  * Analysis data available in both JSON format and human-readable text for detailed inspection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->