### PR TITLE
Improve LoRA auto-strength report grouping and hide disabled rows

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -582,6 +582,7 @@ _BROADCAST_DORA_SUFFIXES = _BROADCAST_DELTA_SUFFIXES + (
 
 _AUTO_STRENGTH_RATIO_FLOOR = 0.30
 _AUTO_STRENGTH_RATIO_CEILING = 1.50
+_AUTO_STRENGTH_DISPLAY_RATIO_EPS = 1e-3
 _AUTO_STRENGTH_EPS = 1e-8
 _AUTO_STRENGTH_ANALYSIS_MIN_NUMEL = 65536
 
@@ -3003,7 +3004,7 @@ def _auto_strength_report_split_groups(logical_groups: Iterable[Dict[str, Any]])
 
     for item in logical_groups:
         ratio = _auto_strength_safe_number(item.get("ratio_applied"))
-        if ratio is None or abs(ratio - 1.0) <= _AUTO_STRENGTH_EPS:
+        if ratio is None or abs(ratio - 1.0) <= _AUTO_STRENGTH_DISPLAY_RATIO_EPS:
             neutral.append(item)
         elif ratio > 1.0:
             boosts.append(item)

--- a/nodes.py
+++ b/nodes.py
@@ -2996,6 +2996,47 @@ def _auto_strength_report_line_for_group(item: Dict[str, Any]) -> str:
     )
 
 
+def _auto_strength_report_split_groups(logical_groups: Iterable[Dict[str, Any]]) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]], List[Dict[str, Any]]]:
+    boosts: List[Dict[str, Any]] = []
+    pullbacks: List[Dict[str, Any]] = []
+    neutral: List[Dict[str, Any]] = []
+
+    for item in logical_groups:
+        ratio = _auto_strength_safe_number(item.get("ratio_applied"))
+        if ratio is None or abs(ratio - 1.0) <= _AUTO_STRENGTH_EPS:
+            neutral.append(item)
+        elif ratio > 1.0:
+            boosts.append(item)
+        else:
+            pullbacks.append(item)
+
+    boosts.sort(
+        key=lambda item: (
+            -(_auto_strength_safe_number(item.get("ratio_applied")) or 1.0),
+            str(item.get("group") or ""),
+            str(item.get("family") or ""),
+            str(item.get("logical_id") or ""),
+        )
+    )
+    pullbacks.sort(
+        key=lambda item: (
+            (_auto_strength_safe_number(item.get("ratio_applied")) or 1.0),
+            str(item.get("group") or ""),
+            str(item.get("family") or ""),
+            str(item.get("logical_id") or ""),
+        )
+    )
+    neutral.sort(
+        key=lambda item: (
+            str(item.get("group") or ""),
+            str(item.get("family") or ""),
+            str(item.get("logical_id") or ""),
+        )
+    )
+
+    return boosts, pullbacks, neutral
+
+
 def _build_auto_strength_row_text_report(row: Dict[str, Any]) -> str:
     idx = int(row.get("row_index", 0)) + 1
     lora_name = str(row.get("lora_name") or "None")
@@ -3040,15 +3081,35 @@ def _build_auto_strength_row_text_report(row: Dict[str, Any]) -> str:
         lines.append("    - none")
 
     logical_groups = report.get("logical_groups") if isinstance(report.get("logical_groups"), list) else []
-    lines.append("  Largest ratio deviations:")
-    if logical_groups:
-        for item in logical_groups[:12]:
+    boosts, pullbacks, neutral = _auto_strength_report_split_groups(logical_groups)
+
+    lines.append("  Strongest boosts:")
+    if boosts:
+        for item in boosts[:6]:
             lines.append(_auto_strength_report_line_for_group(item))
-        remaining = len(logical_groups) - min(12, len(logical_groups))
+        remaining = len(boosts) - min(6, len(boosts))
         if remaining > 0:
-            lines.append(f"    - ... {remaining} more logical groups in JSON report")
+            lines.append(f"    - ... {remaining} more boost groups in JSON report")
     else:
         lines.append("    - none")
+
+    lines.append("  Strongest pullbacks:")
+    if pullbacks:
+        for item in pullbacks[:6]:
+            lines.append(_auto_strength_report_line_for_group(item))
+        remaining = len(pullbacks) - min(6, len(pullbacks))
+        if remaining > 0:
+            lines.append(f"    - ... {remaining} more pullback groups in JSON report")
+    else:
+        lines.append("    - none")
+
+    if neutral:
+        lines.append("  Near global:")
+        for item in neutral[:6]:
+            lines.append(_auto_strength_report_line_for_group(item))
+        remaining = len(neutral) - min(6, len(neutral))
+        if remaining > 0:
+            lines.append(f"    - ... {remaining} more near-global groups in JSON report")
 
     return "\n".join(lines)
 
@@ -3513,15 +3574,6 @@ class DoraPowerLoraLoader:
                 report_rows.append(row_info)
                 continue
             if not e.get("on", True):
-                sm_disabled = float(e.get("strength_model", 0.0))
-                sc_disabled = float(e.get("strength_clip", sm_disabled))
-                row_info.update({
-                    "status": "disabled_row",
-                    "status_detail": "Row toggle is off.",
-                    "strength_model": sm_disabled,
-                    "strength_clip": sc_disabled,
-                })
-                report_rows.append(row_info)
                 continue
             sm = float(e.get("strength_model", 0.0))
             sc = float(e.get("strength_clip", sm))

--- a/web/dora_power_lora_loader.js
+++ b/web/dora_power_lora_loader.js
@@ -120,6 +120,202 @@ function fitText(ctx, text, maxWidth) {
   return out.length ? `${out}…` : "";
 }
 
+const DISPLAY_GROUP_LIMIT = 3;
+const DISPLAY_RATIO_EPS = 1e-3;
+const CLASSIC_DISPLAY_PREFIXES = [
+  "lora_unet_",
+  "lycoris_",
+  "diffusion_model.",
+  "diffusion_model_",
+  "base_model.model.",
+  "base_model_model_",
+  "base_model.",
+  "base_model_",
+  "transformer.",
+  "transformer_",
+  "model.",
+  "model_",
+  "unet.",
+  "unet_",
+];
+
+function normalizeClassicDisplayGroupKind(parts) {
+  const tokens = new Set(parts);
+  if (tokens.has("attentions") || tokens.has("attention") || tokens.has("attn")) return "attn";
+  if (
+    tokens.has("resnets") ||
+    tokens.has("resnet") ||
+    tokens.has("in_layers") ||
+    tokens.has("out_layers") ||
+    tokens.has("emb_layers") ||
+    tokens.has("skip_connection") ||
+    tokens.has("nin_shortcut") ||
+    tokens.has("conv1") ||
+    tokens.has("conv2")
+  ) {
+    return "resnet";
+  }
+  if (tokens.has("downsamplers") || tokens.has("downsampler") || tokens.has("downsample")) return "downsampler";
+  if (tokens.has("upsamplers") || tokens.has("upsampler") || tokens.has("upsample")) return "upsampler";
+  if (tokens.has("proj") || tokens.has("proj_in") || tokens.has("proj_out") || tokens.has("time_emb_proj")) return "proj";
+  if (tokens.has("conv") || tokens.has("conv_in") || tokens.has("conv_out")) return "conv";
+  if (tokens.has("norm")) return "norm";
+  return null;
+}
+
+function normalizeClassicDisplayGroupId(base) {
+  let text = String(base ?? "").trim();
+  if (!text) return null;
+
+  for (const prefix of CLASSIC_DISPLAY_PREFIXES) {
+    if (text.startsWith(prefix)) {
+      text = text.slice(prefix.length);
+      break;
+    }
+  }
+
+  if (!text) return null;
+
+  const parts = text.replace(/[./]+/g, "_").split("_").filter(Boolean);
+  if (!parts.length) return null;
+
+  let root = null;
+  let cursor = 0;
+  if (parts[0] === "middle" && parts[1] === "block") {
+    root = "middle_block";
+    cursor = 2;
+  } else if ((parts[0] === "input" || parts[0] === "output" || parts[0] === "down" || parts[0] === "up") && parts[1] === "blocks") {
+    root = `${parts[0]}_blocks`;
+    cursor = 2;
+  } else {
+    return null;
+  }
+
+  let blockIndex = null;
+  if (cursor < parts.length && /^\d+$/.test(parts[cursor])) {
+    blockIndex = parts[cursor];
+    cursor += 1;
+  }
+  if (cursor < parts.length && /^\d+$/.test(parts[cursor])) {
+    cursor += 1;
+  }
+
+  const kind = normalizeClassicDisplayGroupKind(parts.slice(cursor));
+  if (root === "middle_block") {
+    return kind ? `${root}.${kind}` : root;
+  }
+  if (blockIndex == null) {
+    return kind ? `${root}.${kind}` : root;
+  }
+  return kind ? `${root}.${blockIndex}.${kind}` : `${root}.${blockIndex}`;
+}
+
+function buildDisplayGroups(logicalGroups) {
+  const buckets = new Map();
+  const groups = Array.isArray(logicalGroups) ? logicalGroups : [];
+
+  for (const item of groups) {
+    if (!item || typeof item !== "object") continue;
+
+    const rawId = String(item.logical_id ?? "");
+    const displayId = normalizeClassicDisplayGroupId(rawId) || rawId || "?";
+    let bucket = buckets.get(displayId);
+    if (!bucket) {
+      bucket = {
+        display_id: displayId,
+        fanout: 0,
+        logical_group_count: 0,
+        measured_base_count: 0,
+        ratio_weight: 0,
+        ratio_weight_count: 0,
+      };
+      buckets.set(displayId, bucket);
+    }
+
+    const fanout = Math.max(1, Number(item.fanout) || 0);
+    const ratio = Number(item.ratio_applied);
+    if (Number.isFinite(ratio)) {
+      bucket.ratio_weight += ratio * fanout;
+      bucket.ratio_weight_count += fanout;
+    }
+    bucket.fanout += fanout;
+    bucket.logical_group_count += 1;
+    bucket.measured_base_count += Number(item.measured_base_count) || 0;
+  }
+
+  const out = [];
+  for (const bucket of buckets.values()) {
+    out.push({
+      display_id: bucket.display_id,
+      fanout: bucket.fanout || bucket.logical_group_count,
+      logical_group_count: bucket.logical_group_count,
+      measured_base_count: bucket.measured_base_count,
+      ratio_applied: bucket.ratio_weight_count > 0 ? bucket.ratio_weight / bucket.ratio_weight_count : null,
+    });
+  }
+
+  out.sort((a, b) => String(a.display_id).localeCompare(String(b.display_id)));
+  return out;
+}
+
+function compareDisplayGroupsByRatio(a, b, descending = false) {
+  const ar = Number.isFinite(+a?.ratio_applied) ? +a.ratio_applied : 1.0;
+  const br = Number.isFinite(+b?.ratio_applied) ? +b.ratio_applied : 1.0;
+  if (Math.abs(ar - br) > 1e-9) {
+    return descending ? br - ar : ar - br;
+  }
+  return String(a?.display_id ?? "").localeCompare(String(b?.display_id ?? ""));
+}
+
+function buildDisplayGroupSections(logicalGroups, expanded) {
+  const groups = buildDisplayGroups(logicalGroups);
+  const boosts = [];
+  const pullbacks = [];
+  const neutral = [];
+
+  for (const group of groups) {
+    const ratio = Number(group.ratio_applied);
+    if (!Number.isFinite(ratio) || Math.abs(ratio - 1.0) <= DISPLAY_RATIO_EPS) {
+      neutral.push(group);
+    } else if (ratio > 1.0) {
+      boosts.push(group);
+    } else {
+      pullbacks.push(group);
+    }
+  }
+
+  boosts.sort((a, b) => compareDisplayGroupsByRatio(a, b, true));
+  pullbacks.sort((a, b) => compareDisplayGroupsByRatio(a, b, false));
+  neutral.sort((a, b) => String(a.display_id).localeCompare(String(b.display_id)));
+
+  const sections = [];
+  const addSection = (kind, title, items, limit) => {
+    if (!items.length) return;
+    const visibleItems = expanded || limit == null ? items.slice() : items.slice(0, limit);
+    sections.push({
+      kind,
+      title,
+      items: visibleItems,
+      totalCount: items.length,
+      visibleCount: visibleItems.length,
+    });
+  };
+
+  addSection("boost", "Strongest boosts", boosts, DISPLAY_GROUP_LIMIT);
+  addSection("pullback", "Strongest pullbacks", pullbacks, DISPLAY_GROUP_LIMIT);
+  if (expanded) {
+    addSection("neutral", "Near global", neutral, null);
+  } else if (!boosts.length && !pullbacks.length) {
+    addSection("neutral", "Near global", neutral, 6);
+  }
+
+  return {
+    groups,
+    sections,
+    hasMore: !expanded && sections.some((section) => section.visibleCount < section.totalCount),
+  };
+}
+
 function parseExecutionOutputValue(output, key) {
   const value = output?.[key];
   if (Array.isArray(value)) return value[0] ?? null;
@@ -831,16 +1027,40 @@ class DoraAutoStrengthReportWidget {
     return this._rows().filter((row) => row && typeof row === "object");
   }
 
+  _rowLayout(row) {
+    const analyzed = row.status === "analyzed" && Array.isArray(row.report?.logical_groups);
+    const logicalGroups = analyzed ? row.report.logical_groups : [];
+    const expanded = !!this.parentNode?._doraAutoStrengthExpanded?.[row.row_index];
+    const grouped = analyzed ? buildDisplayGroupSections(logicalGroups, expanded) : { groups: [], sections: [], hasMore: false };
+    return {
+      analyzed,
+      expanded,
+      logicalGroups,
+      displayGroups: grouped.groups,
+      sections: grouped.sections,
+      hasMore: grouped.hasMore,
+    };
+  }
+
+  _estimateRowHeight(layout) {
+    if (!layout.analyzed) return 68;
+    let height = 92;
+    for (const section of layout.sections) {
+      height += 18;
+      height += section.items.length * 20;
+      if (section.items.length) height += 6;
+    }
+    if (layout.hasMore) height += 18;
+    return height;
+  }
+
   computeSize(width) {
     const rows = this._displayRows();
     let height = 72;
     if (!rows.length) return [width || 320, height];
     for (const row of rows) {
-      const analyzed = row.status === "analyzed" && Array.isArray(row.report?.logical_groups);
-      const logicalGroups = analyzed ? row.report.logical_groups : [];
-      const expanded = !!this.parentNode?._doraAutoStrengthExpanded?.[row.row_index];
-      const shown = analyzed ? (expanded ? logicalGroups.length : Math.min(6, logicalGroups.length)) : 0;
-      height += analyzed ? 92 + shown * 20 + (logicalGroups.length > shown ? 18 : 0) : 68;
+      const layout = this._rowLayout(row);
+      height += this._estimateRowHeight(layout);
       height += 10;
     }
     return [width || 320, height];
@@ -894,11 +1114,8 @@ class DoraAutoStrengthReportWidget {
 
     let y = posY + 68;
     for (const row of rows) {
-      const analyzed = row.status === "analyzed" && Array.isArray(row.report?.logical_groups);
-      const logicalGroups = analyzed ? row.report.logical_groups : [];
-      const expanded = !!this.parentNode?._doraAutoStrengthExpanded?.[row.row_index];
-      const shown = analyzed ? (expanded ? logicalGroups.length : Math.min(6, logicalGroups.length)) : 0;
-      const cardHeight = analyzed ? 92 + shown * 20 + (logicalGroups.length > shown ? 18 : 0) : 68;
+      const layout = this._rowLayout(row);
+      const cardHeight = this._estimateRowHeight(layout);
 
       drawRoundedRect(ctx, x, y, cardWidth, cardHeight, 8);
       ctx.fillStyle = "#101318";
@@ -912,15 +1129,15 @@ class DoraAutoStrengthReportWidget {
         w: cardWidth,
         h: 28,
         rowIndex: row.row_index,
-        toggleable: analyzed,
+        toggleable: layout.analyzed,
       });
 
       ctx.fillStyle = colors.text;
       ctx.font = "bold 12px Arial";
-      const toggleGlyph = analyzed ? (expanded ? "▾" : "▸") : "•";
+      const toggleGlyph = layout.analyzed ? (layout.expanded ? "▾" : "▸") : "•";
       ctx.fillText(`${toggleGlyph} ${fitText(ctx, row.lora_name || "None", cardWidth - 150)}`, x + 12, y + 16);
 
-      const badge = analyzed
+      const badge = layout.analyzed
         ? `${row.report.analyzable_bases ?? row.report.mapped_bases}/${row.report.measured_bases} bases`
         : String(row.status_detail || row.status || "");
       ctx.textAlign = "right";
@@ -936,26 +1153,14 @@ class DoraAutoStrengthReportWidget {
       ctx.stroke();
 
       ctx.fillStyle = colors.secondary;
-      if (!analyzed) {
+      if (!layout.analyzed) {
         const line = `${row.status || "unknown"} · model ${formatNumber(row.strength_model, 2)} · clip ${formatNumber(row.strength_clip, 2)}`;
         ctx.fillText(fitText(ctx, line, cardWidth - 24), x + 12, y + 48);
         y += cardHeight + 10;
         continue;
       }
 
-      const topLine = [
-        `model ${formatNumber(row.strength_model, 2)}`,
-        `clip ${formatNumber(row.strength_clip, 2)}`,
-        `${row.report.logical_groups_measured}/${row.report.logical_groups_total} logical`,
-        `load ${row.report.analysis_load_device}`,
-      ].join("  ·  ");
-      ctx.fillText(fitText(ctx, topLine, cardWidth - 24), x + 12, y + 48);
-
-      const cohortNames = Array.isArray(row.report?.cohorts)
-        ? row.report.cohorts.map((cohort) => `${cohort.group}/${cohort.family}`).join("  ·  ")
-        : "";
-      ctx.fillText(fitText(ctx, cohortNames, cardWidth - 24), x + 12, y + 66);
-
+      const displayGroups = layout.displayGroups;
       const floor = Number.isFinite(+row.report?.ratio_floor) ? +row.report.ratio_floor : 0;
       const ceiling = Number.isFinite(+row.report?.ratio_ceiling) ? +row.report.ratio_ceiling : 1;
       const denom = Math.max(1e-6, ceiling - floor);
@@ -965,54 +1170,82 @@ class DoraAutoStrengthReportWidget {
       const barW = Math.max(64, cardWidth - 24 - labelWidth - ratioWidth);
       const center = barX + ((clamp(1, floor, ceiling) - floor) / denom) * barW;
 
+      const topLine = [
+        `model ${formatNumber(row.strength_model, 2)}`,
+        `clip ${formatNumber(row.strength_clip, 2)}`,
+        `${row.report.logical_groups_measured}/${row.report.logical_groups_total} logical`,
+        `display ${displayGroups.length}`,
+        `load ${row.report.analysis_load_device}`,
+      ].join("  ·  ");
+      ctx.fillText(fitText(ctx, topLine, cardWidth - 24), x + 12, y + 48);
+
+      const cohortNames = Array.isArray(row.report?.cohorts)
+        ? row.report.cohorts.map((cohort) => `${cohort.group}/${cohort.family}`).join("  ·  ")
+        : "";
+      ctx.fillText(fitText(ctx, cohortNames, cardWidth - 24), x + 12, y + 66);
+
       let rowY = y + 88;
-      ctx.font = "11px Arial";
-      for (let i = 0; i < shown; i++) {
-        const item = logicalGroups[i];
-        const ratio = Number(item?.ratio_applied);
-        const validRatio = Number.isFinite(ratio);
-        const ratioText = validRatio ? `${ratio.toFixed(2)}×` : "global";
-        const itemLabel = `${item?.logical_id ?? "?"} ×${item?.fanout ?? 1}`;
-
-        ctx.fillStyle = colors.text;
+      ctx.font = "bold 11px Arial";
+      for (const section of layout.sections) {
+        const sectionTitle = section.visibleCount < section.totalCount
+          ? `${section.title} (${section.visibleCount}/${section.totalCount})`
+          : `${section.title} (${section.totalCount})`;
+        ctx.fillStyle = section.kind === "boost" ? "#8bb2ff" : section.kind === "pullback" ? "#f0b05b" : colors.secondary;
         ctx.textAlign = "left";
-        ctx.fillText(fitText(ctx, itemLabel, labelWidth - 8), x + 12, rowY);
+        ctx.fillText(fitText(ctx, sectionTitle, cardWidth - 24), x + 12, rowY + 10);
+        rowY += 18;
 
-        drawRoundedRect(ctx, barX, rowY - 6, barW, 12, 6);
-        ctx.fillStyle = "#0b1020";
-        ctx.fill();
-        ctx.strokeStyle = "#2a2f39";
-        ctx.stroke();
+        ctx.font = "11px Arial";
+        for (const item of section.items) {
+          const ratio = Number(item?.ratio_applied);
+          const validRatio = Number.isFinite(ratio);
+          const ratioText = validRatio ? `${ratio.toFixed(2)}×` : "global";
+          const itemLabel = `${item?.display_id ?? item?.logical_id ?? "?"} ×${item?.fanout ?? 1}`;
 
-        ctx.strokeStyle = "#7c8597";
-        ctx.beginPath();
-        ctx.moveTo(center, rowY - 7);
-        ctx.lineTo(center, rowY + 7);
-        ctx.stroke();
+          ctx.fillStyle = colors.text;
+          ctx.textAlign = "left";
+          ctx.fillText(fitText(ctx, itemLabel, labelWidth - 8), x + 12, rowY);
 
-        const px = validRatio ? barX + ((clamp(ratio, floor, ceiling) - floor) / denom) * barW : center;
-        if (Math.abs(px - center) > 1) {
-          const fillX = Math.min(center, px);
-          const fillW = Math.max(1, Math.abs(px - center));
-          drawRoundedRect(ctx, fillX, rowY - 4, fillW, 8, 4);
-          ctx.fillStyle = px >= center ? "#4f8cff" : "#e3a33b";
+          drawRoundedRect(ctx, barX, rowY - 6, barW, 12, 6);
+          ctx.fillStyle = "#0b1020";
           ctx.fill();
-        }
-        ctx.beginPath();
-        ctx.fillStyle = validRatio ? (px >= center ? "#bcd4ff" : "#ffd08a") : colors.secondary;
-        ctx.arc(px, rowY, 3, 0, Math.PI * 2);
-        ctx.fill();
+          ctx.strokeStyle = "#2a2f39";
+          ctx.stroke();
 
-        ctx.textAlign = "right";
-        ctx.fillStyle = colors.secondary;
-        ctx.fillText(ratioText, x + cardWidth - 12, rowY);
-        rowY += 20;
+          ctx.strokeStyle = "#7c8597";
+          ctx.beginPath();
+          ctx.moveTo(center, rowY - 7);
+          ctx.lineTo(center, rowY + 7);
+          ctx.stroke();
+
+          const px = validRatio ? barX + ((clamp(ratio, floor, ceiling) - floor) / denom) * barW : center;
+          if (Math.abs(px - center) > 1) {
+            const fillX = Math.min(center, px);
+            const fillW = Math.max(1, Math.abs(px - center));
+            drawRoundedRect(ctx, fillX, rowY - 4, fillW, 8, 4);
+            ctx.fillStyle = px >= center ? "#4f8cff" : "#e3a33b";
+            ctx.fill();
+          }
+          ctx.beginPath();
+          ctx.fillStyle = validRatio ? (px >= center ? "#bcd4ff" : "#ffd08a") : colors.secondary;
+          ctx.arc(px, rowY, 3, 0, Math.PI * 2);
+          ctx.fill();
+
+          ctx.textAlign = "right";
+          ctx.fillStyle = colors.secondary;
+          ctx.fillText(ratioText, x + cardWidth - 12, rowY);
+          rowY += 20;
+        }
+
+        if (section.items.length) {
+          rowY += 6;
+        }
       }
 
-      if (logicalGroups.length > shown) {
+      if (layout.hasMore) {
         ctx.textAlign = "left";
         ctx.fillStyle = colors.secondary;
-        ctx.fillText(`click header to ${expanded ? "collapse" : `expand all ${logicalGroups.length}`} logical groups`, x + 12, rowY + 2);
+        ctx.fillText(`click header to ${layout.expanded ? "collapse" : `expand all ${displayGroups.length}`} display groups`, x + 12, rowY + 2);
       }
 
       y += cardHeight + 10;


### PR DESCRIPTION
## Summary
- add display-only grouping for classic `lora_unet_*` style logical groups in the auto-strength widget
- split analyzed output into strongest boosts, strongest pullbacks, and near-global groups for both the text report and inline display
- remove disabled LoRA rows from report generation so toggled-off entries do not appear in analysis output
- update widget sizing and rendering to match the new grouped sections

## Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-strength reports now show three sections: "Strongest boosts", "Strongest pullbacks", and "Near global" neutral groups, each with per-section top-item limits.

* **Improvements**
  * Grouping and normalization of report entries for clearer labels and aggregation.
  * Widget sizing, headers and expand/collapse behavior updated to reflect grouped display counts.
  * Disabled rows are omitted from report output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->