### PR TITLE
[codex] Restore cached UI replay for Dora loader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.VC.opendb
 __pycache__/
 *.pyc
+.codex

--- a/nodes.py
+++ b/nodes.py
@@ -3255,6 +3255,7 @@ class DoraPowerLoraLoader:
 
     RETURN_TYPES = ("MODEL", "CLIP", "STRING", "STRING")
     RETURN_NAMES = ("MODEL", "CLIP", "auto_strength_report_json", "analysis_report")
+    HAS_INTERMEDIATE_OUTPUT = True
     FUNCTION = "load_loras"
     CATEGORY = "loaders"
 


### PR DESCRIPTION
## Summary
- mark `DoraPowerLoraLoader` as `HAS_INTERMEDIATE_OUTPUT = True` so ComfyUI 0.19 replays its cached custom UI payloads
- add `.codex` to `.gitignore` so local Codex workspace metadata stays untracked

## Why
ComfyUI 0.19 gates cached UI replay on `HAS_INTERMEDIATE_OUTPUT`. This loader already returns `auto_strength_report_json` and `analysis_report` in its `ui` payload, but without the flag those reports stop repopulating when the node output is served from cache. Model and CLIP outputs still work, so generation succeeds while the stats UI disappears.

## Validation
- static inspection of `DoraPowerLoraLoader` confirms it emits the custom UI payload fields and previously lacked the required class flag
- structured QA pass on the diff confirmed the change is the smallest correct compatibility fix for ComfyUI 0.19 cached UI replay behavior
- repository tests were not run per repo instructions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `DoraPowerLoraLoader` node now supports intermediate output, enabling its outputs to be accessed and utilized during intermediate processing stages in your workflows.

* **Chores**
  * Updated git configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->