### PR TITLE
Add DoRA state manager node

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,3 +500,44 @@ This repo is meant for cases where plain ComfyUI LoRA loading is not enough, esp
 - OneTrainer DoRA exports
 - Diffusers / PEFT DoRA exports
 - Z-Image Turbo / Lumina2 attention-format LoRAs
+
+---
+
+## DoRA State Manager
+
+This build adds a **DoRA State Manager** node for workflow-serialized character states.
+
+Use it to save:
+
+- character / LoRA combinations
+- per-character loader settings such as auto-strength and DoRA compatibility toggles
+- multiple positive / negative prompt presets per character
+- arbitrary JSON settings for future downstream nodes
+
+### Basic wiring
+
+1. Add **DoRA State Manager**.
+2. Add **DoRA Power LoRA Loader**.
+3. Connect `dora_state` from the manager to the loader's optional `dora_state` input.
+4. Connect `positive_prompt` / `negative_prompt` outputs to your text encode path as needed.
+
+When `dora_state` is connected, the loader uses the selected character's saved LoRA stack. If it is not connected, the loader keeps its normal local row-widget behavior.
+
+### Outputs
+
+- `dora_state` — typed `DORA_STATE` payload for **DoRA Power LoRA Loader**
+- `positive_prompt` — selected prompt preset's positive text
+- `negative_prompt` — selected prompt preset's negative text
+- `settings_json` — selected prompt preset's arbitrary settings object serialized as JSON
+
+### Persistence and payload behavior
+
+The manager state is stored in the workflow through hidden backend widgets:
+
+- `state_json`
+- `selected_character_id`
+- `selected_prompt_id`
+
+No external preset database is required for this first version.
+
+The `DORA_STATE` payload contains the selected character identity, selected prompt identity, saved LoRA rows, saved loader-global overrides, prompt text, and prompt settings. The loader accepts only this typed payload shape; invalid or missing `dora_state` data falls back to the loader's existing local row-widget parsing.

--- a/__init__.py
+++ b/__init__.py
@@ -1,4 +1,4 @@
-from .nodes import DoraPowerLoraLoader
+from .nodes import DoraPowerLoraLoader, DoraStateManager
 
 # Backend API for frontend LoRA dropdown (avoids relying on /object_info variants).
 import folder_paths
@@ -17,8 +17,10 @@ WEB_DIRECTORY = "./web"
 
 NODE_CLASS_MAPPINGS = {
     "DoRA Power LoRA Loader": DoraPowerLoraLoader,
+    "DoRA State Manager": DoraStateManager,
 }
 
 NODE_DISPLAY_NAME_MAPPINGS = {
     "DoRA Power LoRA Loader": "DoRA Power LoRA Loader",
+    "DoRA State Manager": "DoRA State Manager",
 }

--- a/nodes.py
+++ b/nodes.py
@@ -506,6 +506,21 @@ def _clean_state_id(value: Any, fallback: str) -> str:
     return text or fallback
 
 
+def _state_manager_bool(value: Any, default: bool = False) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return default
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off", ""}:
+            return False
+        return default
+    return bool(value)
+
+
 def _normalize_manager_lora_row(row: Any) -> Optional[Dict[str, Any]]:
     if not isinstance(row, dict):
         return None
@@ -521,7 +536,7 @@ def _normalize_manager_lora_row(row: Any) -> Optional[Dict[str, Any]]:
     except Exception:
         strength_clip = strength_model
     return {
-        "enabled": bool(row.get("enabled", row.get("on", True))),
+        "enabled": _state_manager_bool(row.get("enabled", row.get("on", True)), default=True),
         "name": name,
         "strength_model": strength_model,
         "strength_clip": strength_clip,
@@ -556,7 +571,7 @@ def _normalize_manager_loader_globals(globals_in: Any) -> Dict[str, Any]:
             "zimage_lumina2_compat",
             "auto_strength_enabled",
         }:
-            out[key] = bool(value)
+            out[key] = _state_manager_bool(value)
         elif key in {"dora_decompose_debug_n", "dora_decompose_debug_stack_depth"}:
             try:
                 out[key] = int(value)

--- a/nodes.py
+++ b/nodes.py
@@ -429,6 +429,336 @@ class FlexibleOptionalInputType(dict):
         return self._fallback_type
 
 
+
+# --------------------------------------------------------------------------------------
+# DoRA state manager payload helpers
+# --------------------------------------------------------------------------------------
+
+_DORA_STATE_MANAGER_SCHEMA_VERSION = 1
+_DORA_STATE_KIND = "dora_state_manager_state"
+_DORA_STATE_LOADER_GLOBAL_KEYS: Set[str] = {
+    "stack_enabled",
+    "verbose",
+    "log_unloaded_keys",
+    "broadcast_auto_scale",
+    "broadcast_modulations",
+    "broadcast_include_dora_scale",
+    "broadcast_scale",
+    "dora_decompose_debug",
+    "dora_decompose_debug_n",
+    "dora_decompose_debug_stack_depth",
+    "dora_slice_fix",
+    "dora_adaln_swap_fix",
+    "zimage_lumina2_compat",
+    "auto_strength_enabled",
+    "auto_strength_device",
+    "auto_strength_ratio_floor",
+    "auto_strength_ratio_ceiling",
+}
+
+
+def _state_manager_make_id(prefix: str, index: int) -> str:
+    return f"{prefix}_{index + 1}"
+
+
+def _state_manager_default_state() -> Dict[str, Any]:
+    return {
+        "version": _DORA_STATE_MANAGER_SCHEMA_VERSION,
+        "characters": [
+            {
+                "id": "default_character",
+                "name": "Default Character",
+                "loras": [],
+                "loader_globals": {},
+                "prompts": [
+                    {
+                        "id": "default_prompt",
+                        "name": "Default Prompt",
+                        "positive": "",
+                        "negative": "",
+                        "settings": {},
+                    }
+                ],
+            }
+        ],
+    }
+
+
+def _safe_json_load(raw: Any, fallback: Any) -> Any:
+    if isinstance(raw, str):
+        text = raw.strip()
+        if not text:
+            return fallback
+        try:
+            return json.loads(text)
+        except Exception:
+            return fallback
+    if isinstance(raw, dict):
+        return raw
+    return fallback
+
+
+def _clean_state_id(value: Any, fallback: str) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return fallback
+    text = re.sub(r"[^A-Za-z0-9_.:-]+", "_", text).strip("_")
+    return text or fallback
+
+
+def _normalize_manager_lora_row(row: Any) -> Optional[Dict[str, Any]]:
+    if not isinstance(row, dict):
+        return None
+    name = str(row.get("name", row.get("lora", row.get("lora_name", "None"))) or "None").strip()
+    if not name:
+        name = "None"
+    try:
+        strength_model = float(row.get("strength_model", row.get("strengthModel", row.get("strength", 1.0))))
+    except Exception:
+        strength_model = 1.0
+    try:
+        strength_clip = float(row.get("strength_clip", row.get("strengthClip", row.get("strengthTwo", strength_model))))
+    except Exception:
+        strength_clip = strength_model
+    return {
+        "enabled": bool(row.get("enabled", row.get("on", True))),
+        "name": name,
+        "strength_model": strength_model,
+        "strength_clip": strength_clip,
+    }
+
+
+def _normalize_manager_settings(settings: Any) -> Dict[str, Any]:
+    if isinstance(settings, dict):
+        return settings
+    parsed = _safe_json_load(settings, {})
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _normalize_manager_loader_globals(globals_in: Any) -> Dict[str, Any]:
+    if not isinstance(globals_in, dict):
+        return {}
+    out: Dict[str, Any] = {}
+    for key in _DORA_STATE_LOADER_GLOBAL_KEYS:
+        if key not in globals_in:
+            continue
+        value = globals_in.get(key)
+        if key in {
+            "stack_enabled",
+            "verbose",
+            "log_unloaded_keys",
+            "broadcast_auto_scale",
+            "broadcast_modulations",
+            "broadcast_include_dora_scale",
+            "dora_decompose_debug",
+            "dora_slice_fix",
+            "dora_adaln_swap_fix",
+            "zimage_lumina2_compat",
+            "auto_strength_enabled",
+        }:
+            out[key] = bool(value)
+        elif key in {"dora_decompose_debug_n", "dora_decompose_debug_stack_depth"}:
+            try:
+                out[key] = int(value)
+            except Exception:
+                continue
+        elif key == "auto_strength_device":
+            out[key] = _normalize_auto_strength_device(value)
+        else:
+            try:
+                out[key] = float(value)
+            except Exception:
+                continue
+    return out
+
+
+def _normalize_manager_prompt(prompt: Any, index: int) -> Optional[Dict[str, Any]]:
+    if not isinstance(prompt, dict):
+        return None
+    prompt_id = _clean_state_id(prompt.get("id"), _state_manager_make_id("prompt", index))
+    name = str(prompt.get("name") or f"Prompt {index + 1}").strip() or f"Prompt {index + 1}"
+    settings = _normalize_manager_settings(prompt.get("settings", {}))
+    return {
+        "id": prompt_id,
+        "name": name,
+        "positive": str(prompt.get("positive", prompt.get("positive_prompt", "")) or ""),
+        "negative": str(prompt.get("negative", prompt.get("negative_prompt", "")) or ""),
+        "settings": settings,
+    }
+
+
+def _normalize_state_manager_state(raw: Any) -> Dict[str, Any]:
+    parsed = _safe_json_load(raw, _state_manager_default_state())
+    if not isinstance(parsed, dict):
+        parsed = _state_manager_default_state()
+
+    characters_in = parsed.get("characters")
+    if not isinstance(characters_in, list):
+        characters_in = []
+
+    characters: List[Dict[str, Any]] = []
+    used_ids: Set[str] = set()
+    for char_index, char in enumerate(characters_in):
+        if not isinstance(char, dict):
+            continue
+        base_id = _clean_state_id(char.get("id"), _state_manager_make_id("character", char_index))
+        char_id = base_id
+        suffix = 2
+        while char_id in used_ids:
+            char_id = f"{base_id}_{suffix}"
+            suffix += 1
+        used_ids.add(char_id)
+
+        name = str(char.get("name") or f"Character {char_index + 1}").strip() or f"Character {char_index + 1}"
+        loras_in = char.get("loras")
+        loras = []
+        if isinstance(loras_in, list):
+            for row in loras_in:
+                normalized = _normalize_manager_lora_row(row)
+                if normalized is not None:
+                    loras.append(normalized)
+
+        prompts_in = char.get("prompts")
+        prompts: List[Dict[str, Any]] = []
+        if isinstance(prompts_in, list):
+            used_prompt_ids: Set[str] = set()
+            for prompt_index, prompt in enumerate(prompts_in):
+                normalized_prompt = _normalize_manager_prompt(prompt, prompt_index)
+                if normalized_prompt is None:
+                    continue
+                prompt_base_id = normalized_prompt["id"]
+                prompt_id = prompt_base_id
+                prompt_suffix = 2
+                while prompt_id in used_prompt_ids:
+                    prompt_id = f"{prompt_base_id}_{prompt_suffix}"
+                    prompt_suffix += 1
+                used_prompt_ids.add(prompt_id)
+                normalized_prompt["id"] = prompt_id
+                prompts.append(normalized_prompt)
+        if not prompts:
+            prompts = _state_manager_default_state()["characters"][0]["prompts"]
+
+        characters.append(
+            {
+                "id": char_id,
+                "name": name,
+                "loras": loras,
+                "loader_globals": _normalize_manager_loader_globals(char.get("loader_globals", char.get("globals", {}))),
+                "prompts": prompts,
+            }
+        )
+
+    if not characters:
+        characters = _state_manager_default_state()["characters"]
+
+    return {
+        "version": _DORA_STATE_MANAGER_SCHEMA_VERSION,
+        "characters": characters,
+    }
+
+
+def _pick_state_manager_character(state: Dict[str, Any], selected_character_id: Any) -> Dict[str, Any]:
+    selected = str(selected_character_id or "").strip()
+    characters = state.get("characters") if isinstance(state.get("characters"), list) else []
+    for char in characters:
+        if isinstance(char, dict) and char.get("id") == selected:
+            return char
+    return characters[0]
+
+
+def _pick_state_manager_prompt(character: Dict[str, Any], selected_prompt_id: Any) -> Dict[str, Any]:
+    selected = str(selected_prompt_id or "").strip()
+    prompts = character.get("prompts") if isinstance(character.get("prompts"), list) else []
+    for prompt in prompts:
+        if isinstance(prompt, dict) and prompt.get("id") == selected:
+            return prompt
+    return prompts[0] if prompts else _state_manager_default_state()["characters"][0]["prompts"][0]
+
+
+def _resolve_dora_state_payload(state_json: Any, selected_character_id: Any, selected_prompt_id: Any) -> Dict[str, Any]:
+    state = _normalize_state_manager_state(state_json)
+    character = _pick_state_manager_character(state, selected_character_id)
+    prompt = _pick_state_manager_prompt(character, selected_prompt_id)
+    settings = _normalize_manager_settings(prompt.get("settings", {}))
+    return {
+        "version": _DORA_STATE_MANAGER_SCHEMA_VERSION,
+        "kind": _DORA_STATE_KIND,
+        "character": {
+            "id": character.get("id", ""),
+            "name": character.get("name", ""),
+        },
+        "prompt": {
+            "id": prompt.get("id", ""),
+            "name": prompt.get("name", ""),
+        },
+        "loras": character.get("loras", []),
+        "loader_globals": character.get("loader_globals", {}),
+        "settings": settings,
+        "positive_prompt": str(prompt.get("positive", "") or ""),
+        "negative_prompt": str(prompt.get("negative", "") or ""),
+    }
+
+
+def _normalize_runtime_dora_state_payload(raw: Any) -> Optional[Dict[str, Any]]:
+    payload = _safe_json_load(raw, None)
+    if not isinstance(payload, dict):
+        return None
+    if payload.get("kind") != _DORA_STATE_KIND:
+        return None
+    rows_in = payload.get("loras")
+    if not isinstance(rows_in, list):
+        return None
+    loras = []
+    for row in rows_in:
+        normalized = _normalize_manager_lora_row(row)
+        if normalized is not None:
+            loras.append(normalized)
+    globals_out = _normalize_manager_loader_globals(payload.get("loader_globals", payload.get("globals", {})))
+    return {
+        "version": _DORA_STATE_MANAGER_SCHEMA_VERSION,
+        "kind": _DORA_STATE_KIND,
+        "character": payload.get("character") if isinstance(payload.get("character"), dict) else {},
+        "prompt": payload.get("prompt") if isinstance(payload.get("prompt"), dict) else {},
+        "loras": loras,
+        "loader_globals": globals_out,
+        "settings": _normalize_manager_settings(payload.get("settings", {})),
+        "positive_prompt": str(payload.get("positive_prompt", "") or ""),
+        "negative_prompt": str(payload.get("negative_prompt", "") or ""),
+    }
+
+
+def _parse_dora_state_lora_entries(state_payload: Optional[Dict[str, Any]]) -> Optional[List[Dict[str, Any]]]:
+    if not isinstance(state_payload, dict):
+        return None
+    rows = state_payload.get("loras")
+    if not isinstance(rows, list):
+        return None
+    entries: List[Dict[str, Any]] = []
+    for row in rows:
+        normalized = _normalize_manager_lora_row(row)
+        if normalized is None:
+            continue
+        name = normalized.get("name", "None")
+        if name in ("", "None", "NONE"):
+            continue
+        entries.append(
+            {
+                "on": bool(normalized.get("enabled", True)),
+                "lora": name,
+                "strength_model": float(normalized.get("strength_model", 1.0)),
+                "strength_clip": float(normalized.get("strength_clip", normalized.get("strength_model", 1.0))),
+            }
+        )
+    return entries
+
+
+def _state_payload_get_loader_global(state_payload: Optional[Dict[str, Any]], key: str, fallback: Any) -> Any:
+    if isinstance(state_payload, dict):
+        globals_in = state_payload.get("loader_globals")
+        if isinstance(globals_in, dict) and key in globals_in:
+            return globals_in[key]
+    return fallback
+
 _LORA_MAGNITUDE_VECTOR_RE = re.compile(
     r"^(?P<base>.+?)\.lora_magnitude_vector(?:\.(?P<adapter>[A-Za-z0-9_-]+))?(?:\.weight)?$"
 )
@@ -3209,6 +3539,68 @@ def _build_auto_strength_stack_text_report(stack_report: Dict[str, Any]) -> str:
         lines.append(_build_auto_strength_row_text_report(row))
     return "\n".join(lines)
 
+
+class DoraStateManager:
+    """
+    Workflow-serialized state manager for character LoRA stacks and prompt/settings presets.
+
+    Output `dora_state` can be connected to DoRA Power LoRA Loader's optional `dora_state`
+    input. When connected, the loader uses the selected character's LoRA stack and any saved
+    loader-global overrides from this manager instead of its local row widgets.
+    """
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "state_json": (
+                    "STRING",
+                    {
+                        "default": json.dumps(_state_manager_default_state(), separators=(",", ":")),
+                        "multiline": True,
+                    },
+                ),
+                "selected_character_id": ("STRING", {"default": "default_character", "multiline": False}),
+                "selected_prompt_id": ("STRING", {"default": "default_prompt", "multiline": False}),
+            }
+        }
+
+    RETURN_TYPES = ("DORA_STATE", "STRING", "STRING", "STRING")
+    RETURN_NAMES = ("dora_state", "positive_prompt", "negative_prompt", "settings_json")
+    FUNCTION = "resolve_state"
+    CATEGORY = "state managers"
+
+    @classmethod
+    def IS_CHANGED(cls, state_json: Any, selected_character_id: Any = "", selected_prompt_id: Any = ""):
+        payload = {
+            "state_json": state_json,
+            "selected_character_id": selected_character_id,
+            "selected_prompt_id": selected_prompt_id,
+        }
+        return json.dumps(payload, sort_keys=True, default=str)
+
+    @classmethod
+    def VALIDATE_INPUTS(cls, state_json: Any, selected_character_id: Any = "", selected_prompt_id: Any = ""):
+        state = _normalize_state_manager_state(state_json)
+        character = _pick_state_manager_character(state, selected_character_id)
+        prompt = _pick_state_manager_prompt(character, selected_prompt_id)
+        if not character:
+            return "DoRA State Manager: no character states are available."
+        if not prompt:
+            return "DoRA State Manager: no prompt states are available for the selected character."
+        return True
+
+    def resolve_state(self, state_json: Any, selected_character_id: Any = "", selected_prompt_id: Any = ""):
+        payload = _resolve_dora_state_payload(state_json, selected_character_id, selected_prompt_id)
+        settings_json = json.dumps(payload.get("settings", {}), ensure_ascii=False, sort_keys=True, indent=2)
+        return (
+            payload,
+            payload.get("positive_prompt", ""),
+            payload.get("negative_prompt", ""),
+            settings_json,
+        )
+
+
 class DoraPowerLoraLoader:
     """
     Power LoRA Loader-style stack + DoRA/Flux2 key-fix loader.
@@ -3229,6 +3621,10 @@ class DoraPowerLoraLoader:
             "optional": FlexibleOptionalInputType(
                 any_type,
                 data={
+                    # Optional state-manager input. When connected, this overrides local LoRA rows
+                    # and any saved loader-global settings in the manager payload.
+                    "dora_state": ("DORA_STATE",),
+
                     # Flux2 modulation handling
                     "broadcast_modulations": ("BOOLEAN", {"default": True}),
                     "broadcast_include_dora_scale": ("BOOLEAN", {"default": False}),
@@ -3517,39 +3913,41 @@ class DoraPowerLoraLoader:
         return model, clip, auto_strength_report
 
     def load_loras(self, model, clip, **kwargs):
-        # Global controls (provided by JS UI; also safe if absent)
-        stack_enabled = bool(kwargs.get("stack_enabled", True))
-        verbose = bool(kwargs.get("verbose", False))
-        log_unloaded_keys = bool(kwargs.get("log_unloaded_keys", False))
-        broadcast_auto_scale = bool(kwargs.get("broadcast_auto_scale", True))
-        broadcast_modulations = bool(kwargs.get("broadcast_modulations", True))
-        broadcast_include_dora_scale = bool(kwargs.get("broadcast_include_dora_scale", False))
+        state_payload = _normalize_runtime_dora_state_payload(kwargs.get("dora_state"))
+
+        # Global controls (provided by JS UI; optionally overridden by DoRA State Manager)
+        stack_enabled = bool(_state_payload_get_loader_global(state_payload, "stack_enabled", kwargs.get("stack_enabled", True)))
+        verbose = bool(_state_payload_get_loader_global(state_payload, "verbose", kwargs.get("verbose", False)))
+        log_unloaded_keys = bool(_state_payload_get_loader_global(state_payload, "log_unloaded_keys", kwargs.get("log_unloaded_keys", False)))
+        broadcast_auto_scale = bool(_state_payload_get_loader_global(state_payload, "broadcast_auto_scale", kwargs.get("broadcast_auto_scale", True)))
+        broadcast_modulations = bool(_state_payload_get_loader_global(state_payload, "broadcast_modulations", kwargs.get("broadcast_modulations", True)))
+        broadcast_include_dora_scale = bool(_state_payload_get_loader_global(state_payload, "broadcast_include_dora_scale", kwargs.get("broadcast_include_dora_scale", False)))
         try:
-            broadcast_scale = float(kwargs.get("broadcast_scale", 1.0))
+            broadcast_scale = float(_state_payload_get_loader_global(state_payload, "broadcast_scale", kwargs.get("broadcast_scale", 1.0)))
         except Exception:
             broadcast_scale = 1.0
 
-        # DoRA decompose debug controls (node-adjustable)
-        dora_dbg = bool(kwargs.get("dora_decompose_debug", False))
+        # DoRA decompose debug controls (node-adjustable / state-manager overrideable)
+        dora_dbg = bool(_state_payload_get_loader_global(state_payload, "dora_decompose_debug", kwargs.get("dora_decompose_debug", False)))
         try:
-            dora_dbg_n = int(kwargs.get("dora_decompose_debug_n", 30))
+            dora_dbg_n = int(_state_payload_get_loader_global(state_payload, "dora_decompose_debug_n", kwargs.get("dora_decompose_debug_n", 30)))
         except Exception:
             dora_dbg_n = 30
         try:
-            dora_dbg_stack = int(kwargs.get("dora_decompose_debug_stack_depth", 10))
+            dora_dbg_stack = int(_state_payload_get_loader_global(state_payload, "dora_decompose_debug_stack_depth", kwargs.get("dora_decompose_debug_stack_depth", 10)))
         except Exception:
             dora_dbg_stack = 10
-        dora_slice_fix = bool(kwargs.get("dora_slice_fix", True))
-        dora_adaln_swap_fix = bool(kwargs.get("dora_adaln_swap_fix", True))
-        zimage_lumina2_compat = bool(kwargs.get("zimage_lumina2_compat", True))
-        auto_strength_enabled = bool(kwargs.get("auto_strength_enabled", False))
-        auto_strength_device = _normalize_auto_strength_device(kwargs.get("auto_strength_device", "gpu"))
+        dora_slice_fix = bool(_state_payload_get_loader_global(state_payload, "dora_slice_fix", kwargs.get("dora_slice_fix", True)))
+        dora_adaln_swap_fix = bool(_state_payload_get_loader_global(state_payload, "dora_adaln_swap_fix", kwargs.get("dora_adaln_swap_fix", True)))
+        zimage_lumina2_compat = bool(_state_payload_get_loader_global(state_payload, "zimage_lumina2_compat", kwargs.get("zimage_lumina2_compat", True)))
+        auto_strength_enabled = bool(_state_payload_get_loader_global(state_payload, "auto_strength_enabled", kwargs.get("auto_strength_enabled", False)))
+        auto_strength_device = _normalize_auto_strength_device(_state_payload_get_loader_global(state_payload, "auto_strength_device", kwargs.get("auto_strength_device", "gpu")))
         try:
-            auto_strength_ratio_floor = float(kwargs.get("auto_strength_ratio_floor", _AUTO_STRENGTH_RATIO_FLOOR))
+            auto_strength_ratio_floor = float(_state_payload_get_loader_global(state_payload, "auto_strength_ratio_floor", kwargs.get("auto_strength_ratio_floor", _AUTO_STRENGTH_RATIO_FLOOR)))
         except Exception:
             auto_strength_ratio_floor = _AUTO_STRENGTH_RATIO_FLOOR
         try:
-            auto_strength_ratio_ceiling = float(kwargs.get("auto_strength_ratio_ceiling", _AUTO_STRENGTH_RATIO_CEILING))
+            auto_strength_ratio_ceiling = float(_state_payload_get_loader_global(state_payload, "auto_strength_ratio_ceiling", kwargs.get("auto_strength_ratio_ceiling", _AUTO_STRENGTH_RATIO_CEILING)))
         except Exception:
             auto_strength_ratio_ceiling = _AUTO_STRENGTH_RATIO_CEILING
         if auto_strength_ratio_ceiling < auto_strength_ratio_floor:
@@ -3585,7 +3983,9 @@ class DoraPowerLoraLoader:
                 },
             }
 
-        entries = _parse_lora_stack_kwargs(kwargs)
+        entries = _parse_dora_state_lora_entries(state_payload) if state_payload is not None else None
+        if entries is None:
+            entries = _parse_lora_stack_kwargs(kwargs)
         if not entries:
             stack_report = {
                 "schema": 1,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "dora-dynamic-lora-loader"
 description = "A ComfyUI custom node that loads and stacks regular LoRAs and DoRA LoRAs with Flux/Flux2 and OneTrainer compatibility fixes."
-version = "1.0.21"
+version = "1.0.22"
 license = { file = "LICENSE" }
 
 [project.urls]

--- a/web/dora_state_manager.js
+++ b/web/dora_state_manager.js
@@ -77,6 +77,18 @@ function normalizeDevice(value) {
   return AUTO_STRENGTH_DEVICE_CHOICES.includes(v) ? v : "gpu";
 }
 
+function normalizeBoolean(value, fallback = false) {
+  if (typeof value === "boolean") return value;
+  if (value == null) return fallback;
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (["1", "true", "yes", "on"].includes(normalized)) return true;
+    if (["0", "false", "no", "off", ""].includes(normalized)) return false;
+    return fallback;
+  }
+  return Boolean(value);
+}
+
 function normalizeLoaderGlobals(globalsIn) {
   const src = globalsIn && typeof globalsIn === "object" ? globalsIn : {};
   const out = {};
@@ -93,7 +105,7 @@ function normalizeLoaderGlobals(globalsIn) {
     "zimage_lumina2_compat",
     "auto_strength_enabled",
   ]) {
-    if (Object.prototype.hasOwnProperty.call(src, key)) out[key] = Boolean(src[key]);
+    if (Object.prototype.hasOwnProperty.call(src, key)) out[key] = normalizeBoolean(src[key]);
   }
   for (const key of ["broadcast_scale", "auto_strength_ratio_floor", "auto_strength_ratio_ceiling"]) {
     if (Object.prototype.hasOwnProperty.call(src, key)) out[key] = normalizeNumber(src[key], key === "broadcast_scale" ? 1.0 : 0.0);
@@ -110,7 +122,7 @@ function normalizeLoraRow(row) {
   const strengthModel = normalizeNumber(r.strength_model ?? r.strengthModel ?? r.strength, 1.0);
   const strengthClip = normalizeNumber(r.strength_clip ?? r.strengthClip ?? r.strengthTwo, strengthModel);
   return {
-    enabled: r.enabled !== undefined ? Boolean(r.enabled) : r.on !== undefined ? Boolean(r.on) : true,
+    enabled: r.enabled !== undefined ? normalizeBoolean(r.enabled, true) : r.on !== undefined ? normalizeBoolean(r.on, true) : true,
     name: String(r.name ?? r.lora ?? r.lora_name ?? "None").trim() || "None",
     strength_model: strengthModel,
     strength_clip: strengthClip,
@@ -659,14 +671,19 @@ function installNode(node) {
   if (!node) return;
   node.resizable = true;
 
+  const state = readNodeState(node);
+  const { character, prompt } = ensureSelection(node, state);
+  saveState(node, state, { characterId: character.id, promptId: prompt.id });
+
+  if (typeof node.addDOMWidget !== "function") {
+    console.warn(`[${EXT_NAME}] addDOMWidget is unavailable; falling back to raw JSON widgets.`);
+    return;
+  }
+
   const widgets = getWidgets(node);
   hideWidget(widgets.stateWidget);
   hideWidget(widgets.characterWidget);
   hideWidget(widgets.promptWidget);
-
-  const state = readNodeState(node);
-  const { character, prompt } = ensureSelection(node, state);
-  saveState(node, state, { characterId: character.id, promptId: prompt.id });
 
   if (node.__dsmInstalled) {
     render(node);
@@ -674,23 +691,18 @@ function installNode(node) {
   }
   node.__dsmInstalled = true;
 
-  if (typeof node.addDOMWidget === "function") {
-    const root = document.createElement("div");
-    node.__dsmRoot = root;
-    const widget = node.addDOMWidget(DOM_WIDGET_NAME, DOM_WIDGET_TYPE, root, {
-      getMinHeight: () => MIN_WIDGET_HEIGHT,
-      getHeight: () => "100%",
-      onDraw: (domWidget) => syncDomWidgetSize(node, domWidget),
-      afterResize: (domWidgetNode) => syncDomWidgetSize(domWidgetNode, widget),
-      serialize: false,
-    });
-    widget.serialize = false;
-    node.__dsmWidget = widget;
-    syncDomWidgetSize(node, widget);
-  } else {
-    console.warn(`[${EXT_NAME}] addDOMWidget is unavailable; falling back to raw JSON widgets.`);
-    return;
-  }
+  const root = document.createElement("div");
+  node.__dsmRoot = root;
+  const widget = node.addDOMWidget(DOM_WIDGET_NAME, DOM_WIDGET_TYPE, root, {
+    getMinHeight: () => MIN_WIDGET_HEIGHT,
+    getHeight: () => "100%",
+    onDraw: (domWidget) => syncDomWidgetSize(node, domWidget),
+    afterResize: (domWidgetNode) => syncDomWidgetSize(domWidgetNode, widget),
+    serialize: false,
+  });
+  widget.serialize = false;
+  node.__dsmWidget = widget;
+  syncDomWidgetSize(node, widget);
 
   fetchLoras().then(() => {
     render(node);

--- a/web/dora_state_manager.js
+++ b/web/dora_state_manager.js
@@ -1,0 +1,744 @@
+import { app } from "../../scripts/app.js";
+import "../../scripts/domWidget.js";
+
+const EXT_NAME = "comfyui_dora_dynamic_lora.state_manager";
+const NODE_CLASS = "DoRA State Manager";
+const LORA_API = "/dora_dynamic_lora/loras";
+const STATE_WIDGET = "state_json";
+const SELECTED_CHARACTER_WIDGET = "selected_character_id";
+const SELECTED_PROMPT_WIDGET = "selected_prompt_id";
+const DOM_WIDGET_NAME = "dora_state_manager_ui";
+const DOM_WIDGET_TYPE = "DORA_STATE_MANAGER_UI";
+const STYLE_ID = "dora-state-manager-style";
+const MIN_NODE_WIDTH = 620;
+const MIN_WIDGET_HEIGHT = 700;
+const AUTO_STRENGTH_DEVICE_CHOICES = ["auto", "cpu", "gpu"];
+
+function clone(value) {
+  if (typeof structuredClone === "function") return structuredClone(value);
+  return JSON.parse(JSON.stringify(value));
+}
+
+function makeId(prefix) {
+  if (globalThis.crypto?.randomUUID) return `${prefix}_${globalThis.crypto.randomUUID()}`;
+  return `${prefix}_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function defaultPrompt() {
+  return {
+    id: "default_prompt",
+    name: "Default Prompt",
+    positive: "",
+    negative: "",
+    settings: {},
+  };
+}
+
+function defaultCharacter() {
+  return {
+    id: "default_character",
+    name: "Default Character",
+    loras: [],
+    loader_globals: {},
+    prompts: [defaultPrompt()],
+  };
+}
+
+function defaultState() {
+  return {
+    version: 1,
+    characters: [defaultCharacter()],
+  };
+}
+
+function safeJsonParse(raw, fallback) {
+  if (raw && typeof raw === "object") return clone(raw);
+  if (typeof raw !== "string" || !raw.trim()) return clone(fallback);
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" ? parsed : clone(fallback);
+  } catch {
+    return clone(fallback);
+  }
+}
+
+function cleanId(value, fallback) {
+  const text = String(value ?? "").trim().replace(/[^A-Za-z0-9_.:-]+/g, "_").replace(/^_+|_+$/g, "");
+  return text || fallback;
+}
+
+function normalizeNumber(value, fallback = 1.0) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function normalizeDevice(value) {
+  const v = String(value ?? "gpu").toLowerCase();
+  return AUTO_STRENGTH_DEVICE_CHOICES.includes(v) ? v : "gpu";
+}
+
+function normalizeLoaderGlobals(globalsIn) {
+  const src = globalsIn && typeof globalsIn === "object" ? globalsIn : {};
+  const out = {};
+  for (const key of [
+    "stack_enabled",
+    "verbose",
+    "log_unloaded_keys",
+    "broadcast_auto_scale",
+    "broadcast_modulations",
+    "broadcast_include_dora_scale",
+    "dora_decompose_debug",
+    "dora_slice_fix",
+    "dora_adaln_swap_fix",
+    "zimage_lumina2_compat",
+    "auto_strength_enabled",
+  ]) {
+    if (Object.prototype.hasOwnProperty.call(src, key)) out[key] = Boolean(src[key]);
+  }
+  for (const key of ["broadcast_scale", "auto_strength_ratio_floor", "auto_strength_ratio_ceiling"]) {
+    if (Object.prototype.hasOwnProperty.call(src, key)) out[key] = normalizeNumber(src[key], key === "broadcast_scale" ? 1.0 : 0.0);
+  }
+  for (const key of ["dora_decompose_debug_n", "dora_decompose_debug_stack_depth"]) {
+    if (Object.prototype.hasOwnProperty.call(src, key)) out[key] = Math.floor(normalizeNumber(src[key], key === "dora_decompose_debug_n" ? 30 : 10));
+  }
+  if (Object.prototype.hasOwnProperty.call(src, "auto_strength_device")) out.auto_strength_device = normalizeDevice(src.auto_strength_device);
+  return out;
+}
+
+function normalizeLoraRow(row) {
+  const r = row && typeof row === "object" ? row : {};
+  const strengthModel = normalizeNumber(r.strength_model ?? r.strengthModel ?? r.strength, 1.0);
+  const strengthClip = normalizeNumber(r.strength_clip ?? r.strengthClip ?? r.strengthTwo, strengthModel);
+  return {
+    enabled: r.enabled !== undefined ? Boolean(r.enabled) : r.on !== undefined ? Boolean(r.on) : true,
+    name: String(r.name ?? r.lora ?? r.lora_name ?? "None").trim() || "None",
+    strength_model: strengthModel,
+    strength_clip: strengthClip,
+  };
+}
+
+function normalizeSettings(value) {
+  if (value && typeof value === "object" && !Array.isArray(value)) return clone(value);
+  const parsed = safeJsonParse(value, {});
+  return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
+}
+
+function normalizePrompt(prompt, index) {
+  const p = prompt && typeof prompt === "object" ? prompt : {};
+  return {
+    id: cleanId(p.id, `prompt_${index + 1}`),
+    name: String(p.name ?? `Prompt ${index + 1}`).trim() || `Prompt ${index + 1}`,
+    positive: String(p.positive ?? p.positive_prompt ?? ""),
+    negative: String(p.negative ?? p.negative_prompt ?? ""),
+    settings: normalizeSettings(p.settings),
+  };
+}
+
+function normalizeCharacter(character, index) {
+  const c = character && typeof character === "object" ? character : {};
+  const promptsIn = Array.isArray(c.prompts) ? c.prompts : [];
+  const prompts = promptsIn.map(normalizePrompt).filter(Boolean);
+  return {
+    id: cleanId(c.id, `character_${index + 1}`),
+    name: String(c.name ?? `Character ${index + 1}`).trim() || `Character ${index + 1}`,
+    loras: Array.isArray(c.loras) ? c.loras.map(normalizeLoraRow) : [],
+    loader_globals: normalizeLoaderGlobals(c.loader_globals ?? c.globals),
+    prompts: prompts.length ? prompts : [defaultPrompt()],
+  };
+}
+
+function normalizeState(raw) {
+  const parsed = safeJsonParse(raw, defaultState());
+  const charsIn = Array.isArray(parsed.characters) ? parsed.characters : [];
+  const chars = charsIn.map(normalizeCharacter).filter(Boolean);
+  return {
+    version: 1,
+    characters: chars.length ? chars : [defaultCharacter()],
+  };
+}
+
+function serializeState(state) {
+  return JSON.stringify(normalizeState(state), null, 0);
+}
+
+function getWidgets(node) {
+  const map = new Map();
+  for (const widget of node.widgets ?? []) map.set(widget.name, widget);
+  return {
+    stateWidget: map.get(STATE_WIDGET),
+    characterWidget: map.get(SELECTED_CHARACTER_WIDGET),
+    promptWidget: map.get(SELECTED_PROMPT_WIDGET),
+  };
+}
+
+function setWidgetValue(widget, value) {
+  if (!widget) return;
+  widget.value = value;
+  widget.callback?.(value);
+}
+
+function widgetValue(widget, fallback = "") {
+  return widget?.value ?? fallback;
+}
+
+function hideWidget(widget) {
+  if (!widget || widget.__dsmHidden) return;
+  widget.__dsmHidden = true;
+  widget.type = "hidden";
+  widget.computeSize = () => [0, 0];
+  widget.draw = () => {};
+}
+
+function selectedCharacter(state, selectedId) {
+  return state.characters.find((c) => c.id === selectedId) || state.characters[0];
+}
+
+function selectedPrompt(character, selectedId) {
+  return character.prompts.find((p) => p.id === selectedId) || character.prompts[0];
+}
+
+function ensureSelection(node, state) {
+  const { characterWidget, promptWidget } = getWidgets(node);
+  let charId = String(widgetValue(characterWidget, "") || "").trim();
+  let character = selectedCharacter(state, charId);
+  if (!character || character.id !== charId) {
+    character = state.characters[0];
+    charId = character.id;
+    setWidgetValue(characterWidget, charId);
+  }
+  let promptId = String(widgetValue(promptWidget, "") || "").trim();
+  let prompt = selectedPrompt(character, promptId);
+  if (!prompt || prompt.id !== promptId) {
+    prompt = character.prompts[0];
+    setWidgetValue(promptWidget, prompt.id);
+  }
+  return { character, prompt };
+}
+
+function markNodeDirty(node) {
+  node.setDirtyCanvas?.(true, true);
+  node.graph?.change?.();
+}
+
+function saveState(node, state, opts = {}) {
+  const widgets = getWidgets(node);
+  const normalized = normalizeState(state);
+  setWidgetValue(widgets.stateWidget, serializeState(normalized));
+  if (opts.characterId) setWidgetValue(widgets.characterWidget, opts.characterId);
+  if (opts.promptId) setWidgetValue(widgets.promptWidget, opts.promptId);
+  node.properties = node.properties || {};
+  node.properties.dora_state_manager = {
+    state: normalized,
+    selected_character_id: widgetValue(widgets.characterWidget, ""),
+    selected_prompt_id: widgetValue(widgets.promptWidget, ""),
+  };
+  if (opts.dirty !== false) markNodeDirty(node);
+}
+
+function readNodeState(node) {
+  const { stateWidget } = getWidgets(node);
+  return normalizeState(widgetValue(stateWidget, serializeState(defaultState())));
+}
+
+let loraCache = null;
+async function fetchLoras() {
+  if (loraCache) return loraCache;
+  try {
+    const response = await fetch(LORA_API, { cache: "no-store" });
+    if (!response.ok) throw new Error(`${response.status} ${response.statusText}`);
+    const list = await response.json();
+    loraCache = Array.isArray(list) ? ["None", ...list.filter((x) => x && x !== "None" && x !== "NONE")] : ["None"];
+  } catch (err) {
+    console.warn(`[${EXT_NAME}] failed to fetch LoRA list`, err);
+    loraCache = ["None"];
+  }
+  return loraCache;
+}
+
+function ensureStyles() {
+  if (document.getElementById(STYLE_ID)) return;
+  const style = document.createElement("style");
+  style.id = STYLE_ID;
+  style.textContent = `
+    .dsm-root {
+      --dsm-gap: 8px;
+      box-sizing: border-box;
+      height: 100%;
+      min-height: ${MIN_WIDGET_HEIGHT}px;
+      padding: 8px;
+      overflow: auto;
+      display: flex;
+      flex-direction: column;
+      gap: var(--dsm-gap);
+      color: var(--input-text, #ddd);
+      background: rgba(20, 20, 20, 0.20);
+      font: 12px/1.35 system-ui, sans-serif;
+    }
+    .dsm-root * { box-sizing: border-box; }
+    .dsm-row { display: flex; gap: 6px; align-items: center; }
+    .dsm-row.wrap { flex-wrap: wrap; }
+    .dsm-section { border: 1px solid rgba(128,128,128,.35); border-radius: 8px; padding: 8px; display: flex; flex-direction: column; gap: 7px; }
+    .dsm-section-title { font-weight: 650; opacity: .95; }
+    .dsm-root input, .dsm-root select, .dsm-root textarea, .dsm-root button {
+      font: inherit;
+      color: var(--input-text, #ddd);
+      background: var(--comfy-input-bg, #222);
+      border: 1px solid rgba(128,128,128,.45);
+      border-radius: 5px;
+      padding: 4px 6px;
+    }
+    .dsm-root button { cursor: pointer; white-space: nowrap; }
+    .dsm-root textarea { width: 100%; min-height: 82px; resize: vertical; }
+    .dsm-root input[type="checkbox"] { width: auto; }
+    .dsm-flex { flex: 1 1 auto; min-width: 0; }
+    .dsm-small { width: 74px; }
+    .dsm-mid { width: 132px; }
+    .dsm-muted { opacity: .68; }
+    .dsm-lora-row { display: grid; grid-template-columns: auto minmax(160px,1fr) 80px 80px auto; gap: 6px; align-items: center; }
+    .dsm-grid2 { display: grid; grid-template-columns: minmax(0,1fr) minmax(0,1fr); gap: 6px; }
+    .dsm-details { display: flex; flex-direction: column; gap: 7px; }
+    .dsm-details summary { cursor: pointer; user-select: none; }
+  `;
+  document.head.appendChild(style);
+}
+
+function makeButton(label, callback, title = "") {
+  const button = document.createElement("button");
+  button.type = "button";
+  button.textContent = label;
+  if (title) button.title = title;
+  button.addEventListener("click", (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    callback(event);
+  });
+  return button;
+}
+
+function makeInput(value, onChange, attrs = {}) {
+  const input = document.createElement("input");
+  input.value = value ?? "";
+  Object.assign(input, attrs);
+  input.addEventListener("input", () => onChange(input.value));
+  input.addEventListener("change", () => onChange(input.value));
+  return input;
+}
+
+function makeCheckbox(value, onChange) {
+  const input = document.createElement("input");
+  input.type = "checkbox";
+  input.checked = Boolean(value);
+  input.addEventListener("change", () => onChange(input.checked));
+  return input;
+}
+
+function makeSelect(values, selected, onChange) {
+  const select = document.createElement("select");
+  for (const value of values) {
+    const option = document.createElement("option");
+    option.value = value.value ?? value;
+    option.textContent = value.label ?? value;
+    select.appendChild(option);
+  }
+  select.value = selected;
+  select.addEventListener("change", () => onChange(select.value));
+  return select;
+}
+
+function addLabel(container, text, control) {
+  const label = document.createElement("label");
+  label.className = "dsm-row dsm-flex";
+  const span = document.createElement("span");
+  span.textContent = text;
+  span.className = "dsm-muted";
+  label.append(span, control);
+  container.appendChild(label);
+  return label;
+}
+
+function updateGlobalsFromUi(globals, patch) {
+  Object.assign(globals, patch);
+  return normalizeLoaderGlobals(globals);
+}
+
+function render(node) {
+  const root = node.__dsmRoot;
+  if (!root) return;
+  ensureStyles();
+
+  const state = readNodeState(node);
+  const { character, prompt } = ensureSelection(node, state);
+  const selectedCharId = character.id;
+  const selectedPromptId = prompt.id;
+
+  root.innerHTML = "";
+  root.className = "dsm-root";
+
+  const datalistId = `dsm_loras_${node.id ?? "node"}`;
+  const datalist = document.createElement("datalist");
+  datalist.id = datalistId;
+  for (const name of loraCache || ["None"]) {
+    const option = document.createElement("option");
+    option.value = name;
+    datalist.appendChild(option);
+  }
+  root.appendChild(datalist);
+
+  const header = document.createElement("div");
+  header.className = "dsm-section";
+  const headerTitle = document.createElement("div");
+  headerTitle.className = "dsm-section-title";
+  headerTitle.textContent = "Character state";
+  const charRow = document.createElement("div");
+  charRow.className = "dsm-row wrap";
+  const charSelect = makeSelect(
+    state.characters.map((c) => ({ value: c.id, label: c.name })),
+    selectedCharId,
+    (id) => {
+      const next = selectedCharacter(state, id);
+      saveState(node, state, { characterId: next.id, promptId: next.prompts[0]?.id || "" });
+      render(node);
+    }
+  );
+  charSelect.className = "dsm-flex";
+  charRow.append(
+    charSelect,
+    makeButton("New", () => {
+      const c = defaultCharacter();
+      c.id = makeId("character");
+      c.name = `Character ${state.characters.length + 1}`;
+      c.prompts[0].id = makeId("prompt");
+      state.characters.push(c);
+      saveState(node, state, { characterId: c.id, promptId: c.prompts[0].id });
+      render(node);
+    }),
+    makeButton("Duplicate", () => {
+      const copy = clone(character);
+      copy.id = makeId("character");
+      copy.name = `${copy.name} Copy`;
+      copy.prompts = copy.prompts.map((p) => ({ ...p, id: makeId("prompt") }));
+      state.characters.push(copy);
+      saveState(node, state, { characterId: copy.id, promptId: copy.prompts[0]?.id || "" });
+      render(node);
+    }),
+    makeButton("Delete", () => {
+      if (state.characters.length <= 1) return;
+      const index = state.characters.findIndex((c) => c.id === selectedCharId);
+      if (index >= 0) state.characters.splice(index, 1);
+      const next = state.characters[Math.max(0, Math.min(index, state.characters.length - 1))];
+      saveState(node, state, { characterId: next.id, promptId: next.prompts[0]?.id || "" });
+      render(node);
+    })
+  );
+  const nameInput = makeInput(character.name, (value) => {
+    character.name = value.trim() || character.name;
+    saveState(node, state, { characterId: character.id, promptId: selectedPromptId });
+  });
+  nameInput.className = "dsm-flex";
+  const nameRow = document.createElement("div");
+  nameRow.className = "dsm-row";
+  nameRow.append(Object.assign(document.createElement("span"), { textContent: "Name", className: "dsm-muted" }), nameInput);
+  header.append(headerTitle, charRow, nameRow);
+  root.appendChild(header);
+
+  const loraSection = document.createElement("div");
+  loraSection.className = "dsm-section";
+  const loraTitle = document.createElement("div");
+  loraTitle.className = "dsm-row";
+  const titleText = document.createElement("div");
+  titleText.className = "dsm-section-title dsm-flex";
+  titleText.textContent = "LoRA combination";
+  loraTitle.append(
+    titleText,
+    makeButton("Refresh", async () => {
+      loraCache = null;
+      await fetchLoras();
+      render(node);
+    }),
+    makeButton("Add LoRA", () => {
+      character.loras.push({ enabled: true, name: "None", strength_model: 1.0, strength_clip: 1.0 });
+      saveState(node, state, { characterId: selectedCharId, promptId: selectedPromptId });
+      render(node);
+    })
+  );
+  loraSection.appendChild(loraTitle);
+  if (!character.loras.length) {
+    const empty = document.createElement("div");
+    empty.className = "dsm-muted";
+    empty.textContent = "No LoRA rows saved for this character yet.";
+    loraSection.appendChild(empty);
+  }
+  character.loras.forEach((row, index) => {
+    const loraRow = document.createElement("div");
+    loraRow.className = "dsm-lora-row";
+    const enabled = makeCheckbox(row.enabled, (checked) => {
+      row.enabled = checked;
+      saveState(node, state, { characterId: selectedCharId, promptId: selectedPromptId });
+    });
+    const name = makeInput(row.name, (value) => {
+      row.name = value.trim() || "None";
+      saveState(node, state, { characterId: selectedCharId, promptId: selectedPromptId });
+    }, { list: datalistId });
+    const sm = makeInput(row.strength_model, (value) => {
+      row.strength_model = normalizeNumber(value, row.strength_model);
+      saveState(node, state, { characterId: selectedCharId, promptId: selectedPromptId });
+    }, { type: "number", step: "0.05" });
+    const sc = makeInput(row.strength_clip, (value) => {
+      row.strength_clip = normalizeNumber(value, row.strength_clip);
+      saveState(node, state, { characterId: selectedCharId, promptId: selectedPromptId });
+    }, { type: "number", step: "0.05" });
+    loraRow.append(enabled, name, sm, sc, makeButton("×", () => {
+      character.loras.splice(index, 1);
+      saveState(node, state, { characterId: selectedCharId, promptId: selectedPromptId });
+      render(node);
+    }, "Remove LoRA row"));
+    loraSection.appendChild(loraRow);
+  });
+  root.appendChild(loraSection);
+
+  const promptSection = document.createElement("div");
+  promptSection.className = "dsm-section";
+  const promptTitle = document.createElement("div");
+  promptTitle.className = "dsm-row";
+  const promptTitleText = document.createElement("div");
+  promptTitleText.className = "dsm-section-title dsm-flex";
+  promptTitleText.textContent = "Prompt preset";
+  promptTitle.append(
+    promptTitleText,
+    makeButton("New", () => {
+      const p = defaultPrompt();
+      p.id = makeId("prompt");
+      p.name = `Prompt ${character.prompts.length + 1}`;
+      character.prompts.push(p);
+      saveState(node, state, { characterId: selectedCharId, promptId: p.id });
+      render(node);
+    }),
+    makeButton("Duplicate", () => {
+      const p = { ...clone(prompt), id: makeId("prompt"), name: `${prompt.name} Copy` };
+      character.prompts.push(p);
+      saveState(node, state, { characterId: selectedCharId, promptId: p.id });
+      render(node);
+    }),
+    makeButton("Delete", () => {
+      if (character.prompts.length <= 1) return;
+      const index = character.prompts.findIndex((p) => p.id === selectedPromptId);
+      if (index >= 0) character.prompts.splice(index, 1);
+      const next = character.prompts[Math.max(0, Math.min(index, character.prompts.length - 1))];
+      saveState(node, state, { characterId: selectedCharId, promptId: next.id });
+      render(node);
+    })
+  );
+  const promptSelect = makeSelect(
+    character.prompts.map((p) => ({ value: p.id, label: p.name })),
+    selectedPromptId,
+    (id) => {
+      saveState(node, state, { characterId: selectedCharId, promptId: id });
+      render(node);
+    }
+  );
+  promptSelect.className = "dsm-flex";
+  const promptSelectRow = document.createElement("div");
+  promptSelectRow.className = "dsm-row";
+  promptSelectRow.append(promptSelect);
+  const promptName = makeInput(prompt.name, (value) => {
+    prompt.name = value.trim() || prompt.name;
+    saveState(node, state, { characterId: selectedCharId, promptId: prompt.id });
+  });
+  promptName.className = "dsm-flex";
+  const promptNameRow = document.createElement("div");
+  promptNameRow.className = "dsm-row";
+  promptNameRow.append(Object.assign(document.createElement("span"), { textContent: "Name", className: "dsm-muted" }), promptName);
+  const positive = document.createElement("textarea");
+  positive.value = prompt.positive;
+  positive.placeholder = "Positive prompt";
+  positive.addEventListener("input", () => {
+    prompt.positive = positive.value;
+    saveState(node, state, { characterId: selectedCharId, promptId: prompt.id });
+  });
+  const negative = document.createElement("textarea");
+  negative.value = prompt.negative;
+  negative.placeholder = "Negative prompt";
+  negative.addEventListener("input", () => {
+    prompt.negative = negative.value;
+    saveState(node, state, { characterId: selectedCharId, promptId: prompt.id });
+  });
+  promptSection.append(promptTitle, promptSelectRow, promptNameRow, positive, negative);
+  root.appendChild(promptSection);
+
+  const settingsSection = document.createElement("details");
+  settingsSection.className = "dsm-section dsm-details";
+  const settingsSummary = document.createElement("summary");
+  settingsSummary.className = "dsm-section-title";
+  settingsSummary.textContent = "Saved loader settings / future node settings";
+  settingsSection.appendChild(settingsSummary);
+
+  const globals = character.loader_globals || (character.loader_globals = {});
+  const row1 = document.createElement("div");
+  row1.className = "dsm-grid2";
+  const stackEnabled = makeCheckbox(globals.stack_enabled ?? true, (checked) => {
+    character.loader_globals = updateGlobalsFromUi(globals, { stack_enabled: checked });
+    saveState(node, state, { characterId: selectedCharId, promptId: selectedPromptId });
+  });
+  const autoStrength = makeCheckbox(globals.auto_strength_enabled ?? false, (checked) => {
+    character.loader_globals = updateGlobalsFromUi(globals, { auto_strength_enabled: checked });
+    saveState(node, state, { characterId: selectedCharId, promptId: selectedPromptId });
+  });
+  addLabel(row1, "Stack", stackEnabled);
+  addLabel(row1, "Auto-strength", autoStrength);
+  settingsSection.appendChild(row1);
+
+  const row2 = document.createElement("div");
+  row2.className = "dsm-grid2";
+  const device = makeSelect(AUTO_STRENGTH_DEVICE_CHOICES, normalizeDevice(globals.auto_strength_device ?? "gpu"), (value) => {
+    character.loader_globals = updateGlobalsFromUi(globals, { auto_strength_device: value });
+    saveState(node, state, { characterId: selectedCharId, promptId: selectedPromptId });
+  });
+  const broadcastMods = makeCheckbox(globals.broadcast_modulations ?? true, (checked) => {
+    character.loader_globals = updateGlobalsFromUi(globals, { broadcast_modulations: checked });
+    saveState(node, state, { characterId: selectedCharId, promptId: selectedPromptId });
+  });
+  addLabel(row2, "Device", device);
+  addLabel(row2, "Broadcast modulation", broadcastMods);
+  settingsSection.appendChild(row2);
+
+  const row3 = document.createElement("div");
+  row3.className = "dsm-grid2";
+  const floor = makeInput(globals.auto_strength_ratio_floor ?? 0.30, (value) => {
+    character.loader_globals = updateGlobalsFromUi(globals, { auto_strength_ratio_floor: normalizeNumber(value, 0.30) });
+    saveState(node, state, { characterId: selectedCharId, promptId: selectedPromptId });
+  }, { type: "number", step: "0.01" });
+  const ceiling = makeInput(globals.auto_strength_ratio_ceiling ?? 1.50, (value) => {
+    character.loader_globals = updateGlobalsFromUi(globals, { auto_strength_ratio_ceiling: normalizeNumber(value, 1.50) });
+    saveState(node, state, { characterId: selectedCharId, promptId: selectedPromptId });
+  }, { type: "number", step: "0.01" });
+  addLabel(row3, "Ratio floor", floor);
+  addLabel(row3, "Ratio ceiling", ceiling);
+  settingsSection.appendChild(row3);
+
+  const row4 = document.createElement("div");
+  row4.className = "dsm-grid2";
+  const sliceFix = makeCheckbox(globals.dora_slice_fix ?? true, (checked) => {
+    character.loader_globals = updateGlobalsFromUi(globals, { dora_slice_fix: checked });
+    saveState(node, state, { characterId: selectedCharId, promptId: selectedPromptId });
+  });
+  const adalnFix = makeCheckbox(globals.dora_adaln_swap_fix ?? true, (checked) => {
+    character.loader_globals = updateGlobalsFromUi(globals, { dora_adaln_swap_fix: checked });
+    saveState(node, state, { characterId: selectedCharId, promptId: selectedPromptId });
+  });
+  addLabel(row4, "Slice fix", sliceFix);
+  addLabel(row4, "AdaLN swap fix", adalnFix);
+  settingsSection.appendChild(row4);
+
+  const settingsJson = document.createElement("textarea");
+  settingsJson.value = JSON.stringify(prompt.settings || {}, null, 2);
+  settingsJson.placeholder = "Arbitrary JSON for future nodes, e.g. autoguidance/scale-locked guidance settings";
+  settingsJson.addEventListener("change", () => {
+    const parsed = safeJsonParse(settingsJson.value, null);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      prompt.settings = parsed;
+      saveState(node, state, { characterId: selectedCharId, promptId: selectedPromptId });
+      settingsJson.value = JSON.stringify(prompt.settings, null, 2);
+    }
+  });
+  const settingsLabel = document.createElement("div");
+  settingsLabel.className = "dsm-muted";
+  settingsLabel.textContent = "Prompt/settings JSON output";
+  settingsSection.append(settingsLabel, settingsJson);
+  root.appendChild(settingsSection);
+}
+
+function syncDomWidgetSize(node, widget) {
+  if (!node || !widget) return;
+  node.size = Array.isArray(node.size) ? node.size : [MIN_NODE_WIDTH, MIN_WIDGET_HEIGHT];
+  node.size[0] = Math.max(Number(node.size[0]) || 0, MIN_NODE_WIDTH);
+  node.size[1] = Math.max(Number(node.size[1]) || 0, MIN_WIDGET_HEIGHT + 90);
+  node.min_size = [MIN_NODE_WIDTH, MIN_WIDGET_HEIGHT + 90];
+}
+
+function installNode(node) {
+  if (!node) return;
+  node.resizable = true;
+
+  const widgets = getWidgets(node);
+  hideWidget(widgets.stateWidget);
+  hideWidget(widgets.characterWidget);
+  hideWidget(widgets.promptWidget);
+
+  const state = readNodeState(node);
+  const { character, prompt } = ensureSelection(node, state);
+  saveState(node, state, { characterId: character.id, promptId: prompt.id });
+
+  if (node.__dsmInstalled) {
+    render(node);
+    return;
+  }
+  node.__dsmInstalled = true;
+
+  if (typeof node.addDOMWidget === "function") {
+    const root = document.createElement("div");
+    node.__dsmRoot = root;
+    const widget = node.addDOMWidget(DOM_WIDGET_NAME, DOM_WIDGET_TYPE, root, {
+      getMinHeight: () => MIN_WIDGET_HEIGHT,
+      getHeight: () => "100%",
+      onDraw: (domWidget) => syncDomWidgetSize(node, domWidget),
+      afterResize: (domWidgetNode) => syncDomWidgetSize(domWidgetNode, widget),
+      serialize: false,
+    });
+    widget.serialize = false;
+    node.__dsmWidget = widget;
+    syncDomWidgetSize(node, widget);
+  } else {
+    console.warn(`[${EXT_NAME}] addDOMWidget is unavailable; falling back to raw JSON widgets.`);
+    return;
+  }
+
+  fetchLoras().then(() => {
+    render(node);
+    markNodeDirty(node);
+  });
+  render(node);
+}
+
+app.registerExtension({
+  name: EXT_NAME,
+
+  async beforeRegisterNodeDef(nodeType, nodeData) {
+    const nodeName = nodeData?.name ?? "";
+    const displayName = nodeData?.display_name ?? "";
+    const comfyClass = nodeType?.comfyClass ?? "";
+    if (nodeName !== NODE_CLASS && displayName !== NODE_CLASS && comfyClass !== NODE_CLASS) return;
+
+    const origOnNodeCreated = nodeType.prototype.onNodeCreated;
+    nodeType.prototype.onNodeCreated = function () {
+      const result = origOnNodeCreated?.apply(this, arguments);
+      queueMicrotask(() => installNode(this));
+      return result;
+    };
+
+    const origConfigure = nodeType.prototype.configure;
+    nodeType.prototype.configure = function (info) {
+      const result = origConfigure?.apply(this, arguments);
+      queueMicrotask(() => installNode(this));
+      return result;
+    };
+
+    const origOnSerialize = nodeType.prototype.onSerialize;
+    nodeType.prototype.onSerialize = function (o) {
+      const result = origOnSerialize?.apply(this, arguments);
+      try {
+        const state = readNodeState(this);
+        const widgets = getWidgets(this);
+        saveState(this, state, {
+          characterId: widgetValue(widgets.characterWidget, "default_character"),
+          promptId: widgetValue(widgets.promptWidget, "default_prompt"),
+          dirty: false,
+        });
+        o.properties = o.properties || {};
+        o.properties.dora_state_manager = this.properties?.dora_state_manager;
+      } catch (err) {
+        console.warn(`[${EXT_NAME}] serialize sync failed`, err);
+      }
+      return result;
+    };
+  },
+});

--- a/web/index.js
+++ b/web/index.js
@@ -1,1 +1,2 @@
 import "./dora_power_lora_loader.js";
+import "./dora_state_manager.js";


### PR DESCRIPTION
## Summary

- add a DoRA State Manager node that emits typed `DORA_STATE` plus prompt/settings outputs
- let DoRA Power LoRA Loader consume connected manager state while preserving local row-widget fallback
- add the DOMWidget manager UI, node registration, README docs, and version bump to 1.0.22

## Validation

- `python3 -m py_compile nodes.py __init__.py`
- Ouroboros QA structured review: PASS, 0.94

Repository tests were not run per workspace instruction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a DoRA State Manager node with a UI to create/manage characters, LoRA stacks, prompt presets, and loader-global settings; outputs a serializable DoRA state plus positive/negative prompts and settings JSON.
  * DoRA-aware loader: optionally consumes the manager's state to populate LoRA stacks and global loader controls.

* **Documentation**
  * Added docs describing the State Manager, wiring to the loader, persistence behavior, and expected state payload shape.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->