### PR TITLE
Add DoRA state manager workflow UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,12 +516,18 @@ Use it to save:
 
 ### Basic wiring
 
-1. Add **DoRA State Manager**.
-2. Add **DoRA Power LoRA Loader**.
-3. Connect `dora_state` from the manager to the loader's optional `dora_state` input.
-4. Connect `positive_prompt` / `negative_prompt` outputs to your text encode path as needed.
+1. Configure a normal **DoRA Power LoRA Loader** and prompt nodes as usual.
+2. Add **DoRA State Manager**.
+3. Select a character tile or create a new one.
+4. Use **Capture selected nodes** after selecting an existing **DoRA Power LoRA Loader** and prompt text nodes, or connect the manager inputs and use **Capture connected**.
+5. Connect `dora_state` from the manager to the loader's optional `dora_state` input.
+6. Connect `positive_prompt` / `negative_prompt` outputs to your text encode path as needed.
 
 When `dora_state` is connected, the loader uses the selected character's saved LoRA stack. If it is not connected, the loader keeps its normal local row-widget behavior.
+
+The manager has optional input ports for `positive_prompt`, `negative_prompt`, `settings_json_input`, and `lora_stack`. The loader appends a `lora_stack` output so an existing stack can be routed into the manager without manually recreating rows. Existing loader outputs keep their original indexes; `lora_stack` is appended after `analysis_report`.
+
+The UI uses a resizable DOM widget, character thumbnail tiles, and a selected-character submenu for prompts, LoRA stack capture/editing, and future settings JSON.
 
 ### Outputs
 
@@ -529,32 +535,18 @@ When `dora_state` is connected, the loader uses the selected character's saved L
 - `positive_prompt` — selected prompt preset's positive text
 - `negative_prompt` — selected prompt preset's negative text
 - `settings_json` — selected prompt preset's arbitrary settings object serialized as JSON
+- `selected_lora_stack` — selected character's LoRA stack as a typed `DORA_LORA_STACK` payload
 
 ### Persistence and payload behavior
 
 The manager state is stored in the workflow through hidden backend widgets:
 
 - `state_json`
+- `ui_state_json`
 - `selected_character_id`
 - `selected_prompt_id`
+- `use_runtime_inputs`
 
 No external preset database is required for this first version.
 
 The `DORA_STATE` payload contains the selected character identity, selected prompt identity, saved LoRA rows, saved loader-global overrides, prompt text, and prompt settings. The loader accepts only this typed payload shape; invalid or missing `dora_state` data falls back to the loader's existing local row-widget parsing.
-
-## DoRA State Manager
-
-The `DoRA State Manager` stores character-level LoRA stacks and per-character prompt/settings presets.
-
-Recommended workflow:
-
-1. Configure a normal `DoRA Power LoRA Loader` and prompt nodes as usual.
-2. Add `DoRA State Manager`.
-3. Select a character tile or create a new one.
-4. Use **Capture selected nodes** after selecting an existing `DoRA Power LoRA Loader` and prompt text nodes, or connect the manager inputs and use **Capture connected**.
-5. Connect `DoRA State Manager.dora_state` to `DoRA Power LoRA Loader.dora_state` to drive the loader from the selected character.
-6. Connect `positive_prompt` / `negative_prompt` to text encode nodes as needed.
-
-The manager has optional input ports for `positive_prompt`, `negative_prompt`, `settings_json_input`, and `lora_stack`. The loader appends a `lora_stack` output so an existing stack can be routed into the manager without manually recreating rows. Existing loader outputs keep their original indexes; `lora_stack` is appended after `analysis_report`.
-
-The UI uses a resizable DOM widget, character thumbnail tiles, and a selected-character submenu for prompts, LoRA stack capture/editing, and future settings JSON.

--- a/README.md
+++ b/README.md
@@ -541,3 +541,20 @@ The manager state is stored in the workflow through hidden backend widgets:
 No external preset database is required for this first version.
 
 The `DORA_STATE` payload contains the selected character identity, selected prompt identity, saved LoRA rows, saved loader-global overrides, prompt text, and prompt settings. The loader accepts only this typed payload shape; invalid or missing `dora_state` data falls back to the loader's existing local row-widget parsing.
+
+## DoRA State Manager
+
+The `DoRA State Manager` stores character-level LoRA stacks and per-character prompt/settings presets.
+
+Recommended workflow:
+
+1. Configure a normal `DoRA Power LoRA Loader` and prompt nodes as usual.
+2. Add `DoRA State Manager`.
+3. Select a character tile or create a new one.
+4. Use **Capture selected nodes** after selecting an existing `DoRA Power LoRA Loader` and prompt text nodes, or connect the manager inputs and use **Capture connected**.
+5. Connect `DoRA State Manager.dora_state` to `DoRA Power LoRA Loader.dora_state` to drive the loader from the selected character.
+6. Connect `positive_prompt` / `negative_prompt` to text encode nodes as needed.
+
+The manager has optional input ports for `positive_prompt`, `negative_prompt`, `settings_json_input`, and `lora_stack`. The loader appends a `lora_stack` output so an existing stack can be routed into the manager without manually recreating rows. Existing loader outputs keep their original indexes; `lora_stack` is appended after `analysis_report`.
+
+The UI uses a resizable DOM widget, character thumbnail tiles, and a selected-character submenu for prompts, LoRA stack capture/editing, and future settings JSON.

--- a/nodes.py
+++ b/nodes.py
@@ -436,6 +436,7 @@ class FlexibleOptionalInputType(dict):
 
 _DORA_STATE_MANAGER_SCHEMA_VERSION = 1
 _DORA_STATE_KIND = "dora_state_manager_state"
+_DORA_LORA_STACK_KIND = "dora_lora_stack"
 _DORA_STATE_LOADER_GLOBAL_KEYS: Set[str] = {
     "stack_enabled",
     "verbose",
@@ -468,6 +469,7 @@ def _state_manager_default_state() -> Dict[str, Any]:
             {
                 "id": "default_character",
                 "name": "Default Character",
+                "thumbnail": {},
                 "loras": [],
                 "loader_globals": {},
                 "prompts": [
@@ -548,6 +550,91 @@ def _normalize_manager_settings(settings: Any) -> Dict[str, Any]:
         return settings
     parsed = _safe_json_load(settings, {})
     return parsed if isinstance(parsed, dict) else {}
+
+
+def _normalize_manager_thumbnail(thumbnail: Any) -> Dict[str, Any]:
+    if isinstance(thumbnail, dict):
+        filename = str(thumbnail.get("filename", "")).strip()
+        subfolder = str(thumbnail.get("subfolder", "")).strip()
+        type_name = str(thumbnail.get("type", "input")).strip() or "input"
+        url = str(thumbnail.get("url", "")).strip()
+        if filename:
+            return {"filename": filename, "subfolder": subfolder, "type": type_name}
+        if url:
+            return {"url": url}
+        return {}
+    text = str(thumbnail or "").strip()
+    if text:
+        return {"url": text}
+    return {}
+
+
+def _normalize_runtime_lora_stack(raw: Any) -> Optional[Dict[str, Any]]:
+    payload = _safe_json_load(raw, None)
+    if not isinstance(payload, dict):
+        return None
+
+    # Accept either the explicit stack output from DoRA Power LoRA Loader or a resolved
+    # manager payload. The latter makes manager chaining and old workflows less brittle.
+    kind = payload.get("kind")
+    if kind not in {_DORA_LORA_STACK_KIND, _DORA_STATE_KIND}:
+        return None
+
+    rows_in = payload.get("loras", payload.get("rows", []))
+    rows: List[Dict[str, Any]] = []
+    if isinstance(rows_in, list):
+        for row in rows_in:
+            normalized = _normalize_manager_lora_row(row)
+            if normalized is not None:
+                rows.append(normalized)
+
+    return {
+        "version": _DORA_STATE_MANAGER_SCHEMA_VERSION,
+        "kind": _DORA_LORA_STACK_KIND,
+        "loras": rows,
+        "loader_globals": _normalize_manager_loader_globals(payload.get("loader_globals", payload.get("globals", {}))),
+    }
+
+
+def _manager_rows_to_lora_entries(rows: Iterable[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    entries: List[Dict[str, Any]] = []
+    for row in rows:
+        normalized = _normalize_manager_lora_row(row)
+        if normalized is None:
+            continue
+        name = normalized.get("name", "None")
+        if name in ("", "None", "NONE"):
+            continue
+        entries.append({
+            "on": bool(normalized.get("enabled", True)),
+            "lora": name,
+            "strength_model": float(normalized.get("strength_model", 1.0)),
+            "strength_clip": float(normalized.get("strength_clip", normalized.get("strength_model", 1.0))),
+        })
+    return entries
+
+
+def _lora_entries_to_manager_rows(entries: Iterable[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    rows: List[Dict[str, Any]] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        rows.append({
+            "enabled": bool(entry.get("on", entry.get("enabled", True))),
+            "name": str(entry.get("lora", entry.get("name", "None")) or "None"),
+            "strength_model": float(entry.get("strength_model", entry.get("strength", 1.0))),
+            "strength_clip": float(entry.get("strength_clip", entry.get("strengthTwo", entry.get("strength_model", entry.get("strength", 1.0))))),
+        })
+    return rows
+
+
+def _build_lora_stack_payload(entries: Iterable[Dict[str, Any]], loader_globals: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "version": _DORA_STATE_MANAGER_SCHEMA_VERSION,
+        "kind": _DORA_LORA_STACK_KIND,
+        "loras": _lora_entries_to_manager_rows(entries),
+        "loader_globals": _normalize_manager_loader_globals(loader_globals),
+    }
 
 
 def _normalize_manager_loader_globals(globals_in: Any) -> Dict[str, Any]:
@@ -657,6 +744,7 @@ def _normalize_state_manager_state(raw: Any) -> Dict[str, Any]:
             {
                 "id": char_id,
                 "name": name,
+                "thumbnail": _normalize_manager_thumbnail(char.get("thumbnail", {})),
                 "loras": loras,
                 "loader_globals": _normalize_manager_loader_globals(char.get("loader_globals", char.get("globals", {}))),
                 "prompts": prompts,
@@ -690,27 +778,58 @@ def _pick_state_manager_prompt(character: Dict[str, Any], selected_prompt_id: An
     return prompts[0] if prompts else _state_manager_default_state()["characters"][0]["prompts"][0]
 
 
-def _resolve_dora_state_payload(state_json: Any, selected_character_id: Any, selected_prompt_id: Any) -> Dict[str, Any]:
+def _resolve_dora_state_payload(
+    state_json: Any,
+    selected_character_id: Any,
+    selected_prompt_id: Any,
+    positive_prompt: Any = None,
+    negative_prompt: Any = None,
+    lora_stack: Any = None,
+    settings_json_input: Any = None,
+    use_runtime_inputs: Any = False,
+) -> Dict[str, Any]:
     state = _normalize_state_manager_state(state_json)
     character = _pick_state_manager_character(state, selected_character_id)
     prompt = _pick_state_manager_prompt(character, selected_prompt_id)
+
     settings = _normalize_manager_settings(prompt.get("settings", {}))
+    loras = character.get("loras", [])
+    loader_globals = character.get("loader_globals", {})
+    positive = str(prompt.get("positive", "") or "")
+    negative = str(prompt.get("negative", "") or "")
+
+    if _state_manager_bool(use_runtime_inputs, default=False):
+        stack_payload = _normalize_runtime_lora_stack(lora_stack)
+        if stack_payload is not None:
+            loras = stack_payload.get("loras", [])
+            stack_globals = stack_payload.get("loader_globals")
+            if isinstance(stack_globals, dict) and stack_globals:
+                loader_globals = stack_globals
+        if positive_prompt is not None:
+            positive = str(positive_prompt or "")
+        if negative_prompt is not None:
+            negative = str(negative_prompt or "")
+        parsed_settings = _normalize_manager_settings(settings_json_input)
+        if parsed_settings:
+            settings = parsed_settings
+
     return {
         "version": _DORA_STATE_MANAGER_SCHEMA_VERSION,
         "kind": _DORA_STATE_KIND,
         "character": {
             "id": character.get("id", ""),
             "name": character.get("name", ""),
+            "thumbnail": character.get("thumbnail", {}),
         },
         "prompt": {
             "id": prompt.get("id", ""),
             "name": prompt.get("name", ""),
         },
-        "loras": character.get("loras", []),
-        "loader_globals": character.get("loader_globals", {}),
+        "loras": loras,
+        "loader_globals": loader_globals,
         "settings": settings,
-        "positive_prompt": str(prompt.get("positive", "") or ""),
-        "negative_prompt": str(prompt.get("negative", "") or ""),
+        "positive_prompt": positive,
+        "negative_prompt": negative,
     }
 
 
@@ -748,23 +867,7 @@ def _parse_dora_state_lora_entries(state_payload: Optional[Dict[str, Any]]) -> O
     rows = state_payload.get("loras")
     if not isinstance(rows, list):
         return None
-    entries: List[Dict[str, Any]] = []
-    for row in rows:
-        normalized = _normalize_manager_lora_row(row)
-        if normalized is None:
-            continue
-        name = normalized.get("name", "None")
-        if name in ("", "None", "NONE"):
-            continue
-        entries.append(
-            {
-                "on": bool(normalized.get("enabled", True)),
-                "lora": name,
-                "strength_model": float(normalized.get("strength_model", 1.0)),
-                "strength_clip": float(normalized.get("strength_clip", normalized.get("strength_model", 1.0))),
-            }
-        )
-    return entries
+    return _manager_rows_to_lora_entries(rows)
 
 
 def _state_payload_get_loader_global(state_payload: Optional[Dict[str, Any]], key: str, fallback: Any) -> Any:
@@ -3575,27 +3678,73 @@ class DoraStateManager:
                         "multiline": True,
                     },
                 ),
+                "ui_state_json": (
+                    "STRING",
+                    {
+                        "default": json.dumps({"version": _DORA_STATE_MANAGER_SCHEMA_VERSION}, separators=(",", ":")),
+                        "multiline": False,
+                    },
+                ),
                 "selected_character_id": ("STRING", {"default": "default_character", "multiline": False}),
                 "selected_prompt_id": ("STRING", {"default": "default_prompt", "multiline": False}),
-            }
+                "use_runtime_inputs": ("BOOLEAN", {"default": False}),
+            },
+            "optional": {
+                "positive_prompt": ("STRING", {"forceInput": True, "multiline": True, "default": ""}),
+                "negative_prompt": ("STRING", {"forceInput": True, "multiline": True, "default": ""}),
+                "settings_json_input": ("STRING", {"forceInput": True, "multiline": True, "default": ""}),
+                "lora_stack": ("DORA_LORA_STACK",),
+            },
         }
 
-    RETURN_TYPES = ("DORA_STATE", "STRING", "STRING", "STRING")
-    RETURN_NAMES = ("dora_state", "positive_prompt", "negative_prompt", "settings_json")
+    RETURN_TYPES = ("DORA_STATE", "STRING", "STRING", "STRING", "DORA_LORA_STACK")
+    RETURN_NAMES = ("dora_state", "positive_prompt", "negative_prompt", "settings_json", "selected_lora_stack")
     FUNCTION = "resolve_state"
     CATEGORY = "state managers"
 
     @classmethod
-    def IS_CHANGED(cls, state_json: Any, selected_character_id: Any = "", selected_prompt_id: Any = ""):
+    def IS_CHANGED(
+        cls,
+        state_json: Any,
+        ui_state_json: Any = "",
+        selected_character_id: Any = "",
+        selected_prompt_id: Any = "",
+        use_runtime_inputs: Any = False,
+        positive_prompt: Any = None,
+        negative_prompt: Any = None,
+        settings_json_input: Any = None,
+        lora_stack: Any = None,
+    ):
         payload = {
             "state_json": state_json,
+            "ui_state_json": ui_state_json,
             "selected_character_id": selected_character_id,
             "selected_prompt_id": selected_prompt_id,
+            "use_runtime_inputs": use_runtime_inputs,
         }
+        if _state_manager_bool(use_runtime_inputs, default=False):
+            payload.update({
+                "positive_prompt": positive_prompt,
+                "negative_prompt": negative_prompt,
+                "settings_json_input": settings_json_input,
+                "lora_stack": lora_stack,
+            })
         return json.dumps(payload, sort_keys=True, default=str)
 
     @classmethod
-    def VALIDATE_INPUTS(cls, state_json: Any, selected_character_id: Any = "", selected_prompt_id: Any = ""):
+    def VALIDATE_INPUTS(
+        cls,
+        state_json: Any,
+        ui_state_json: Any = "",
+        selected_character_id: Any = "",
+        selected_prompt_id: Any = "",
+        use_runtime_inputs: Any = False,
+        positive_prompt: Any = None,
+        negative_prompt: Any = None,
+        settings_json_input: Any = None,
+        lora_stack: Any = None,
+    ):
+        del ui_state_json, use_runtime_inputs, positive_prompt, negative_prompt, settings_json_input, lora_stack
         state = _normalize_state_manager_state(state_json)
         character = _pick_state_manager_character(state, selected_character_id)
         prompt = _pick_state_manager_prompt(character, selected_prompt_id)
@@ -3605,14 +3754,40 @@ class DoraStateManager:
             return "DoRA State Manager: no prompt states are available for the selected character."
         return True
 
-    def resolve_state(self, state_json: Any, selected_character_id: Any = "", selected_prompt_id: Any = ""):
-        payload = _resolve_dora_state_payload(state_json, selected_character_id, selected_prompt_id)
+    def resolve_state(
+        self,
+        state_json: Any,
+        ui_state_json: Any = "",
+        selected_character_id: Any = "",
+        selected_prompt_id: Any = "",
+        use_runtime_inputs: Any = False,
+        positive_prompt: Any = None,
+        negative_prompt: Any = None,
+        settings_json_input: Any = None,
+        lora_stack: Any = None,
+    ):
+        del ui_state_json
+        payload = _resolve_dora_state_payload(
+            state_json,
+            selected_character_id,
+            selected_prompt_id,
+            positive_prompt=positive_prompt,
+            negative_prompt=negative_prompt,
+            lora_stack=lora_stack,
+            settings_json_input=settings_json_input,
+            use_runtime_inputs=use_runtime_inputs,
+        )
         settings_json = json.dumps(payload.get("settings", {}), ensure_ascii=False, sort_keys=True, indent=2)
+        lora_stack_payload = _build_lora_stack_payload(
+            _manager_rows_to_lora_entries(payload.get("loras", [])),
+            payload.get("loader_globals", {}),
+        )
         return (
             payload,
             payload.get("positive_prompt", ""),
             payload.get("negative_prompt", ""),
             settings_json,
+            lora_stack_payload,
         )
 
 
@@ -3664,8 +3839,8 @@ class DoraPowerLoraLoader:
             "hidden": {},
         }
 
-    RETURN_TYPES = ("MODEL", "CLIP", "STRING", "STRING")
-    RETURN_NAMES = ("MODEL", "CLIP", "auto_strength_report_json", "analysis_report")
+    RETURN_TYPES = ("MODEL", "CLIP", "STRING", "STRING", "DORA_LORA_STACK")
+    RETURN_NAMES = ("MODEL", "CLIP", "auto_strength_report_json", "analysis_report", "lora_stack")
     HAS_INTERMEDIATE_OUTPUT = True
     FUNCTION = "load_loras"
     CATEGORY = "loaders"
@@ -3978,6 +4153,31 @@ class DoraPowerLoraLoader:
 
         report_rows: List[Dict[str, Any]] = []
 
+        entries = _parse_dora_state_lora_entries(state_payload) if state_payload is not None else None
+        if entries is None:
+            entries = _parse_lora_stack_kwargs(kwargs)
+
+        loader_globals_payload = {
+            "stack_enabled": stack_enabled,
+            "verbose": verbose,
+            "log_unloaded_keys": log_unloaded_keys,
+            "broadcast_auto_scale": broadcast_auto_scale,
+            "broadcast_modulations": broadcast_modulations,
+            "broadcast_include_dora_scale": broadcast_include_dora_scale,
+            "broadcast_scale": broadcast_scale,
+            "dora_decompose_debug": dora_dbg,
+            "dora_decompose_debug_n": dora_dbg_n,
+            "dora_decompose_debug_stack_depth": dora_dbg_stack,
+            "dora_slice_fix": dora_slice_fix,
+            "dora_adaln_swap_fix": dora_adaln_swap_fix,
+            "zimage_lumina2_compat": zimage_lumina2_compat,
+            "auto_strength_enabled": auto_strength_enabled,
+            "auto_strength_device": auto_strength_device,
+            "auto_strength_ratio_floor": auto_strength_ratio_floor,
+            "auto_strength_ratio_ceiling": auto_strength_ratio_ceiling,
+        }
+        lora_stack_payload = _build_lora_stack_payload(entries, loader_globals_payload)
+
         if not stack_enabled:
             stack_report = {
                 "schema": 1,
@@ -3991,16 +4191,13 @@ class DoraPowerLoraLoader:
             report_json = _auto_strength_json_dumps(stack_report, pretty=True)
             report_text = _build_auto_strength_stack_text_report(stack_report)
             return {
-                "result": (model, clip, report_json, report_text),
+                "result": (model, clip, report_json, report_text, lora_stack_payload),
                 "ui": {
                     "auto_strength_report_json": (report_json,),
                     "analysis_report": (report_text,),
                 },
             }
 
-        entries = _parse_dora_state_lora_entries(state_payload) if state_payload is not None else None
-        if entries is None:
-            entries = _parse_lora_stack_kwargs(kwargs)
         if not entries:
             stack_report = {
                 "schema": 1,
@@ -4014,7 +4211,7 @@ class DoraPowerLoraLoader:
             report_json = _auto_strength_json_dumps(stack_report, pretty=True)
             report_text = _build_auto_strength_stack_text_report(stack_report)
             return {
-                "result": (model, clip, report_json, report_text),
+                "result": (model, clip, report_json, report_text, lora_stack_payload),
                 "ui": {
                     "auto_strength_report_json": (report_json,),
                     "analysis_report": (report_text,),
@@ -4138,7 +4335,7 @@ class DoraPowerLoraLoader:
         report_json = _auto_strength_json_dumps(stack_report, pretty=True)
         report_text = _build_auto_strength_stack_text_report(stack_report)
         return {
-            "result": (new_model, new_clip, report_json, report_text),
+            "result": (new_model, new_clip, report_json, report_text, lora_stack_payload),
             "ui": {
                 "auto_strength_report_json": (report_json,),
                 "analysis_report": (report_text,),

--- a/nodes.py
+++ b/nodes.py
@@ -803,15 +803,18 @@ def _resolve_dora_state_payload(
         if stack_payload is not None:
             loras = stack_payload.get("loras", [])
             stack_globals = stack_payload.get("loader_globals")
-            if isinstance(stack_globals, dict) and stack_globals:
+            if isinstance(stack_globals, dict):
                 loader_globals = stack_globals
         if positive_prompt is not None:
             positive = str(positive_prompt or "")
         if negative_prompt is not None:
             negative = str(negative_prompt or "")
-        parsed_settings = _normalize_manager_settings(settings_json_input)
-        if parsed_settings:
-            settings = parsed_settings
+        if settings_json_input is not None:
+            raw_settings = settings_json_input
+            if not (isinstance(raw_settings, str) and raw_settings.strip() == ""):
+                parsed_settings = _safe_json_load(raw_settings, None)
+                if isinstance(parsed_settings, dict):
+                    settings = parsed_settings
 
     return {
         "version": _DORA_STATE_MANAGER_SCHEMA_VERSION,

--- a/web/dora_state_manager.js
+++ b/web/dora_state_manager.js
@@ -113,7 +113,8 @@ function normalizeThumbnail(value) {
   const subfolder = String(value.subfolder ?? "").trim();
   const type = String(value.type ?? "input").trim() || "input";
   const url = String(value.url ?? "").trim();
-  if (filename) return { filename, subfolder, type };
+  const cacheKey = String(value.cacheKey ?? value.hash ?? value.etag ?? value.updatedAt ?? value.version ?? "").trim();
+  if (filename) return cacheKey ? { filename, subfolder, type, cacheKey } : { filename, subfolder, type };
   if (url) return { url };
   return {};
 }
@@ -126,7 +127,7 @@ function thumbnailUrl(thumbnail) {
   params.set("filename", t.filename);
   if (t.subfolder) params.set("subfolder", t.subfolder);
   params.set("type", t.type || "input");
-  params.set("rand", String(Date.now()));
+  if (t.cacheKey) params.set("cache_key", t.cacheKey);
   return api.apiURL(`/view?${params.toString()}`);
 }
 
@@ -557,7 +558,6 @@ function makeInput(value, onChange, attrs = {}) {
   const input = document.createElement("input");
   input.value = value ?? "";
   Object.assign(input, attrs);
-  input.addEventListener("input", () => onChange(input.value));
   input.addEventListener("change", () => onChange(input.value));
   return input;
 }

--- a/web/dora_state_manager.js
+++ b/web/dora_state_manager.js
@@ -1,27 +1,50 @@
 import { app } from "../../scripts/app.js";
+import { api } from "../../scripts/api.js";
 import "../../scripts/domWidget.js";
 
 const EXT_NAME = "comfyui_dora_dynamic_lora.state_manager";
 const NODE_CLASS = "DoRA State Manager";
-const LORA_API = "/dora_dynamic_lora/loras";
+const CUSTOM_WIDGET_INPUT = "state_manager_ui";
+const CUSTOM_WIDGET_TYPE = "DORA_STATE_MANAGER_UI";
 const STATE_WIDGET = "state_json";
+const UI_STATE_WIDGET = "ui_state_json";
 const SELECTED_CHARACTER_WIDGET = "selected_character_id";
 const SELECTED_PROMPT_WIDGET = "selected_prompt_id";
-const DOM_WIDGET_NAME = "dora_state_manager_ui";
-const DOM_WIDGET_TYPE = "DORA_STATE_MANAGER_UI";
+const USE_RUNTIME_INPUTS_WIDGET = "use_runtime_inputs";
 const STYLE_ID = "dora-state-manager-style";
+const MIN_WIDGET_HEIGHT = 520;
 const MIN_NODE_WIDTH = 620;
-const MIN_WIDGET_HEIGHT = 700;
+const MIN_NODE_HEIGHT = 680;
+const THUMBNAIL_SUBFOLDER = "dora_state_manager";
 const AUTO_STRENGTH_DEVICE_CHOICES = ["auto", "cpu", "gpu"];
 
-function clone(value) {
+function structuredCloneCompat(value) {
   if (typeof structuredClone === "function") return structuredClone(value);
   return JSON.parse(JSON.stringify(value));
+}
+
+function safeJsonParse(raw, fallback) {
+  if (raw && typeof raw === "object") return structuredCloneCompat(raw);
+  if (typeof raw !== "string" || !raw.trim()) return structuredCloneCompat(fallback);
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" ? parsed : structuredCloneCompat(fallback);
+  } catch {
+    return structuredCloneCompat(fallback);
+  }
 }
 
 function makeId(prefix) {
   if (globalThis.crypto?.randomUUID) return `${prefix}_${globalThis.crypto.randomUUID()}`;
   return `${prefix}_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function cleanId(value, fallback) {
+  const text = String(value ?? "")
+    .trim()
+    .replace(/[^A-Za-z0-9_.:-]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+  return text || fallback;
 }
 
 function defaultPrompt() {
@@ -38,6 +61,7 @@ function defaultCharacter() {
   return {
     id: "default_character",
     name: "Default Character",
+    thumbnail: {},
     loras: [],
     loader_globals: {},
     prompts: [defaultPrompt()],
@@ -45,36 +69,16 @@ function defaultCharacter() {
 }
 
 function defaultState() {
-  return {
-    version: 1,
-    characters: [defaultCharacter()],
-  };
+  return { version: 1, characters: [defaultCharacter()] };
 }
 
-function safeJsonParse(raw, fallback) {
-  if (raw && typeof raw === "object") return clone(raw);
-  if (typeof raw !== "string" || !raw.trim()) return clone(fallback);
-  try {
-    const parsed = JSON.parse(raw);
-    return parsed && typeof parsed === "object" ? parsed : clone(fallback);
-  } catch {
-    return clone(fallback);
-  }
-}
-
-function cleanId(value, fallback) {
-  const text = String(value ?? "").trim().replace(/[^A-Za-z0-9_.:-]+/g, "_").replace(/^_+|_+$/g, "");
-  return text || fallback;
+function defaultUiState() {
+  return { version: 1, panel: "prompts", status: "" };
 }
 
 function normalizeNumber(value, fallback = 1.0) {
   const n = Number(value);
   return Number.isFinite(n) ? n : fallback;
-}
-
-function normalizeDevice(value) {
-  const v = String(value ?? "gpu").toLowerCase();
-  return AUTO_STRENGTH_DEVICE_CHOICES.includes(v) ? v : "gpu";
 }
 
 function normalizeBoolean(value, fallback = false) {
@@ -87,6 +91,43 @@ function normalizeBoolean(value, fallback = false) {
     return fallback;
   }
   return Boolean(value);
+}
+
+function normalizeDevice(value) {
+  const text = String(value ?? "gpu").trim().toLowerCase();
+  return AUTO_STRENGTH_DEVICE_CHOICES.includes(text) ? text : "gpu";
+}
+
+function normalizeSettings(value) {
+  if (value && typeof value === "object" && !Array.isArray(value)) return structuredCloneCompat(value);
+  const parsed = safeJsonParse(value, {});
+  return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
+}
+
+function normalizeThumbnail(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    const url = String(value ?? "").trim();
+    return url ? { url } : {};
+  }
+  const filename = String(value.filename ?? "").trim();
+  const subfolder = String(value.subfolder ?? "").trim();
+  const type = String(value.type ?? "input").trim() || "input";
+  const url = String(value.url ?? "").trim();
+  if (filename) return { filename, subfolder, type };
+  if (url) return { url };
+  return {};
+}
+
+function thumbnailUrl(thumbnail) {
+  const t = normalizeThumbnail(thumbnail);
+  if (t.url) return t.url;
+  if (!t.filename) return "";
+  const params = new URLSearchParams();
+  params.set("filename", t.filename);
+  if (t.subfolder) params.set("subfolder", t.subfolder);
+  params.set("type", t.type || "input");
+  params.set("rand", String(Date.now()));
+  return api.apiURL(`/view?${params.toString()}`);
 }
 
 function normalizeLoaderGlobals(globalsIn) {
@@ -129,12 +170,6 @@ function normalizeLoraRow(row) {
   };
 }
 
-function normalizeSettings(value) {
-  if (value && typeof value === "object" && !Array.isArray(value)) return clone(value);
-  const parsed = safeJsonParse(value, {});
-  return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
-}
-
 function normalizePrompt(prompt, index) {
   const p = prompt && typeof prompt === "object" ? prompt : {};
   return {
@@ -148,11 +183,11 @@ function normalizePrompt(prompt, index) {
 
 function normalizeCharacter(character, index) {
   const c = character && typeof character === "object" ? character : {};
-  const promptsIn = Array.isArray(c.prompts) ? c.prompts : [];
-  const prompts = promptsIn.map(normalizePrompt).filter(Boolean);
+  const prompts = Array.isArray(c.prompts) ? c.prompts.map(normalizePrompt).filter(Boolean) : [];
   return {
     id: cleanId(c.id, `character_${index + 1}`),
     name: String(c.name ?? `Character ${index + 1}`).trim() || `Character ${index + 1}`,
+    thumbnail: normalizeThumbnail(c.thumbnail),
     loras: Array.isArray(c.loras) ? c.loras.map(normalizeLoraRow) : [],
     loader_globals: normalizeLoaderGlobals(c.loader_globals ?? c.globals),
     prompts: prompts.length ? prompts : [defaultPrompt()],
@@ -162,10 +197,16 @@ function normalizeCharacter(character, index) {
 function normalizeState(raw) {
   const parsed = safeJsonParse(raw, defaultState());
   const charsIn = Array.isArray(parsed.characters) ? parsed.characters : [];
-  const chars = charsIn.map(normalizeCharacter).filter(Boolean);
+  const characters = charsIn.map(normalizeCharacter).filter(Boolean);
+  return { version: 1, characters: characters.length ? characters : [defaultCharacter()] };
+}
+
+function normalizeUiState(raw) {
+  const parsed = safeJsonParse(raw, defaultUiState());
   return {
     version: 1,
-    characters: chars.length ? chars : [defaultCharacter()],
+    panel: ["prompts", "loras", "settings"].includes(parsed.panel) ? parsed.panel : "prompts",
+    status: String(parsed.status ?? ""),
   };
 }
 
@@ -173,13 +214,19 @@ function serializeState(state) {
   return JSON.stringify(normalizeState(state), null, 0);
 }
 
+function serializeUiState(uiState) {
+  return JSON.stringify(normalizeUiState(uiState), null, 0);
+}
+
 function getWidgets(node) {
   const map = new Map();
   for (const widget of node.widgets ?? []) map.set(widget.name, widget);
   return {
     stateWidget: map.get(STATE_WIDGET),
+    uiStateWidget: map.get(UI_STATE_WIDGET),
     characterWidget: map.get(SELECTED_CHARACTER_WIDGET),
     promptWidget: map.get(SELECTED_PROMPT_WIDGET),
+    useRuntimeInputsWidget: map.get(USE_RUNTIME_INPUTS_WIDGET),
   };
 }
 
@@ -196,9 +243,19 @@ function widgetValue(widget, fallback = "") {
 function hideWidget(widget) {
   if (!widget || widget.__dsmHidden) return;
   widget.__dsmHidden = true;
+  widget.hidden = true;
+  widget.options = widget.options || {};
+  widget.options.hidden = true;
   widget.type = "hidden";
   widget.computeSize = () => [0, 0];
   widget.draw = () => {};
+}
+
+function getCurrentState(node) {
+  const widgets = getWidgets(node);
+  const state = normalizeState(widgetValue(widgets.stateWidget, serializeState(defaultState())));
+  const uiState = normalizeUiState(widgetValue(widgets.uiStateWidget, serializeUiState(defaultUiState())));
+  return { state, uiState };
 }
 
 function selectedCharacter(state, selectedId) {
@@ -232,86 +289,255 @@ function markNodeDirty(node) {
   node.graph?.change?.();
 }
 
-function saveState(node, state, opts = {}) {
+function updateState(node, state, uiState, opts = {}) {
   const widgets = getWidgets(node);
-  const normalized = normalizeState(state);
-  setWidgetValue(widgets.stateWidget, serializeState(normalized));
+  const normalizedState = normalizeState(state);
+  const normalizedUiState = normalizeUiState(uiState || defaultUiState());
+  if (opts.status !== undefined) normalizedUiState.status = String(opts.status || "");
+  setWidgetValue(widgets.stateWidget, serializeState(normalizedState));
+  setWidgetValue(widgets.uiStateWidget, serializeUiState(normalizedUiState));
   if (opts.characterId) setWidgetValue(widgets.characterWidget, opts.characterId);
   if (opts.promptId) setWidgetValue(widgets.promptWidget, opts.promptId);
+  if (opts.useRuntimeInputs !== undefined) setWidgetValue(widgets.useRuntimeInputsWidget, Boolean(opts.useRuntimeInputs));
   node.properties = node.properties || {};
   node.properties.dora_state_manager = {
-    state: normalized,
+    state: normalizedState,
+    ui_state: normalizedUiState,
     selected_character_id: widgetValue(widgets.characterWidget, ""),
     selected_prompt_id: widgetValue(widgets.promptWidget, ""),
+    use_runtime_inputs: Boolean(widgetValue(widgets.useRuntimeInputsWidget, false)),
   };
   if (opts.dirty !== false) markNodeDirty(node);
+  cacheRenderableState(node, normalizedState, normalizedUiState);
+  if (opts.render !== false) scheduleRender(node);
 }
 
-function readNodeState(node) {
-  const { stateWidget } = getWidgets(node);
-  return normalizeState(widgetValue(stateWidget, serializeState(defaultState())));
+function cacheRenderableState(node, state, uiState) {
+  const ctx = node.__dsm;
+  if (!ctx) return;
+  ctx.state = state;
+  ctx.uiState = uiState;
 }
 
-let loraCache = null;
-async function fetchLoras() {
-  if (loraCache) return loraCache;
-  try {
-    const response = await fetch(LORA_API, { cache: "no-store" });
-    if (!response.ok) throw new Error(`${response.status} ${response.statusText}`);
-    const list = await response.json();
-    loraCache = Array.isArray(list) ? ["None", ...list.filter((x) => x && x !== "None" && x !== "NONE")] : ["None"];
-  } catch (err) {
-    console.warn(`[${EXT_NAME}] failed to fetch LoRA list`, err);
-    loraCache = ["None"];
+function getRenderableState(node) {
+  const ctx = node.__dsm;
+  if (ctx?.state && ctx?.uiState) return { state: ctx.state, uiState: ctx.uiState };
+  const snapshot = getCurrentState(node);
+  cacheRenderableState(node, snapshot.state, snapshot.uiState);
+  return snapshot;
+}
+
+function setStatus(node, text) {
+  const { state, uiState } = getCurrentState(node);
+  uiState.status = text;
+  updateState(node, state, uiState, { dirty: false, render: true });
+}
+
+function getFiniteNumber(value, fallback = 0) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : fallback;
+}
+
+function getWidgetOuterHeight(node, widget) {
+  const nodeHeight = Math.max(MIN_NODE_HEIGHT, getFiniteNumber(node?.size?.[1], MIN_NODE_HEIGHT));
+  const widgetY = Math.max(0, getFiniteNumber(widget?.y, getFiniteNumber(widget?.last_y, 0)));
+  return Math.max(MIN_WIDGET_HEIGHT, Math.floor(nodeHeight - widgetY));
+}
+
+function syncDomWidgetSize(node, widget) {
+  const ctx = node.__dsm;
+  if (!ctx || !widget) return;
+  const margin = Math.max(0, getFiniteNumber(widget.margin, 10));
+  const outerHeight = getWidgetOuterHeight(node, widget);
+  const innerHeight = Math.max(0, outerHeight - margin * 2);
+  const width = Math.max(MIN_NODE_WIDTH, getFiniteNumber(node?.size?.[0], MIN_NODE_WIDTH));
+  widget.computedHeight = outerHeight;
+  widget.width = width;
+  ctx.root.style.height = `${innerHeight}px`;
+  ctx.root.style.minHeight = `${Math.max(0, MIN_WIDGET_HEIGHT - margin * 2)}px`;
+}
+
+function scheduleRender(node) {
+  const ctx = node.__dsm;
+  if (!ctx || ctx.renderFrame) return;
+  ctx.renderFrame = requestAnimationFrame(() => {
+    ctx.renderFrame = 0;
+    renderNode(node);
+  });
+}
+
+function chainNodeCallback(node, name, fn) {
+  const original = node[name];
+  node[name] = function (...args) {
+    const result = original?.apply(this, args);
+    fn.apply(this, args);
+    return result;
+  };
+}
+
+function isTargetNode(nodeData, nodeType) {
+  const nodeName = nodeData?.name ?? "";
+  const displayName = nodeData?.display_name ?? "";
+  const comfyClass = nodeType?.comfyClass ?? "";
+  return nodeName === NODE_CLASS || displayName === NODE_CLASS || comfyClass === NODE_CLASS;
+}
+
+function isDoraLoaderNode(node) {
+  const values = [node?.comfyClass, node?.type, node?.title, node?.constructor?.title].map((v) => String(v ?? ""));
+  return values.some((v) => v === "DoRA Power LoRA Loader" || v.includes("DoRA Power LoRA Loader"));
+}
+
+function normalizeDoraLoaderState(state) {
+  const st = state && typeof state === "object" ? state : {};
+  const rows = Array.isArray(st.rows) ? st.rows.map(normalizeLoraRow) : [];
+  return {
+    loras: rows.filter((row) => row.name && row.name !== "None"),
+    loader_globals: normalizeLoaderGlobals(st.globals),
+  };
+}
+
+function extractLoraStackFromNode(sourceNode) {
+  if (!sourceNode) return null;
+  if (sourceNode.properties?.dora_power_lora) return normalizeDoraLoaderState(sourceNode.properties.dora_power_lora);
+  if (sourceNode._doraRows || sourceNode._doraGlobals) {
+    return normalizeDoraLoaderState({ rows: sourceNode._doraRows || [], globals: sourceNode._doraGlobals || {} });
   }
-  return loraCache;
+  if (sourceNode.properties?.dora_state_manager?.state) {
+    const state = normalizeState(sourceNode.properties.dora_state_manager.state);
+    const charId = sourceNode.properties.dora_state_manager.selected_character_id;
+    const character = selectedCharacter(state, charId);
+    return { loras: character.loras || [], loader_globals: character.loader_globals || {} };
+  }
+  return null;
 }
 
-function ensureStyles() {
-  if (document.getElementById(STYLE_ID)) return;
-  const style = document.createElement("style");
-  style.id = STYLE_ID;
-  style.textContent = `
-    .dsm-root {
-      --dsm-gap: 8px;
-      box-sizing: border-box;
-      height: 100%;
-      min-height: ${MIN_WIDGET_HEIGHT}px;
-      padding: 8px;
-      overflow: auto;
-      display: flex;
-      flex-direction: column;
-      gap: var(--dsm-gap);
-      color: var(--input-text, #ddd);
-      background: rgba(20, 20, 20, 0.20);
-      font: 12px/1.35 system-ui, sans-serif;
-    }
-    .dsm-root * { box-sizing: border-box; }
-    .dsm-row { display: flex; gap: 6px; align-items: center; }
-    .dsm-row.wrap { flex-wrap: wrap; }
-    .dsm-section { border: 1px solid rgba(128,128,128,.35); border-radius: 8px; padding: 8px; display: flex; flex-direction: column; gap: 7px; }
-    .dsm-section-title { font-weight: 650; opacity: .95; }
-    .dsm-root input, .dsm-root select, .dsm-root textarea, .dsm-root button {
-      font: inherit;
-      color: var(--input-text, #ddd);
-      background: var(--comfy-input-bg, #222);
-      border: 1px solid rgba(128,128,128,.45);
-      border-radius: 5px;
-      padding: 4px 6px;
-    }
-    .dsm-root button { cursor: pointer; white-space: nowrap; }
-    .dsm-root textarea { width: 100%; min-height: 82px; resize: vertical; }
-    .dsm-root input[type="checkbox"] { width: auto; }
-    .dsm-flex { flex: 1 1 auto; min-width: 0; }
-    .dsm-small { width: 74px; }
-    .dsm-mid { width: 132px; }
-    .dsm-muted { opacity: .68; }
-    .dsm-lora-row { display: grid; grid-template-columns: auto minmax(160px,1fr) 80px 80px auto; gap: 6px; align-items: center; }
-    .dsm-grid2 { display: grid; grid-template-columns: minmax(0,1fr) minmax(0,1fr); gap: 6px; }
-    .dsm-details { display: flex; flex-direction: column; gap: 7px; }
-    .dsm-details summary { cursor: pointer; user-select: none; }
-  `;
-  document.head.appendChild(style);
+function getSelectedGraphNodes() {
+  const selected = app?.canvas?.selected_nodes;
+  if (Array.isArray(selected)) return selected;
+  if (selected && typeof selected === "object") return Object.values(selected).filter(Boolean);
+  return [];
+}
+
+function getInputLink(node, inputName) {
+  const input = (node.inputs || []).find((candidate) => candidate.name === inputName);
+  if (!input || input.link == null) return null;
+  const graph = node.graph || app.graph;
+  return graph?.links?.[input.link] || null;
+}
+
+function getConnectedOriginNode(node, inputName) {
+  const link = getInputLink(node, inputName);
+  if (!link) return null;
+  const graph = node.graph || app.graph;
+  return graph?.getNodeById?.(link.origin_id) || null;
+}
+
+function extractTextFromNode(sourceNode) {
+  if (!sourceNode) return "";
+  const preferredNames = new Set(["text", "positive", "negative", "prompt", "string", "value"]);
+  const widgets = sourceNode.widgets || [];
+  for (const widget of widgets) {
+    if (preferredNames.has(String(widget.name ?? "").toLowerCase()) && typeof widget.value === "string") return widget.value;
+  }
+  for (const widget of widgets) {
+    if (typeof widget.value === "string" && widget.value.trim()) return widget.value;
+  }
+  return "";
+}
+
+function captureConnectedLoraStack(node, character) {
+  const stackSource = getConnectedOriginNode(node, "lora_stack");
+  const stack = extractLoraStackFromNode(stackSource);
+  if (!stack) return false;
+  character.loras = stack.loras;
+  character.loader_globals = stack.loader_globals;
+  return true;
+}
+
+function captureSelectedLoaderStack(targetNode, character) {
+  const loader = getSelectedGraphNodes().filter((node) => node && node !== targetNode).find(isDoraLoaderNode);
+  const stack = extractLoraStackFromNode(loader);
+  if (!stack) return false;
+  character.loras = stack.loras;
+  character.loader_globals = stack.loader_globals;
+  return true;
+}
+
+function captureConnectedInputs(node, character, prompt) {
+  const changes = [];
+  const stackSource = getConnectedOriginNode(node, "lora_stack");
+  const stack = extractLoraStackFromNode(stackSource);
+  if (stack) {
+    character.loras = stack.loras;
+    character.loader_globals = stack.loader_globals;
+    changes.push("LoRA stack");
+  }
+
+  const positive = extractTextFromNode(getConnectedOriginNode(node, "positive_prompt"));
+  if (positive || getInputLink(node, "positive_prompt")) {
+    prompt.positive = positive;
+    changes.push("positive prompt");
+  }
+
+  const negative = extractTextFromNode(getConnectedOriginNode(node, "negative_prompt"));
+  if (negative || getInputLink(node, "negative_prompt")) {
+    prompt.negative = negative;
+    changes.push("negative prompt");
+  }
+
+  const settingsText = extractTextFromNode(getConnectedOriginNode(node, "settings_json_input"));
+  if (settingsText || getInputLink(node, "settings_json_input")) {
+    const parsed = normalizeSettings(settingsText);
+    prompt.settings = parsed;
+    changes.push("settings JSON");
+  }
+
+  return changes;
+}
+
+function captureSelectedNodes(targetNode, character, prompt) {
+  const selected = getSelectedGraphNodes().filter((node) => node && node !== targetNode);
+  const changes = [];
+  const loader = selected.find(isDoraLoaderNode);
+  const stack = extractLoraStackFromNode(loader);
+  if (stack) {
+    character.loras = stack.loras;
+    character.loader_globals = stack.loader_globals;
+    changes.push("LoRA stack");
+  }
+
+  const textNodes = selected.filter((node) => node !== loader).map((node) => ({ node, text: extractTextFromNode(node) })).filter((item) => item.text);
+  const negativeCandidate = textNodes.find((item) => /negative|neg/i.test(`${item.node?.title ?? ""} ${item.node?.type ?? ""}`));
+  const positiveCandidate = textNodes.find((item) => item !== negativeCandidate);
+  if (positiveCandidate) {
+    prompt.positive = positiveCandidate.text;
+    changes.push("positive prompt");
+  }
+  if (negativeCandidate) {
+    prompt.negative = negativeCandidate.text;
+    changes.push("negative prompt");
+  } else if (textNodes.length >= 2) {
+    prompt.negative = textNodes[1].text;
+    changes.push("negative prompt");
+  }
+  return changes;
+}
+
+async function uploadThumbnailFile(file) {
+  const body = new FormData();
+  body.append("image", file);
+  body.append("type", "input");
+  body.append("subfolder", THUMBNAIL_SUBFOLDER);
+  const response = await api.fetchApi("/upload/image", { method: "POST", body });
+  if (!response.ok) throw new Error(`${response.status} ${response.statusText}`);
+  const payload = await response.json();
+  const filename = String(payload?.name ?? "").trim();
+  if (!filename) throw new Error("upload returned no filename");
+  return {
+    filename,
+    subfolder: String(payload?.subfolder ?? THUMBNAIL_SUBFOLDER).trim(),
+    type: String(payload?.type ?? "input").trim() || "input",
+  };
 }
 
 function makeButton(label, callback, title = "") {
@@ -336,6 +562,14 @@ function makeInput(value, onChange, attrs = {}) {
   return input;
 }
 
+function makeTextarea(value, onChange, attrs = {}) {
+  const textarea = document.createElement("textarea");
+  textarea.value = value ?? "";
+  Object.assign(textarea, attrs);
+  textarea.addEventListener("input", () => onChange(textarea.value));
+  return textarea;
+}
+
 function makeCheckbox(value, onChange) {
   const input = document.createElement("input");
   input.type = "checkbox";
@@ -357,393 +591,572 @@ function makeSelect(values, selected, onChange) {
   return select;
 }
 
-function addLabel(container, text, control) {
+function labelledControl(labelText, control) {
   const label = document.createElement("label");
-  label.className = "dsm-row dsm-flex";
+  label.className = "dsm-labelled";
   const span = document.createElement("span");
-  span.textContent = text;
-  span.className = "dsm-muted";
+  span.textContent = labelText;
   label.append(span, control);
-  container.appendChild(label);
   return label;
 }
 
-function updateGlobalsFromUi(globals, patch) {
-  Object.assign(globals, patch);
-  return normalizeLoaderGlobals(globals);
+function setPanel(node, panel) {
+  const { state, uiState } = getCurrentState(node);
+  uiState.panel = panel;
+  updateState(node, state, uiState, { dirty: false });
 }
 
-function render(node) {
-  const root = node.__dsmRoot;
-  if (!root) return;
-  ensureStyles();
-
-  const state = readNodeState(node);
-  const { character, prompt } = ensureSelection(node, state);
-  const selectedCharId = character.id;
-  const selectedPromptId = prompt.id;
-
-  root.innerHTML = "";
-  root.className = "dsm-root";
-
-  const datalistId = `dsm_loras_${node.id ?? "node"}`;
-  const datalist = document.createElement("datalist");
-  datalist.id = datalistId;
-  for (const name of loraCache || ["None"]) {
-    const option = document.createElement("option");
-    option.value = name;
-    datalist.appendChild(option);
+function renderCharacterTile(node, state, uiState, character, selectedId) {
+  const tile = document.createElement("button");
+  tile.type = "button";
+  tile.className = `dsm-character-tile${character.id === selectedId ? " selected" : ""}`;
+  const thumb = document.createElement("div");
+  thumb.className = "dsm-thumb";
+  const url = thumbnailUrl(character.thumbnail);
+  if (url) {
+    const img = document.createElement("img");
+    img.src = url;
+    img.alt = character.name;
+    thumb.appendChild(img);
+  } else {
+    const initials = character.name.trim().slice(0, 2).toUpperCase() || "?";
+    thumb.textContent = initials;
   }
-  root.appendChild(datalist);
+  const name = document.createElement("div");
+  name.className = "dsm-character-name";
+  name.textContent = character.name;
+  const meta = document.createElement("div");
+  meta.className = "dsm-muted";
+  meta.textContent = `${character.loras.length} LoRA${character.loras.length === 1 ? "" : "s"} · ${character.prompts.length} preset${character.prompts.length === 1 ? "" : "s"}`;
+  tile.append(thumb, name, meta);
+  tile.addEventListener("click", () => {
+    const promptId = character.prompts[0]?.id || "";
+    updateState(node, state, uiState, { characterId: character.id, promptId });
+  });
+  return tile;
+}
 
-  const header = document.createElement("div");
-  header.className = "dsm-section";
-  const headerTitle = document.createElement("div");
-  headerTitle.className = "dsm-section-title";
-  headerTitle.textContent = "Character state";
-  const charRow = document.createElement("div");
-  charRow.className = "dsm-row wrap";
-  const charSelect = makeSelect(
-    state.characters.map((c) => ({ value: c.id, label: c.name })),
-    selectedCharId,
-    (id) => {
-      const next = selectedCharacter(state, id);
-      saveState(node, state, { characterId: next.id, promptId: next.prompts[0]?.id || "" });
-      render(node);
-    }
+function renderHeader(node, state, uiState, character, prompt) {
+  const widgets = getWidgets(node);
+  const section = document.createElement("div");
+  section.className = "dsm-section dsm-top";
+
+  const toolbar = document.createElement("div");
+  toolbar.className = "dsm-toolbar";
+  const title = document.createElement("div");
+  title.className = "dsm-title";
+  title.textContent = "DoRA State Manager";
+
+  const liveInputs = makeCheckbox(Boolean(widgetValue(widgets.useRuntimeInputsWidget, false)), (checked) => {
+    updateState(node, state, uiState, { useRuntimeInputs: checked, status: checked ? "Runtime inputs override saved state during execution." : "Saved state drives execution." });
+  });
+
+  toolbar.append(
+    title,
+    makeButton("Capture connected", () => {
+      const changes = captureConnectedInputs(node, character, prompt);
+      updateState(node, state, uiState, {
+        characterId: character.id,
+        promptId: prompt.id,
+        status: changes.length ? `Captured ${changes.join(", ")} from connected inputs.` : "No connected prompt/lora inputs found.",
+      });
+    }, "Capture positive/negative/settings/lora_stack inputs into the selected character/preset"),
+    makeButton("Capture selected nodes", () => {
+      const changes = captureSelectedNodes(node, character, prompt);
+      updateState(node, state, uiState, {
+        characterId: character.id,
+        promptId: prompt.id,
+        status: changes.length ? `Captured ${changes.join(", ")} from selected graph nodes.` : "Select a DoRA loader and/or text nodes first.",
+      });
+    }, "Read the selected DoRA Power LoRA Loader and selected text nodes from the graph"),
+    labelledControl("Runtime override", liveInputs)
   );
-  charSelect.className = "dsm-flex";
-  charRow.append(
-    charSelect,
-    makeButton("New", () => {
+
+  const grid = document.createElement("div");
+  grid.className = "dsm-character-grid";
+  for (const item of state.characters) grid.appendChild(renderCharacterTile(node, state, uiState, item, character.id));
+
+  const controls = document.createElement("div");
+  controls.className = "dsm-toolbar";
+  controls.append(
+    makeButton("New character", () => {
       const c = defaultCharacter();
       c.id = makeId("character");
       c.name = `Character ${state.characters.length + 1}`;
       c.prompts[0].id = makeId("prompt");
       state.characters.push(c);
-      saveState(node, state, { characterId: c.id, promptId: c.prompts[0].id });
-      render(node);
+      updateState(node, state, uiState, { characterId: c.id, promptId: c.prompts[0].id, status: "Created character." });
     }),
     makeButton("Duplicate", () => {
-      const copy = clone(character);
+      const copy = structuredCloneCompat(character);
       copy.id = makeId("character");
       copy.name = `${copy.name} Copy`;
       copy.prompts = copy.prompts.map((p) => ({ ...p, id: makeId("prompt") }));
       state.characters.push(copy);
-      saveState(node, state, { characterId: copy.id, promptId: copy.prompts[0]?.id || "" });
-      render(node);
+      updateState(node, state, uiState, { characterId: copy.id, promptId: copy.prompts[0]?.id || "", status: "Duplicated character." });
     }),
     makeButton("Delete", () => {
-      if (state.characters.length <= 1) return;
-      const index = state.characters.findIndex((c) => c.id === selectedCharId);
+      if (state.characters.length <= 1) {
+        setStatus(node, "At least one character must remain.");
+        return;
+      }
+      const index = state.characters.findIndex((c) => c.id === character.id);
       if (index >= 0) state.characters.splice(index, 1);
       const next = state.characters[Math.max(0, Math.min(index, state.characters.length - 1))];
-      saveState(node, state, { characterId: next.id, promptId: next.prompts[0]?.id || "" });
-      render(node);
+      updateState(node, state, uiState, { characterId: next.id, promptId: next.prompts[0]?.id || "", status: "Deleted character." });
     })
   );
+
+  section.append(toolbar, grid, controls);
+  return section;
+}
+
+function renderCharacterPanel(node, state, uiState, character) {
+  const section = document.createElement("div");
+  section.className = "dsm-section dsm-panel";
+  const title = document.createElement("div");
+  title.className = "dsm-section-title";
+  title.textContent = "Selected character";
+
   const nameInput = makeInput(character.name, (value) => {
     character.name = value.trim() || character.name;
-    saveState(node, state, { characterId: character.id, promptId: selectedPromptId });
+    updateState(node, state, uiState, { characterId: character.id, render: true });
   });
-  nameInput.className = "dsm-flex";
-  const nameRow = document.createElement("div");
-  nameRow.className = "dsm-row";
-  nameRow.append(Object.assign(document.createElement("span"), { textContent: "Name", className: "dsm-muted" }), nameInput);
-  header.append(headerTitle, charRow, nameRow);
-  root.appendChild(header);
 
-  const loraSection = document.createElement("div");
-  loraSection.className = "dsm-section";
-  const loraTitle = document.createElement("div");
-  loraTitle.className = "dsm-row";
-  const titleText = document.createElement("div");
-  titleText.className = "dsm-section-title dsm-flex";
-  titleText.textContent = "LoRA combination";
-  loraTitle.append(
-    titleText,
-    makeButton("Refresh", async () => {
-      loraCache = null;
-      await fetchLoras();
-      render(node);
-    }),
-    makeButton("Add LoRA", () => {
-      character.loras.push({ enabled: true, name: "None", strength_model: 1.0, strength_clip: 1.0 });
-      saveState(node, state, { characterId: selectedCharId, promptId: selectedPromptId });
-      render(node);
+  const preview = document.createElement("div");
+  preview.className = "dsm-large-thumb";
+  const url = thumbnailUrl(character.thumbnail);
+  if (url) {
+    const img = document.createElement("img");
+    img.src = url;
+    img.alt = character.name;
+    preview.appendChild(img);
+  } else {
+    preview.textContent = "Drop thumbnail here";
+  }
+
+  const fileInput = document.createElement("input");
+  fileInput.type = "file";
+  fileInput.accept = "image/*";
+  fileInput.style.display = "none";
+  fileInput.addEventListener("change", async () => {
+    const file = fileInput.files?.[0];
+    if (!file) return;
+    try {
+      character.thumbnail = await uploadThumbnailFile(file);
+      updateState(node, state, uiState, { characterId: character.id, status: "Thumbnail uploaded." });
+    } catch (err) {
+      setStatus(node, `Thumbnail upload failed: ${err?.message || err}`);
+    } finally {
+      fileInput.value = "";
+    }
+  });
+  preview.addEventListener("click", () => fileInput.click());
+  preview.addEventListener("dragover", (event) => {
+    event.preventDefault();
+    preview.classList.add("dragging");
+  });
+  preview.addEventListener("dragleave", () => preview.classList.remove("dragging"));
+  preview.addEventListener("drop", async (event) => {
+    event.preventDefault();
+    preview.classList.remove("dragging");
+    const file = [...(event.dataTransfer?.files || [])].find((candidate) => candidate.type.startsWith("image/"));
+    if (!file) return;
+    try {
+      character.thumbnail = await uploadThumbnailFile(file);
+      updateState(node, state, uiState, { characterId: character.id, status: "Thumbnail uploaded." });
+    } catch (err) {
+      setStatus(node, `Thumbnail upload failed: ${err?.message || err}`);
+    }
+  });
+
+  const loraSummary = document.createElement("div");
+  loraSummary.className = "dsm-lora-summary";
+  const activeRows = character.loras.filter((row) => row.enabled && row.name && row.name !== "None");
+  loraSummary.textContent = activeRows.length
+    ? activeRows.map((row) => `${row.name} (${row.strength_model}/${row.strength_clip})`).join("\n")
+    : "No saved LoRA stack for this character.";
+
+  const thumbnailButtons = document.createElement("div");
+  thumbnailButtons.className = "dsm-toolbar";
+  thumbnailButtons.append(
+    makeButton("Choose thumbnail", () => fileInput.click()),
+    makeButton("Clear", () => {
+      character.thumbnail = {};
+      updateState(node, state, uiState, { characterId: character.id, status: "Thumbnail cleared." });
     })
   );
-  loraSection.appendChild(loraTitle);
-  if (!character.loras.length) {
-    const empty = document.createElement("div");
-    empty.className = "dsm-muted";
-    empty.textContent = "No LoRA rows saved for this character yet.";
-    loraSection.appendChild(empty);
-  }
-  character.loras.forEach((row, index) => {
-    const loraRow = document.createElement("div");
-    loraRow.className = "dsm-lora-row";
-    const enabled = makeCheckbox(row.enabled, (checked) => {
-      row.enabled = checked;
-      saveState(node, state, { characterId: selectedCharId, promptId: selectedPromptId });
-    });
-    const name = makeInput(row.name, (value) => {
-      row.name = value.trim() || "None";
-      saveState(node, state, { characterId: selectedCharId, promptId: selectedPromptId });
-    }, { list: datalistId });
-    const sm = makeInput(row.strength_model, (value) => {
-      row.strength_model = normalizeNumber(value, row.strength_model);
-      saveState(node, state, { characterId: selectedCharId, promptId: selectedPromptId });
-    }, { type: "number", step: "0.05" });
-    const sc = makeInput(row.strength_clip, (value) => {
-      row.strength_clip = normalizeNumber(value, row.strength_clip);
-      saveState(node, state, { characterId: selectedCharId, promptId: selectedPromptId });
-    }, { type: "number", step: "0.05" });
-    loraRow.append(enabled, name, sm, sc, makeButton("×", () => {
-      character.loras.splice(index, 1);
-      saveState(node, state, { characterId: selectedCharId, promptId: selectedPromptId });
-      render(node);
-    }, "Remove LoRA row"));
-    loraSection.appendChild(loraRow);
-  });
-  root.appendChild(loraSection);
 
-  const promptSection = document.createElement("div");
-  promptSection.className = "dsm-section";
-  const promptTitle = document.createElement("div");
-  promptTitle.className = "dsm-row";
-  const promptTitleText = document.createElement("div");
-  promptTitleText.className = "dsm-section-title dsm-flex";
-  promptTitleText.textContent = "Prompt preset";
-  promptTitle.append(
-    promptTitleText,
+  section.append(title, labelledControl("Name", nameInput), preview, fileInput, thumbnailButtons, labelledControl("Saved LoRA stack", loraSummary));
+  return section;
+}
+
+function renderPromptPanel(node, state, uiState, character, prompt) {
+  const section = document.createElement("div");
+  section.className = "dsm-section dsm-panel";
+
+  const tabs = document.createElement("div");
+  tabs.className = "dsm-tabs";
+  for (const [panel, label] of [["prompts", "Prompts"], ["loras", "LoRA stack"], ["settings", "Settings"]]) {
+    const btn = makeButton(label, () => setPanel(node, panel));
+    if (uiState.panel === panel) btn.classList.add("selected");
+    tabs.appendChild(btn);
+  }
+  section.appendChild(tabs);
+
+  if (uiState.panel === "loras") {
+    renderLoraPanelContent(section, node, state, uiState, character, prompt);
+  } else if (uiState.panel === "settings") {
+    renderSettingsPanelContent(section, node, state, uiState, character, prompt);
+  } else {
+    renderPromptPanelContent(section, node, state, uiState, character, prompt);
+  }
+
+  if (uiState.status) {
+    const status = document.createElement("div");
+    status.className = "dsm-status";
+    status.textContent = uiState.status;
+    section.appendChild(status);
+  }
+  return section;
+}
+
+function renderPromptPanelContent(section, node, state, uiState, character, prompt) {
+  const header = document.createElement("div");
+  header.className = "dsm-toolbar";
+  const select = makeSelect(character.prompts.map((p) => ({ value: p.id, label: p.name })), prompt.id, (id) => {
+    updateState(node, state, uiState, { characterId: character.id, promptId: id });
+  });
+  select.className = "dsm-flex";
+  header.append(
+    select,
     makeButton("New", () => {
       const p = defaultPrompt();
       p.id = makeId("prompt");
       p.name = `Prompt ${character.prompts.length + 1}`;
       character.prompts.push(p);
-      saveState(node, state, { characterId: selectedCharId, promptId: p.id });
-      render(node);
+      updateState(node, state, uiState, { characterId: character.id, promptId: p.id, status: "Created prompt preset." });
     }),
     makeButton("Duplicate", () => {
-      const p = { ...clone(prompt), id: makeId("prompt"), name: `${prompt.name} Copy` };
-      character.prompts.push(p);
-      saveState(node, state, { characterId: selectedCharId, promptId: p.id });
-      render(node);
+      const copy = { ...structuredCloneCompat(prompt), id: makeId("prompt"), name: `${prompt.name} Copy` };
+      character.prompts.push(copy);
+      updateState(node, state, uiState, { characterId: character.id, promptId: copy.id, status: "Duplicated prompt preset." });
     }),
     makeButton("Delete", () => {
-      if (character.prompts.length <= 1) return;
-      const index = character.prompts.findIndex((p) => p.id === selectedPromptId);
+      if (character.prompts.length <= 1) {
+        setStatus(node, "At least one prompt preset must remain.");
+        return;
+      }
+      const index = character.prompts.findIndex((p) => p.id === prompt.id);
       if (index >= 0) character.prompts.splice(index, 1);
       const next = character.prompts[Math.max(0, Math.min(index, character.prompts.length - 1))];
-      saveState(node, state, { characterId: selectedCharId, promptId: next.id });
-      render(node);
+      updateState(node, state, uiState, { characterId: character.id, promptId: next.id, status: "Deleted prompt preset." });
     })
   );
-  const promptSelect = makeSelect(
-    character.prompts.map((p) => ({ value: p.id, label: p.name })),
-    selectedPromptId,
-    (id) => {
-      saveState(node, state, { characterId: selectedCharId, promptId: id });
-      render(node);
-    }
-  );
-  promptSelect.className = "dsm-flex";
-  const promptSelectRow = document.createElement("div");
-  promptSelectRow.className = "dsm-row";
-  promptSelectRow.append(promptSelect);
-  const promptName = makeInput(prompt.name, (value) => {
+
+  const name = makeInput(prompt.name, (value) => {
     prompt.name = value.trim() || prompt.name;
-    saveState(node, state, { characterId: selectedCharId, promptId: prompt.id });
+    updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id });
   });
-  promptName.className = "dsm-flex";
-  const promptNameRow = document.createElement("div");
-  promptNameRow.className = "dsm-row";
-  promptNameRow.append(Object.assign(document.createElement("span"), { textContent: "Name", className: "dsm-muted" }), promptName);
-  const positive = document.createElement("textarea");
-  positive.value = prompt.positive;
-  positive.placeholder = "Positive prompt";
-  positive.addEventListener("input", () => {
-    prompt.positive = positive.value;
-    saveState(node, state, { characterId: selectedCharId, promptId: prompt.id });
-  });
-  const negative = document.createElement("textarea");
-  negative.value = prompt.negative;
-  negative.placeholder = "Negative prompt";
-  negative.addEventListener("input", () => {
-    prompt.negative = negative.value;
-    saveState(node, state, { characterId: selectedCharId, promptId: prompt.id });
-  });
-  promptSection.append(promptTitle, promptSelectRow, promptNameRow, positive, negative);
-  root.appendChild(promptSection);
 
-  const settingsSection = document.createElement("details");
-  settingsSection.className = "dsm-section dsm-details";
-  const settingsSummary = document.createElement("summary");
-  settingsSummary.className = "dsm-section-title";
-  settingsSummary.textContent = "Saved loader settings / future node settings";
-  settingsSection.appendChild(settingsSummary);
+  const positive = makeTextarea(prompt.positive, (value) => {
+    prompt.positive = value;
+    updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id, render: false });
+  }, { placeholder: "Positive prompt" });
 
+  const negative = makeTextarea(prompt.negative, (value) => {
+    prompt.negative = value;
+    updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id, render: false });
+  }, { placeholder: "Negative prompt" });
+
+  section.append(header, labelledControl("Preset name", name), labelledControl("Positive", positive), labelledControl("Negative", negative));
+}
+
+function renderLoraPanelContent(section, node, state, uiState, character, prompt) {
+  const header = document.createElement("div");
+  header.className = "dsm-toolbar";
+  header.append(
+    makeButton("Capture connected", () => {
+      const changed = captureConnectedLoraStack(node, character);
+      updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id, status: changed ? "Captured LoRA stack from connected input." : "No connected lora_stack input found." });
+    }),
+    makeButton("Capture selected loader", () => {
+      const changed = captureSelectedLoaderStack(node, character);
+      updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id, status: changed ? "Captured LoRA stack from selected DoRA loader." : "Select a DoRA Power LoRA Loader first." });
+    }),
+    makeButton("Add manual row", () => {
+      character.loras.push({ enabled: true, name: "None", strength_model: 1.0, strength_clip: 1.0 });
+      updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id, status: "Added manual LoRA row." });
+    })
+  );
+  section.appendChild(header);
+
+  if (!character.loras.length) {
+    const empty = document.createElement("div");
+    empty.className = "dsm-muted";
+    empty.textContent = "No LoRA stack saved. Capture an existing DoRA loader or connect a lora_stack input.";
+    section.appendChild(empty);
+    return;
+  }
+
+  character.loras.forEach((row, index) => {
+    const line = document.createElement("div");
+    line.className = "dsm-lora-row";
+    const enabled = makeCheckbox(row.enabled, (checked) => {
+      row.enabled = checked;
+      updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id });
+    });
+    const name = makeInput(row.name, (value) => {
+      row.name = value.trim() || "None";
+      updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id });
+    });
+    const sm = makeInput(row.strength_model, (value) => {
+      row.strength_model = normalizeNumber(value, row.strength_model);
+      updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id });
+    }, { type: "number", step: "0.05" });
+    const sc = makeInput(row.strength_clip, (value) => {
+      row.strength_clip = normalizeNumber(value, row.strength_clip);
+      updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id });
+    }, { type: "number", step: "0.05" });
+    line.append(enabled, name, sm, sc, makeButton("×", () => {
+      character.loras.splice(index, 1);
+      updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id, status: "Removed LoRA row." });
+    }));
+    section.appendChild(line);
+  });
+}
+
+function renderSettingsPanelContent(section, node, state, uiState, character, prompt) {
   const globals = character.loader_globals || (character.loader_globals = {});
-  const row1 = document.createElement("div");
-  row1.className = "dsm-grid2";
+  const grid = document.createElement("div");
+  grid.className = "dsm-grid2";
+
   const stackEnabled = makeCheckbox(globals.stack_enabled ?? true, (checked) => {
-    character.loader_globals = updateGlobalsFromUi(globals, { stack_enabled: checked });
-    saveState(node, state, { characterId: selectedCharId, promptId: selectedPromptId });
+    character.loader_globals = normalizeLoaderGlobals({ ...globals, stack_enabled: checked });
+    updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id });
   });
   const autoStrength = makeCheckbox(globals.auto_strength_enabled ?? false, (checked) => {
-    character.loader_globals = updateGlobalsFromUi(globals, { auto_strength_enabled: checked });
-    saveState(node, state, { characterId: selectedCharId, promptId: selectedPromptId });
+    character.loader_globals = normalizeLoaderGlobals({ ...globals, auto_strength_enabled: checked });
+    updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id });
   });
-  addLabel(row1, "Stack", stackEnabled);
-  addLabel(row1, "Auto-strength", autoStrength);
-  settingsSection.appendChild(row1);
-
-  const row2 = document.createElement("div");
-  row2.className = "dsm-grid2";
   const device = makeSelect(AUTO_STRENGTH_DEVICE_CHOICES, normalizeDevice(globals.auto_strength_device ?? "gpu"), (value) => {
-    character.loader_globals = updateGlobalsFromUi(globals, { auto_strength_device: value });
-    saveState(node, state, { characterId: selectedCharId, promptId: selectedPromptId });
+    character.loader_globals = normalizeLoaderGlobals({ ...globals, auto_strength_device: value });
+    updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id });
   });
   const broadcastMods = makeCheckbox(globals.broadcast_modulations ?? true, (checked) => {
-    character.loader_globals = updateGlobalsFromUi(globals, { broadcast_modulations: checked });
-    saveState(node, state, { characterId: selectedCharId, promptId: selectedPromptId });
+    character.loader_globals = normalizeLoaderGlobals({ ...globals, broadcast_modulations: checked });
+    updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id });
   });
-  addLabel(row2, "Device", device);
-  addLabel(row2, "Broadcast modulation", broadcastMods);
-  settingsSection.appendChild(row2);
-
-  const row3 = document.createElement("div");
-  row3.className = "dsm-grid2";
-  const floor = makeInput(globals.auto_strength_ratio_floor ?? 0.30, (value) => {
-    character.loader_globals = updateGlobalsFromUi(globals, { auto_strength_ratio_floor: normalizeNumber(value, 0.30) });
-    saveState(node, state, { characterId: selectedCharId, promptId: selectedPromptId });
+  const floor = makeInput(globals.auto_strength_ratio_floor ?? 0.3, (value) => {
+    character.loader_globals = normalizeLoaderGlobals({ ...globals, auto_strength_ratio_floor: normalizeNumber(value, 0.3) });
+    updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id });
   }, { type: "number", step: "0.01" });
-  const ceiling = makeInput(globals.auto_strength_ratio_ceiling ?? 1.50, (value) => {
-    character.loader_globals = updateGlobalsFromUi(globals, { auto_strength_ratio_ceiling: normalizeNumber(value, 1.50) });
-    saveState(node, state, { characterId: selectedCharId, promptId: selectedPromptId });
+  const ceiling = makeInput(globals.auto_strength_ratio_ceiling ?? 1.5, (value) => {
+    character.loader_globals = normalizeLoaderGlobals({ ...globals, auto_strength_ratio_ceiling: normalizeNumber(value, 1.5) });
+    updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id });
   }, { type: "number", step: "0.01" });
-  addLabel(row3, "Ratio floor", floor);
-  addLabel(row3, "Ratio ceiling", ceiling);
-  settingsSection.appendChild(row3);
-
-  const row4 = document.createElement("div");
-  row4.className = "dsm-grid2";
   const sliceFix = makeCheckbox(globals.dora_slice_fix ?? true, (checked) => {
-    character.loader_globals = updateGlobalsFromUi(globals, { dora_slice_fix: checked });
-    saveState(node, state, { characterId: selectedCharId, promptId: selectedPromptId });
+    character.loader_globals = normalizeLoaderGlobals({ ...globals, dora_slice_fix: checked });
+    updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id });
   });
   const adalnFix = makeCheckbox(globals.dora_adaln_swap_fix ?? true, (checked) => {
-    character.loader_globals = updateGlobalsFromUi(globals, { dora_adaln_swap_fix: checked });
-    saveState(node, state, { characterId: selectedCharId, promptId: selectedPromptId });
+    character.loader_globals = normalizeLoaderGlobals({ ...globals, dora_adaln_swap_fix: checked });
+    updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id });
   });
-  addLabel(row4, "Slice fix", sliceFix);
-  addLabel(row4, "AdaLN swap fix", adalnFix);
-  settingsSection.appendChild(row4);
 
-  const settingsJson = document.createElement("textarea");
-  settingsJson.value = JSON.stringify(prompt.settings || {}, null, 2);
-  settingsJson.placeholder = "Arbitrary JSON for future nodes, e.g. autoguidance/scale-locked guidance settings";
-  settingsJson.addEventListener("change", () => {
-    const parsed = safeJsonParse(settingsJson.value, null);
+  grid.append(
+    labelledControl("Stack enabled", stackEnabled),
+    labelledControl("Auto-strength", autoStrength),
+    labelledControl("Analysis device", device),
+    labelledControl("Broadcast modulation", broadcastMods),
+    labelledControl("Ratio floor", floor),
+    labelledControl("Ratio ceiling", ceiling),
+    labelledControl("Slice fix", sliceFix),
+    labelledControl("AdaLN swap fix", adalnFix)
+  );
+
+  const settingsJson = makeTextarea(JSON.stringify(prompt.settings || {}, null, 2), (value) => {
+    const parsed = safeJsonParse(value, null);
     if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
       prompt.settings = parsed;
-      saveState(node, state, { characterId: selectedCharId, promptId: selectedPromptId });
-      settingsJson.value = JSON.stringify(prompt.settings, null, 2);
+      updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id, render: false });
     }
+  }, { placeholder: "Prompt/settings JSON for future nodes" });
+  settingsJson.addEventListener("change", () => {
+    settingsJson.value = JSON.stringify(prompt.settings || {}, null, 2);
+    updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id });
   });
-  const settingsLabel = document.createElement("div");
-  settingsLabel.className = "dsm-muted";
-  settingsLabel.textContent = "Prompt/settings JSON output";
-  settingsSection.append(settingsLabel, settingsJson);
-  root.appendChild(settingsSection);
+
+  section.append(grid, labelledControl("Prompt/settings JSON", settingsJson));
 }
 
-function syncDomWidgetSize(node, widget) {
-  if (!node || !widget) return;
-  node.size = Array.isArray(node.size) ? node.size : [MIN_NODE_WIDTH, MIN_WIDGET_HEIGHT];
-  node.size[0] = Math.max(Number(node.size[0]) || 0, MIN_NODE_WIDTH);
-  node.size[1] = Math.max(Number(node.size[1]) || 0, MIN_WIDGET_HEIGHT + 90);
-  node.min_size = [MIN_NODE_WIDTH, MIN_WIDGET_HEIGHT + 90];
+function renderNode(node) {
+  const ctx = node.__dsm;
+  if (!ctx?.root) return;
+  const { state, uiState } = getRenderableState(node);
+  const { character, prompt } = ensureSelection(node, state);
+  ctx.root.innerHTML = "";
+  ctx.root.className = "dsm-root";
+  ctx.root.append(renderHeader(node, state, uiState, character, prompt));
+  const main = document.createElement("div");
+  main.className = "dsm-main";
+  main.append(renderCharacterPanel(node, state, uiState, character), renderPromptPanel(node, state, uiState, character, prompt));
+  ctx.root.appendChild(main);
 }
 
-function installNode(node) {
-  if (!node) return;
+function ensureStyles() {
+  if (document.getElementById(STYLE_ID)) return;
+  const style = document.createElement("style");
+  style.id = STYLE_ID;
+  style.textContent = `
+    .dsm-root {
+      box-sizing: border-box;
+      width: 100%;
+      height: 100%;
+      min-height: 0;
+      padding: 8px;
+      overflow: hidden;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      color: var(--input-text, #ddd);
+      background: rgba(20, 20, 20, 0.18);
+      font: 12px/1.35 system-ui, sans-serif;
+    }
+    .dsm-root * { box-sizing: border-box; }
+    .dsm-section {
+      border: 1px solid rgba(128,128,128,.35);
+      border-radius: 8px;
+      padding: 8px;
+      background: rgba(0,0,0,.10);
+    }
+    .dsm-top { flex: 0 0 auto; min-height: 0; }
+    .dsm-main { flex: 1 1 auto; min-height: 0; display: grid; grid-template-columns: minmax(200px, .8fr) minmax(300px, 1.2fr); gap: 8px; overflow: hidden; }
+    .dsm-panel { min-height: 0; overflow: auto; display: flex; flex-direction: column; gap: 8px; }
+    .dsm-toolbar { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; margin-bottom: 6px; }
+    .dsm-title, .dsm-section-title { font-weight: 650; opacity: .95; }
+    .dsm-title { flex: 1 1 auto; font-size: 13px; }
+    .dsm-muted { opacity: .68; white-space: pre-wrap; }
+    .dsm-status { border-top: 1px solid rgba(128,128,128,.25); padding-top: 6px; opacity: .78; }
+    .dsm-flex { flex: 1 1 auto; min-width: 0; }
+    .dsm-root input, .dsm-root select, .dsm-root textarea, .dsm-root button {
+      font: inherit;
+      color: var(--input-text, #ddd);
+      background: var(--comfy-input-bg, #222);
+      border: 1px solid rgba(128,128,128,.45);
+      border-radius: 5px;
+      padding: 4px 6px;
+      min-width: 0;
+    }
+    .dsm-root button { cursor: pointer; white-space: nowrap; }
+    .dsm-root button.selected, .dsm-character-tile.selected { border-color: rgba(180, 210, 255, .8); background: rgba(100, 140, 220, .22); }
+    .dsm-root textarea { width: 100%; min-height: 86px; resize: vertical; }
+    .dsm-root input[type="checkbox"] { width: auto; }
+    .dsm-labelled { display: flex; flex-direction: column; gap: 4px; min-width: 0; }
+    .dsm-labelled > span { opacity: .68; }
+    .dsm-character-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(112px, 1fr)); gap: 6px; max-height: 190px; overflow: auto; padding-right: 2px; }
+    .dsm-character-tile { display: flex; flex-direction: column; align-items: stretch; gap: 4px; text-align: left; min-height: 126px; }
+    .dsm-thumb, .dsm-large-thumb { display: flex; align-items: center; justify-content: center; border: 1px solid rgba(128,128,128,.35); border-radius: 7px; overflow: hidden; background: rgba(0,0,0,.22); color: rgba(220,220,220,.72); }
+    .dsm-thumb { height: 76px; font-size: 22px; font-weight: 700; }
+    .dsm-large-thumb { min-height: 170px; cursor: pointer; }
+    .dsm-large-thumb.dragging { border-color: rgba(180, 210, 255, .9); }
+    .dsm-thumb img, .dsm-large-thumb img { width: 100%; height: 100%; object-fit: cover; display: block; }
+    .dsm-character-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-weight: 600; }
+    .dsm-tabs { display: flex; gap: 6px; flex-wrap: wrap; }
+    .dsm-grid2 { display: grid; grid-template-columns: minmax(0, 1fr) minmax(0, 1fr); gap: 8px; }
+    .dsm-lora-row { display: grid; grid-template-columns: auto minmax(110px, 1fr) 76px 76px auto; gap: 6px; align-items: center; }
+    .dsm-lora-summary { white-space: pre-wrap; border: 1px solid rgba(128,128,128,.35); border-radius: 6px; padding: 6px; min-height: 58px; max-height: 190px; overflow: auto; background: rgba(0,0,0,.16); }
+    @media (max-width: 720px) { .dsm-main { grid-template-columns: 1fr; } }
+  `;
+  document.head.appendChild(style);
+}
+
+function initializeNode(node, widget) {
+  if (node.__dsmInitialized) return widget;
+  node.__dsmInitialized = true;
+  node.__dsmWidget = widget;
   node.resizable = true;
 
-  const state = readNodeState(node);
-  const { character, prompt } = ensureSelection(node, state);
-  saveState(node, state, { characterId: character.id, promptId: prompt.id });
-
-  if (typeof node.addDOMWidget !== "function") {
-    console.warn(`[${EXT_NAME}] addDOMWidget is unavailable; falling back to raw JSON widgets.`);
-    return;
-  }
-
   const widgets = getWidgets(node);
-  hideWidget(widgets.stateWidget);
-  hideWidget(widgets.characterWidget);
-  hideWidget(widgets.promptWidget);
+  for (const hidden of [widgets.stateWidget, widgets.uiStateWidget, widgets.characterWidget, widgets.promptWidget, widgets.useRuntimeInputsWidget]) hideWidget(hidden);
 
-  if (node.__dsmInstalled) {
-    render(node);
-    return;
-  }
-  node.__dsmInstalled = true;
+  const oldSize = node.size || [MIN_NODE_WIDTH, MIN_NODE_HEIGHT];
+  node.min_size = [MIN_NODE_WIDTH, MIN_NODE_HEIGHT];
+  node.setSize?.([Math.max(oldSize[0], MIN_NODE_WIDTH), Math.max(oldSize[1], MIN_NODE_HEIGHT)]);
 
-  const root = document.createElement("div");
-  node.__dsmRoot = root;
-  const widget = node.addDOMWidget(DOM_WIDGET_NAME, DOM_WIDGET_TYPE, root, {
-    getMinHeight: () => MIN_WIDGET_HEIGHT,
-    getHeight: () => "100%",
-    onDraw: (domWidget) => syncDomWidgetSize(node, domWidget),
-    afterResize: (domWidgetNode) => syncDomWidgetSize(domWidgetNode, widget),
-    serialize: false,
+  const snapshot = getCurrentState(node);
+  const { character, prompt } = ensureSelection(node, snapshot.state);
+  updateState(node, snapshot.state, snapshot.uiState, { characterId: character.id, promptId: prompt.id, dirty: false, render: false });
+
+  chainNodeCallback(node, "onConfigure", function () {
+    const next = getCurrentState(node);
+    const selection = ensureSelection(node, next.state);
+    updateState(node, next.state, next.uiState, { characterId: selection.character.id, promptId: selection.prompt.id, dirty: false, render: false });
+    scheduleRender(node);
   });
-  widget.serialize = false;
-  node.__dsmWidget = widget;
-  syncDomWidgetSize(node, widget);
 
-  fetchLoras().then(() => {
-    render(node);
-    markNodeDirty(node);
+  chainNodeCallback(node, "onResize", function () {
+    syncDomWidgetSize(node, widget);
+    scheduleRender(node);
   });
-  render(node);
+
+  chainNodeCallback(node, "onRemoved", function () {
+    const ctx = node.__dsm;
+    if (!ctx?.renderFrame) return;
+    cancelAnimationFrame(ctx.renderFrame);
+    ctx.renderFrame = 0;
+  });
+
+  scheduleRender(node);
+  return widget;
+}
+
+function maybeInjectWidgetInput(nodeData) {
+  if (nodeData?.name !== NODE_CLASS && nodeData?.display_name !== NODE_CLASS) return;
+  const required = nodeData?.input?.required;
+  if (!required || required[CUSTOM_WIDGET_INPUT]) return;
+  nodeData.input.required = { ...required, [CUSTOM_WIDGET_INPUT]: [CUSTOM_WIDGET_TYPE, {}] };
 }
 
 app.registerExtension({
   name: EXT_NAME,
 
+  getCustomWidgets() {
+    return {
+      [CUSTOM_WIDGET_TYPE](node, inputName) {
+        ensureStyles();
+        if (node.__dsmWidget) return { widget: node.__dsmWidget, minHeight: MIN_WIDGET_HEIGHT, minWidth: MIN_NODE_WIDTH };
+        const root = document.createElement("div");
+        node.__dsm = { root, renderFrame: 0, state: null, uiState: null };
+        const widget = node.addDOMWidget(inputName, CUSTOM_WIDGET_TYPE, root, {
+          getMinHeight: () => MIN_WIDGET_HEIGHT,
+          getHeight: () => "100%",
+          onDraw: (domWidget) => syncDomWidgetSize(node, domWidget),
+          afterResize: (domWidgetNode) => syncDomWidgetSize(domWidgetNode, widget),
+          serialize: false,
+        });
+        widget.serialize = false;
+        syncDomWidgetSize(node, widget);
+        initializeNode(node, widget);
+        return { widget, minHeight: MIN_WIDGET_HEIGHT, minWidth: MIN_NODE_WIDTH };
+      },
+    };
+  },
+
   async beforeRegisterNodeDef(nodeType, nodeData) {
-    const nodeName = nodeData?.name ?? "";
-    const displayName = nodeData?.display_name ?? "";
-    const comfyClass = nodeType?.comfyClass ?? "";
-    if (nodeName !== NODE_CLASS && displayName !== NODE_CLASS && comfyClass !== NODE_CLASS) return;
-
-    const origOnNodeCreated = nodeType.prototype.onNodeCreated;
-    nodeType.prototype.onNodeCreated = function () {
-      const result = origOnNodeCreated?.apply(this, arguments);
-      queueMicrotask(() => installNode(this));
-      return result;
-    };
-
-    const origConfigure = nodeType.prototype.configure;
-    nodeType.prototype.configure = function (info) {
-      const result = origConfigure?.apply(this, arguments);
-      queueMicrotask(() => installNode(this));
-      return result;
-    };
-
-    const origOnSerialize = nodeType.prototype.onSerialize;
+    maybeInjectWidgetInput(nodeData);
+    if (!isTargetNode(nodeData, nodeType)) return;
+    const originalOnSerialize = nodeType.prototype.onSerialize;
     nodeType.prototype.onSerialize = function (o) {
-      const result = origOnSerialize?.apply(this, arguments);
+      const result = originalOnSerialize?.apply(this, arguments);
       try {
-        const state = readNodeState(this);
-        const widgets = getWidgets(this);
-        saveState(this, state, {
-          characterId: widgetValue(widgets.characterWidget, "default_character"),
-          promptId: widgetValue(widgets.promptWidget, "default_prompt"),
+        const snapshot = getCurrentState(this);
+        const selection = ensureSelection(this, snapshot.state);
+        updateState(this, snapshot.state, snapshot.uiState, {
+          characterId: selection.character.id,
+          promptId: selection.prompt.id,
           dirty: false,
+          render: false,
         });
         o.properties = o.properties || {};
         o.properties.dora_state_manager = this.properties?.dora_state_manager;


### PR DESCRIPTION
## Summary
- rebuild DoRA State Manager around a resizable DOM widget with hidden backing widgets and internal panels
- add runtime prompt/settings/lora_stack inputs plus selected lora_stack output
- append DoRA Power LoRA Loader lora_stack output without changing existing output indexes
- add character thumbnails, capture workflows, and runtime override control

## Validation
- python3 -m py_compile nodes.py
- node --check web/dora_state_manager.js

Repository tests were not run per instruction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned DoRA State Manager UI: resizable widget, character thumbnail tiles, selected-character submenu, and tabbed Prompt/LoRA/Settings panels.
  * Capture workflows: capture connected inputs or selected nodes for prompt presets and LoRA stacks; loader now provides a portable LoRA stack output.

* **Documentation**
  * README expanded with workflow steps, UI behaviors, runtime override options, and persisted state details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->