### PR TITLE
[codex] Add source-only DoRA state manager flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,35 +507,90 @@ This repo is meant for cases where plain ComfyUI LoRA loading is not enough, esp
 
 This build adds a **DoRA State Manager** node for workflow-serialized character states.
 
+The manager separates **saved state** from **runtime execution**:
+
+- execution outputs are source-only and acyclic
+- save/load/apply actions are explicit frontend graph edits
+- no prompt, LoRA stack, settings, or seed value is captured through runtime feedback inputs
+
 Use it to save:
 
 - character / LoRA combinations
-- per-character loader settings such as auto-strength and DoRA compatibility toggles
-- multiple positive / negative prompt presets per character
-- arbitrary JSON settings for future downstream nodes
+- per-character DoRA loader settings such as auto-strength and compatibility toggles
+- multiple positive / negative prompt **templates** per character
+- arbitrary downstream node widget snapshots
+- seed state, including rgthree-style seed nodes
 
 ### Basic wiring
 
-1. Configure a normal **DoRA Power LoRA Loader** and prompt nodes as usual.
-2. Add **DoRA State Manager**.
-3. Select a character tile or create a new one.
-4. Use **Capture selected nodes** after selecting an existing **DoRA Power LoRA Loader** and prompt text nodes, or connect the manager inputs and use **Capture connected**.
-5. Connect `dora_state` from the manager to the loader's optional `dora_state` input.
-6. Connect `positive_prompt` / `negative_prompt` outputs to your text encode path as needed.
+Recommended one-way wiring:
 
-When `dora_state` is connected, the loader uses the selected character's saved LoRA stack. If it is not connected, the loader keeps its normal local row-widget behavior.
+1. Add **DoRA State Manager**.
+2. Add **DoRA Power LoRA Loader**.
+3. Connect `dora_state` from the manager to the loader's optional `dora_state` input.
+4. Connect `positive_prompt_template` and `negative_prompt_template` into the prompt/wildcard path.
+5. Connect `settings_json`, `state_settings`, or `seed` only to downstream nodes that explicitly consume them.
 
-The manager has optional input ports for `positive_prompt`, `negative_prompt`, `settings_json_input`, and `lora_stack`. The loader appends a `lora_stack` output so an existing stack can be routed into the manager without manually recreating rows. Existing loader outputs keep their original indexes; `lora_stack` is appended after `analysis_report`.
+The manager should not receive the processed wildcard prompt. Store the wildcard/template prompt in the manager, then let your wildcard node expand it downstream.
 
-The UI uses a resizable DOM widget, character thumbnail tiles, and a selected-character submenu for prompts, LoRA stack capture/editing, and future settings JSON.
+Correct shape:
+
+```text
+DoRA State Manager positive_prompt_template
+  -> Wildcards Processor
+      -> CLIP Text Encode
+```
+
+Avoid feedback shapes such as:
+
+```text
+Wildcards Processor output
+  -> State Manager input
+  -> Wildcards Processor input
+```
+
+The state manager no longer exposes runtime capture inputs, so this cycle is not part of the node design.
+
+### Save / load / apply workflow
+
+The UI has four graph-editing actions:
+
+- **Save connected** — captures state from nodes connected downstream of the manager outputs.
+- **Load connected** — pushes the selected character/preset into connected downstream nodes.
+- **Save selected** — captures state from selected graph nodes.
+- **Apply selected** — pushes the selected character/preset into selected graph nodes.
+
+Selecting a character tile or prompt preset only changes the manager selection. It does not mutate other nodes until **Load connected** or **Apply selected** is clicked.
+
+### Pattern 1: deterministic downstream settings
+
+The manager outputs:
+
+- `settings_json` — selected prompt preset settings as JSON text
+- `state_settings` — typed `DORA_STATE_SETTINGS` payload
+- `seed` — integer seed extracted from saved settings / rgthree seed snapshots
+
+Future or external nodes can add optional inputs for one of these outputs to consume saved state deterministically during execution.
+
+### Pattern 2: frontend apply/capture
+
+For existing nodes that do not have settings inputs, use the UI actions:
+
+- save selected/connected AutoGuidance or Scale-Locked Guidance nodes into the prompt preset
+- save selected/connected rgthree seed nodes into the prompt preset
+- load/apply the preset back into those graph nodes later
+
+The settings snapshot stores widget values by node identity and class/title fallback. This is intended for controlled workflows where the same downstream nodes remain in the graph.
 
 ### Outputs
 
 - `dora_state` — typed `DORA_STATE` payload for **DoRA Power LoRA Loader**
-- `positive_prompt` — selected prompt preset's positive text
-- `negative_prompt` — selected prompt preset's negative text
-- `settings_json` — selected prompt preset's arbitrary settings object serialized as JSON
+- `positive_prompt_template` — selected prompt preset's positive template text
+- `negative_prompt_template` — selected prompt preset's negative template text
+- `settings_json` — selected prompt preset settings serialized as JSON
 - `selected_lora_stack` — selected character's LoRA stack as a typed `DORA_LORA_STACK` payload
+- `state_settings` — typed `DORA_STATE_SETTINGS` payload for future compatible nodes
+- `seed` — integer seed extracted from saved settings / rgthree seed snapshots
 
 ### Persistence and payload behavior
 
@@ -545,8 +600,5 @@ The manager state is stored in the workflow through hidden backend widgets:
 - `ui_state_json`
 - `selected_character_id`
 - `selected_prompt_id`
-- `use_runtime_inputs`
 
-No external preset database is required for this first version.
-
-The `DORA_STATE` payload contains the selected character identity, selected prompt identity, saved LoRA rows, saved loader-global overrides, prompt text, and prompt settings. The loader accepts only this typed payload shape; invalid or missing `dora_state` data falls back to the loader's existing local row-widget parsing.
+The `DORA_STATE` payload contains the selected character identity, selected prompt identity, saved LoRA rows, saved loader-global overrides, prompt templates, and prompt settings. The DoRA loader accepts this typed payload; invalid or missing `dora_state` data falls back to the loader's existing local row-widget parsing.

--- a/nodes.py
+++ b/nodes.py
@@ -437,6 +437,7 @@ class FlexibleOptionalInputType(dict):
 _DORA_STATE_MANAGER_SCHEMA_VERSION = 1
 _DORA_STATE_KIND = "dora_state_manager_state"
 _DORA_LORA_STACK_KIND = "dora_lora_stack"
+_DORA_STATE_SETTINGS_KIND = "dora_state_settings"
 _DORA_STATE_LOADER_GLOBAL_KEYS: Set[str] = {
     "stack_enabled",
     "verbose",
@@ -679,7 +680,7 @@ def _normalize_manager_prompt(prompt: Any, index: int) -> Optional[Dict[str, Any
         return None
     prompt_id = _clean_state_id(prompt.get("id"), _state_manager_make_id("prompt", index))
     name = str(prompt.get("name") or f"Prompt {index + 1}").strip() or f"Prompt {index + 1}"
-    settings = _normalize_manager_settings(prompt.get("settings", {}))
+    settings = _normalize_settings_with_canonical_seed(prompt.get("settings", {}))
     return {
         "id": prompt_id,
         "name": name,
@@ -782,39 +783,22 @@ def _resolve_dora_state_payload(
     state_json: Any,
     selected_character_id: Any,
     selected_prompt_id: Any,
-    positive_prompt: Any = None,
-    negative_prompt: Any = None,
-    lora_stack: Any = None,
-    settings_json_input: Any = None,
-    use_runtime_inputs: Any = False,
 ) -> Dict[str, Any]:
+    """Resolve the selected saved state without reading any downstream runtime inputs.
+
+    The state manager is intentionally an execution-time source. Save/load/apply behavior
+    is handled by the frontend as explicit graph editing; runtime execution must stay
+    acyclic.
+    """
     state = _normalize_state_manager_state(state_json)
     character = _pick_state_manager_character(state, selected_character_id)
     prompt = _pick_state_manager_prompt(character, selected_prompt_id)
 
-    settings = _normalize_manager_settings(prompt.get("settings", {}))
+    settings = _normalize_settings_with_canonical_seed(prompt.get("settings", {}))
     loras = character.get("loras", [])
     loader_globals = character.get("loader_globals", {})
     positive = str(prompt.get("positive", "") or "")
     negative = str(prompt.get("negative", "") or "")
-
-    if _state_manager_bool(use_runtime_inputs, default=False):
-        stack_payload = _normalize_runtime_lora_stack(lora_stack)
-        if stack_payload is not None:
-            loras = stack_payload.get("loras", [])
-            stack_globals = stack_payload.get("loader_globals")
-            if isinstance(stack_globals, dict):
-                loader_globals = stack_globals
-        if positive_prompt is not None:
-            positive = str(positive_prompt or "")
-        if negative_prompt is not None:
-            negative = str(negative_prompt or "")
-        if settings_json_input is not None:
-            raw_settings = settings_json_input
-            if not (isinstance(raw_settings, str) and raw_settings.strip() == ""):
-                parsed_settings = _safe_json_load(raw_settings, None)
-                if isinstance(parsed_settings, dict):
-                    settings = parsed_settings
 
     return {
         "version": _DORA_STATE_MANAGER_SCHEMA_VERSION,
@@ -835,6 +819,74 @@ def _resolve_dora_state_payload(
         "negative_prompt": negative,
     }
 
+
+def _build_state_settings_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
+    settings = _normalize_settings_with_canonical_seed(payload.get("settings", {}))
+    seed = _extract_seed_from_settings(settings)
+    return {
+        "version": _DORA_STATE_MANAGER_SCHEMA_VERSION,
+        "kind": _DORA_STATE_SETTINGS_KIND,
+        "character": payload.get("character") if isinstance(payload.get("character"), dict) else {},
+        "prompt": payload.get("prompt") if isinstance(payload.get("prompt"), dict) else {},
+        "settings": settings,
+        "seed": seed,
+    }
+
+
+def _extract_seed_from_settings(settings: Any, fallback: int = 0) -> int:
+    settings_dict = _normalize_manager_settings(settings)
+
+    def _coerce(value: Any) -> Optional[int]:
+        try:
+            if isinstance(value, bool):
+                return None
+            if isinstance(value, float) and not math.isfinite(value):
+                return None
+            if isinstance(value, str) and not value.strip():
+                return None
+            n = int(float(value))
+            return max(0, min(0xFFFFFFFFFFFFFFFF, n))
+        except Exception:
+            return None
+
+    for key in ("seed", "noise_seed", "rgthree_seed"):
+        value = settings_dict.get(key)
+        if isinstance(value, dict):
+            for nested_key in ("seed", "value", "noise_seed"):
+                coerced = _coerce(value.get(nested_key))
+                if coerced is not None:
+                    return coerced
+            widgets = value.get("widgets")
+            if isinstance(widgets, dict):
+                for nested_key in ("seed", "noise_seed", "value"):
+                    coerced = _coerce(widgets.get(nested_key))
+                    if coerced is not None:
+                        return coerced
+        else:
+            coerced = _coerce(value)
+            if coerced is not None:
+                return coerced
+
+    nodes = settings_dict.get("nodes")
+    if isinstance(nodes, list):
+        for node in nodes:
+            if not isinstance(node, dict):
+                continue
+            widgets = node.get("widgets")
+            if not isinstance(widgets, dict):
+                continue
+            for key in ("seed", "noise_seed", "value"):
+                coerced = _coerce(widgets.get(key))
+                if coerced is not None:
+                    return coerced
+
+    return max(0, min(0xFFFFFFFFFFFFFFFF, int(fallback)))
+
+
+def _normalize_settings_with_canonical_seed(settings: Any) -> Dict[str, Any]:
+    settings_dict = dict(_normalize_manager_settings(settings))
+    settings_dict["seed"] = _extract_seed_from_settings(settings_dict)
+    return settings_dict
 
 def _normalize_runtime_dora_state_payload(raw: Any) -> Optional[Dict[str, Any]]:
     payload = _safe_json_load(raw, None)
@@ -3663,11 +3715,9 @@ def _build_auto_strength_stack_text_report(stack_report: Dict[str, Any]) -> str:
 
 class DoraStateManager:
     """
-    Workflow-serialized state manager for character LoRA stacks and prompt/settings presets.
-
-    Output `dora_state` can be connected to DoRA Power LoRA Loader's optional `dora_state`
-    input. When connected, the loader uses the selected character's LoRA stack and any saved
-    loader-global overrides from this manager instead of its local row widgets.
+    Workflow-serialized preset manager for character LoRA stacks, prompt templates,
+    settings, and seed state. Runtime execution is source-only and acyclic: capture/load
+    actions are explicit frontend graph edits, not execution-time input feedback.
     """
 
     @classmethod
@@ -3690,18 +3740,19 @@ class DoraStateManager:
                 ),
                 "selected_character_id": ("STRING", {"default": "default_character", "multiline": False}),
                 "selected_prompt_id": ("STRING", {"default": "default_prompt", "multiline": False}),
-                "use_runtime_inputs": ("BOOLEAN", {"default": False}),
-            },
-            "optional": {
-                "positive_prompt": ("STRING", {"forceInput": True, "multiline": True, "default": ""}),
-                "negative_prompt": ("STRING", {"forceInput": True, "multiline": True, "default": ""}),
-                "settings_json_input": ("STRING", {"forceInput": True, "multiline": True, "default": ""}),
-                "lora_stack": ("DORA_LORA_STACK",),
-            },
+            }
         }
 
-    RETURN_TYPES = ("DORA_STATE", "STRING", "STRING", "STRING", "DORA_LORA_STACK")
-    RETURN_NAMES = ("dora_state", "positive_prompt", "negative_prompt", "settings_json", "selected_lora_stack")
+    RETURN_TYPES = ("DORA_STATE", "STRING", "STRING", "STRING", "DORA_LORA_STACK", "DORA_STATE_SETTINGS", "INT")
+    RETURN_NAMES = (
+        "dora_state",
+        "positive_prompt_template",
+        "negative_prompt_template",
+        "settings_json",
+        "selected_lora_stack",
+        "state_settings",
+        "seed",
+    )
     FUNCTION = "resolve_state"
     CATEGORY = "state managers"
 
@@ -3712,26 +3763,13 @@ class DoraStateManager:
         ui_state_json: Any = "",
         selected_character_id: Any = "",
         selected_prompt_id: Any = "",
-        use_runtime_inputs: Any = False,
-        positive_prompt: Any = None,
-        negative_prompt: Any = None,
-        settings_json_input: Any = None,
-        lora_stack: Any = None,
     ):
         payload = {
             "state_json": state_json,
             "ui_state_json": ui_state_json,
             "selected_character_id": selected_character_id,
             "selected_prompt_id": selected_prompt_id,
-            "use_runtime_inputs": use_runtime_inputs,
         }
-        if _state_manager_bool(use_runtime_inputs, default=False):
-            payload.update({
-                "positive_prompt": positive_prompt,
-                "negative_prompt": negative_prompt,
-                "settings_json_input": settings_json_input,
-                "lora_stack": lora_stack,
-            })
         return json.dumps(payload, sort_keys=True, default=str)
 
     @classmethod
@@ -3741,13 +3779,8 @@ class DoraStateManager:
         ui_state_json: Any = "",
         selected_character_id: Any = "",
         selected_prompt_id: Any = "",
-        use_runtime_inputs: Any = False,
-        positive_prompt: Any = None,
-        negative_prompt: Any = None,
-        settings_json_input: Any = None,
-        lora_stack: Any = None,
     ):
-        del ui_state_json, use_runtime_inputs, positive_prompt, negative_prompt, settings_json_input, lora_stack
+        del ui_state_json
         state = _normalize_state_manager_state(state_json)
         character = _pick_state_manager_character(state, selected_character_id)
         prompt = _pick_state_manager_prompt(character, selected_prompt_id)
@@ -3763,34 +3796,29 @@ class DoraStateManager:
         ui_state_json: Any = "",
         selected_character_id: Any = "",
         selected_prompt_id: Any = "",
-        use_runtime_inputs: Any = False,
-        positive_prompt: Any = None,
-        negative_prompt: Any = None,
-        settings_json_input: Any = None,
-        lora_stack: Any = None,
     ):
         del ui_state_json
         payload = _resolve_dora_state_payload(
             state_json,
             selected_character_id,
             selected_prompt_id,
-            positive_prompt=positive_prompt,
-            negative_prompt=negative_prompt,
-            lora_stack=lora_stack,
-            settings_json_input=settings_json_input,
-            use_runtime_inputs=use_runtime_inputs,
         )
-        settings_json = json.dumps(payload.get("settings", {}), ensure_ascii=False, sort_keys=True, indent=2)
+        settings = _normalize_settings_with_canonical_seed(payload.get("settings", {}))
+        settings_json = json.dumps(settings, ensure_ascii=False, sort_keys=True, indent=2)
         lora_stack_payload = _build_lora_stack_payload(
             _manager_rows_to_lora_entries(payload.get("loras", [])),
             payload.get("loader_globals", {}),
         )
+        state_settings_payload = _build_state_settings_payload(payload)
+        seed = _extract_seed_from_settings(settings)
         return (
             payload,
             payload.get("positive_prompt", ""),
             payload.get("negative_prompt", ""),
             settings_json,
             lora_stack_payload,
+            state_settings_payload,
+            seed,
         )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "dora-dynamic-lora-loader"
 description = "A ComfyUI custom node that loads and stacks regular LoRAs and DoRA LoRAs with Flux/Flux2 and OneTrainer compatibility fixes."
-version = "1.0.23"
+version = "1.0.24"
 license = { file = "LICENSE" }
 
 [project.urls]

--- a/web/dora_power_lora_loader.js
+++ b/web/dora_power_lora_loader.js
@@ -594,6 +594,58 @@ function persistNodeState(node) {
   clearExecutionReport(node);
 }
 
+
+function normalizeExternalDoraRows(rowsIn) {
+  const rows = Array.isArray(rowsIn) ? rowsIn : [];
+  const out = rows.map((row) => {
+    const r = row && typeof row === "object" ? row : {};
+    const strengthModel = Number.isFinite(+r.strengthModel)
+      ? +r.strengthModel
+      : (Number.isFinite(+r.strength_model) ? +r.strength_model : (Number.isFinite(+r.strength) ? +r.strength : 1.0));
+    const strengthClip = Number.isFinite(+r.strengthClip)
+      ? +r.strengthClip
+      : (Number.isFinite(+r.strength_clip) ? +r.strength_clip : strengthModel);
+    return {
+      enabled: r.enabled !== undefined ? !!r.enabled : (r.on !== undefined ? !!r.on : true),
+      name: String(r.name ?? r.lora ?? r.lora_name ?? "None").trim() || "None",
+      strengthModel,
+      strengthClip,
+    };
+  });
+  return out.length ? out : [makeRowDefaults()];
+}
+
+function normalizeExternalDoraState(external) {
+  const src = external && typeof external === "object" ? external : {};
+  const rows = normalizeExternalDoraRows(src.rows ?? src.loras);
+  const globals = src.globals ?? src.loader_globals ?? {};
+  return sanitizeState({ rows, globals });
+}
+
+function installGlobalStateApi() {
+  globalThis.__doraPowerLoraLoaderApi = {
+    getState(node) {
+      return getState(node);
+    },
+    setState(node, externalState) {
+      if (!node) return false;
+      const next = normalizeExternalDoraState(externalState);
+      setState(node, next);
+      node._doraRows = next.rows;
+      node._doraGlobals = next.globals;
+      clearExecutionReport(node);
+      try {
+        rebuild(node);
+      } catch (_) {
+        try { buildUI(node, next, _cachedLoras || ["None"]); } catch (_) {}
+      }
+      node.setDirtyCanvas?.(true, true);
+      node.graph?.change?.();
+      return true;
+    },
+  };
+}
+
 function setButtonCallback(widget, cb) {
   if (!widget) return;
   widget.callback = cb;
@@ -1596,6 +1648,8 @@ function buildUI(node, state, loraValues) {
   node.size[0] = Math.max(node.size[0], size[0], minWidth);
   syncNodeHeightToContent(node);
 }
+
+installGlobalStateApi();
 
 app.registerExtension({
   name: EXT_NAME,

--- a/web/dora_state_manager.js
+++ b/web/dora_state_manager.js
@@ -4,19 +4,31 @@ import "../../scripts/domWidget.js";
 
 const EXT_NAME = "comfyui_dora_dynamic_lora.state_manager";
 const NODE_CLASS = "DoRA State Manager";
+const DORA_LOADER_CLASS = "DoRA Power LoRA Loader";
 const CUSTOM_WIDGET_INPUT = "state_manager_ui";
 const CUSTOM_WIDGET_TYPE = "DORA_STATE_MANAGER_UI";
 const STATE_WIDGET = "state_json";
 const UI_STATE_WIDGET = "ui_state_json";
 const SELECTED_CHARACTER_WIDGET = "selected_character_id";
 const SELECTED_PROMPT_WIDGET = "selected_prompt_id";
-const USE_RUNTIME_INPUTS_WIDGET = "use_runtime_inputs";
 const STYLE_ID = "dora-state-manager-style";
 const MIN_WIDGET_HEIGHT = 520;
 const MIN_NODE_WIDTH = 620;
 const MIN_NODE_HEIGHT = 680;
 const THUMBNAIL_SUBFOLDER = "dora_state_manager";
 const AUTO_STRENGTH_DEVICE_CHOICES = ["auto", "cpu", "gpu"];
+const OUTPUT_NAMES = {
+  lora: ["dora_state", "selected_lora_stack"],
+  positive: ["positive_prompt_template", "positive_prompt"],
+  negative: ["negative_prompt_template", "negative_prompt"],
+  settings: ["settings_json", "state_settings"],
+  seed: ["seed"],
+};
+const TEXT_WIDGET_NAMES = ["text", "prompt", "positive", "negative", "string", "value", "wildcard", "wildcards"];
+const POSITIVE_HINT_RE = /positive|pos|prompt/i;
+const NEGATIVE_HINT_RE = /negative|neg/i;
+const SEED_HINT_RE = /seed|noise_seed|rgthree|control_after_generate|randomize|variation|subseed/i;
+const SKIP_SETTING_NODE_RE = /clip text encode|conditioning|preview|reroute/i;
 
 function structuredCloneCompat(value) {
   if (typeof structuredClone === "function") return structuredClone(value);
@@ -79,6 +91,13 @@ function defaultUiState() {
 function normalizeNumber(value, fallback = 1.0) {
   const n = Number(value);
   return Number.isFinite(n) ? n : fallback;
+}
+
+function normalizeInteger(value, fallback = 0) {
+  if (typeof value === "boolean") return fallback;
+  const n = Number(value);
+  if (!Number.isFinite(n)) return fallback;
+  return Math.max(0, Math.min(Number.MAX_SAFE_INTEGER, Math.floor(n)));
 }
 
 function normalizeBoolean(value, fallback = false) {
@@ -227,7 +246,6 @@ function getWidgets(node) {
     uiStateWidget: map.get(UI_STATE_WIDGET),
     characterWidget: map.get(SELECTED_CHARACTER_WIDGET),
     promptWidget: map.get(SELECTED_PROMPT_WIDGET),
-    useRuntimeInputsWidget: map.get(USE_RUNTIME_INPUTS_WIDGET),
   };
 }
 
@@ -286,38 +304,35 @@ function ensureSelection(node, state) {
 }
 
 function markNodeDirty(node) {
-  node.setDirtyCanvas?.(true, true);
-  node.graph?.change?.();
+  node?.setDirtyCanvas?.(true, true);
+  node?.graph?.change?.();
 }
 
 function updateState(node, state, uiState, opts = {}) {
   const widgets = getWidgets(node);
   const normalizedState = normalizeState(state);
   const normalizedUiState = normalizeUiState(uiState || defaultUiState());
-  if (opts.status !== undefined) normalizedUiState.status = String(opts.status || "");
+  const { character, prompt } = ensureSelection(node, normalizedState);
   setWidgetValue(widgets.stateWidget, serializeState(normalizedState));
-  setWidgetValue(widgets.uiStateWidget, serializeUiState(normalizedUiState));
-  if (opts.characterId) setWidgetValue(widgets.characterWidget, opts.characterId);
-  if (opts.promptId) setWidgetValue(widgets.promptWidget, opts.promptId);
-  if (opts.useRuntimeInputs !== undefined) setWidgetValue(widgets.useRuntimeInputsWidget, Boolean(opts.useRuntimeInputs));
+  setWidgetValue(widgets.uiStateWidget, serializeUiState({ ...normalizedUiState, status: opts.status ?? normalizedUiState.status }));
+  setWidgetValue(widgets.characterWidget, opts.characterId ?? character.id);
+  setWidgetValue(widgets.promptWidget, opts.promptId ?? prompt.id);
   node.properties = node.properties || {};
   node.properties.dora_state_manager = {
     state: normalizedState,
-    ui_state: normalizedUiState,
     selected_character_id: widgetValue(widgets.characterWidget, ""),
     selected_prompt_id: widgetValue(widgets.promptWidget, ""),
-    use_runtime_inputs: Boolean(widgetValue(widgets.useRuntimeInputsWidget, false)),
   };
+  cacheRenderableState(node, normalizedState, normalizeUiState(widgetValue(widgets.uiStateWidget, "")));
   if (opts.dirty !== false) markNodeDirty(node);
-  cacheRenderableState(node, normalizedState, normalizedUiState);
   if (opts.render !== false) scheduleRender(node);
 }
 
 function cacheRenderableState(node, state, uiState) {
   const ctx = node.__dsm;
   if (!ctx) return;
-  ctx.state = state;
-  ctx.uiState = uiState;
+  ctx.state = normalizeState(state);
+  ctx.uiState = normalizeUiState(uiState);
 }
 
 function getRenderableState(node) {
@@ -330,8 +345,7 @@ function getRenderableState(node) {
 
 function setStatus(node, text) {
   const { state, uiState } = getCurrentState(node);
-  uiState.status = text;
-  updateState(node, state, uiState, { dirty: false, render: true });
+  updateState(node, state, { ...uiState, status: String(text ?? "") });
 }
 
 function getFiniteNumber(value, fallback = 0) {
@@ -342,20 +356,18 @@ function getFiniteNumber(value, fallback = 0) {
 function getWidgetOuterHeight(node, widget) {
   const nodeHeight = Math.max(MIN_NODE_HEIGHT, getFiniteNumber(node?.size?.[1], MIN_NODE_HEIGHT));
   const widgetY = Math.max(0, getFiniteNumber(widget?.y, getFiniteNumber(widget?.last_y, 0)));
-  return Math.max(MIN_WIDGET_HEIGHT, Math.floor(nodeHeight - widgetY));
+  return Math.max(MIN_WIDGET_HEIGHT, nodeHeight - widgetY - 16);
 }
 
 function syncDomWidgetSize(node, widget) {
   const ctx = node.__dsm;
-  if (!ctx || !widget) return;
+  if (!ctx?.root) return;
   const margin = Math.max(0, getFiniteNumber(widget.margin, 10));
   const outerHeight = getWidgetOuterHeight(node, widget);
   const innerHeight = Math.max(0, outerHeight - margin * 2);
   const width = Math.max(MIN_NODE_WIDTH, getFiniteNumber(node?.size?.[0], MIN_NODE_WIDTH));
-  widget.computedHeight = outerHeight;
-  widget.width = width;
+  ctx.root.style.width = `${Math.max(0, width - margin * 2)}px`;
   ctx.root.style.height = `${innerHeight}px`;
-  ctx.root.style.minHeight = `${Math.max(0, MIN_WIDGET_HEIGHT - margin * 2)}px`;
 }
 
 function scheduleRender(node) {
@@ -383,22 +395,28 @@ function isTargetNode(nodeData, nodeType) {
   return nodeName === NODE_CLASS || displayName === NODE_CLASS || comfyClass === NODE_CLASS;
 }
 
+function nodeNameText(node) {
+  return [node?.comfyClass, node?.type, node?.title, node?.constructor?.title].map((v) => String(v ?? "")).join(" ");
+}
+
 function isDoraLoaderNode(node) {
-  const values = [node?.comfyClass, node?.type, node?.title, node?.constructor?.title].map((v) => String(v ?? ""));
-  return values.some((v) => v === "DoRA Power LoRA Loader" || v.includes("DoRA Power LoRA Loader"));
+  return nodeNameText(node).includes(DORA_LOADER_CLASS);
 }
 
 function normalizeDoraLoaderState(state) {
   const st = state && typeof state === "object" ? state : {};
-  const rows = Array.isArray(st.rows) ? st.rows.map(normalizeLoraRow) : [];
+  const rowsIn = Array.isArray(st.rows) ? st.rows : Array.isArray(st.loras) ? st.loras : [];
+  const rows = rowsIn.map(normalizeLoraRow).filter((row) => row.name && row.name !== "None");
   return {
-    loras: rows.filter((row) => row.name && row.name !== "None"),
-    loader_globals: normalizeLoaderGlobals(st.globals),
+    loras: rows,
+    loader_globals: normalizeLoaderGlobals(st.globals ?? st.loader_globals),
   };
 }
 
 function extractLoraStackFromNode(sourceNode) {
   if (!sourceNode) return null;
+  const loaderApi = globalThis.__doraPowerLoraLoaderApi;
+  if (loaderApi?.getState && isDoraLoaderNode(sourceNode)) return normalizeDoraLoaderState(loaderApi.getState(sourceNode));
   if (sourceNode.properties?.dora_power_lora) return normalizeDoraLoaderState(sourceNode.properties.dora_power_lora);
   if (sourceNode._doraRows || sourceNode._doraGlobals) {
     return normalizeDoraLoaderState({ rows: sourceNode._doraRows || [], globals: sourceNode._doraGlobals || {} });
@@ -412,6 +430,26 @@ function extractLoraStackFromNode(sourceNode) {
   return null;
 }
 
+function applyLoraStackToNode(targetNode, character) {
+  if (!targetNode || !isDoraLoaderNode(targetNode)) return false;
+  const payload = { loras: character.loras || [], loader_globals: character.loader_globals || {} };
+  const loaderApi = globalThis.__doraPowerLoraLoaderApi;
+  if (loaderApi?.setState) return !!loaderApi.setState(targetNode, payload);
+
+  const rows = (payload.loras || []).map((row) => ({
+    enabled: !!row.enabled,
+    name: row.name || "None",
+    strengthModel: normalizeNumber(row.strength_model, 1.0),
+    strengthClip: normalizeNumber(row.strength_clip, normalizeNumber(row.strength_model, 1.0)),
+  }));
+  targetNode.properties = targetNode.properties || {};
+  targetNode.properties.dora_power_lora = { rows, globals: normalizeLoaderGlobals(payload.loader_globals) };
+  targetNode._doraRows = rows;
+  targetNode._doraGlobals = normalizeLoaderGlobals(payload.loader_globals);
+  markNodeDirty(targetNode);
+  return true;
+}
+
 function getSelectedGraphNodes() {
   const selected = app?.canvas?.selected_nodes;
   if (Array.isArray(selected)) return selected;
@@ -419,108 +457,404 @@ function getSelectedGraphNodes() {
   return [];
 }
 
-function getInputLink(node, inputName) {
-  const input = (node.inputs || []).find((candidate) => candidate.name === inputName);
-  if (!input || input.link == null) return null;
-  const graph = node.graph || app.graph;
-  return graph?.links?.[input.link] || null;
+function getGraph(node) {
+  return node?.graph || app.graph;
 }
 
-function getConnectedOriginNode(node, inputName) {
-  const link = getInputLink(node, inputName);
-  if (!link) return null;
-  const graph = node.graph || app.graph;
-  return graph?.getNodeById?.(link.origin_id) || null;
-}
-
-function extractTextFromNode(sourceNode) {
-  if (!sourceNode) return "";
-  const preferredNames = new Set(["text", "positive", "negative", "prompt", "string", "value"]);
-  const widgets = sourceNode.widgets || [];
-  for (const widget of widgets) {
-    if (preferredNames.has(String(widget.name ?? "").toLowerCase()) && typeof widget.value === "string") return widget.value;
+function getOutputTargets(node, outputNames) {
+  const names = new Set(outputNames);
+  const graph = getGraph(node);
+  const out = [];
+  for (const output of node.outputs || []) {
+    if (!names.has(output.name)) continue;
+    for (const linkId of output.links || []) {
+      const link = graph?.links?.[linkId];
+      if (!link) continue;
+      const targetNode = graph?.getNodeById?.(link.target_id);
+      if (!targetNode) continue;
+      const input = (targetNode.inputs || [])[link.target_slot] || null;
+      out.push({ node: targetNode, link, outputName: output.name, inputName: input?.name || "" });
+    }
   }
-  for (const widget of widgets) {
-    if (typeof widget.value === "string" && widget.value.trim()) return widget.value;
-  }
-  return "";
+  return out;
 }
 
-function captureConnectedLoraStack(node, character) {
-  const stackSource = getConnectedOriginNode(node, "lora_stack");
-  const stack = extractLoraStackFromNode(stackSource);
-  if (!stack) return false;
-  character.loras = stack.loras;
-  character.loader_globals = stack.loader_globals;
+function uniqueNodes(targets) {
+  const seen = new Set();
+  const out = [];
+  for (const target of targets) {
+    const node = target?.node || target;
+    if (!node || seen.has(node.id)) continue;
+    seen.add(node.id);
+    out.push(node);
+  }
+  return out;
+}
+
+function getWidgetMap(node) {
+  const map = new Map();
+  for (const widget of node?.widgets || []) {
+    if (!widget?.name) continue;
+    map.set(String(widget.name).toLowerCase(), widget);
+  }
+  return map;
+}
+
+function setNodeWidget(widgetNode, widget, value) {
+  if (!widget) return false;
+  widget.value = value;
+  widget.callback?.(value);
+  widgetNode?.onWidgetChanged?.(widget.name, value, widget.value, widget);
+  markNodeDirty(widgetNode);
   return true;
 }
 
-function captureSelectedLoaderStack(targetNode, character) {
-  const loader = getSelectedGraphNodes().filter((node) => node && node !== targetNode).find(isDoraLoaderNode);
-  const stack = extractLoraStackFromNode(loader);
-  if (!stack) return false;
-  character.loras = stack.loras;
-  character.loader_globals = stack.loader_globals;
-  return true;
+function isTextWidget(widget) {
+  if (!widget) return false;
+  if (typeof widget.value === "string") return true;
+  const t = String(widget.type ?? "").toLowerCase();
+  return t === "string" || t === "text" || t === "customtext";
 }
 
-function captureConnectedInputs(node, character, prompt) {
+function findTextWidget(node, role = "", inputName = "") {
+  const widgets = node?.widgets || [];
+  const hints = [];
+  const roleText = String(role || "").toLowerCase();
+  const inputText = String(inputName || "").toLowerCase();
+  if (inputText) hints.push(inputText);
+  if (roleText === "positive") hints.push("positive", "pos", "prompt");
+  if (roleText === "negative") hints.push("negative", "neg");
+  hints.push(...TEXT_WIDGET_NAMES);
+
+  for (const hint of hints) {
+    const exact = widgets.find((w) => isTextWidget(w) && String(w.name ?? "").toLowerCase() === hint);
+    if (exact) return exact;
+  }
+  for (const hint of hints) {
+    const partial = widgets.find((w) => isTextWidget(w) && `${w.name ?? ""} ${w.label ?? ""}`.toLowerCase().includes(hint));
+    if (partial) return partial;
+  }
+  return widgets.find(isTextWidget) || null;
+}
+
+function extractTextFromNode(sourceNode, role = "", inputName = "") {
+  const widget = findTextWidget(sourceNode, role, inputName);
+  return typeof widget?.value === "string" ? widget.value : "";
+}
+
+function applyTextToNode(targetNode, text, role = "", inputName = "") {
+  const widget = findTextWidget(targetNode, role, inputName);
+  return setNodeWidget(targetNode, widget, String(text ?? ""));
+}
+
+function isJsonSafeWidgetValue(value) {
+  if (value == null) return true;
+  if (["string", "number", "boolean"].includes(typeof value)) return true;
+  if (Array.isArray(value)) return value.every(isJsonSafeWidgetValue);
+  if (typeof value === "object") {
+    try {
+      const encoded = JSON.stringify(value);
+      return encoded.length < 20000;
+    } catch {
+      return false;
+    }
+  }
+  return false;
+}
+
+function nodeIdentity(node) {
+  return {
+    id: node?.id ?? null,
+    type: String(node?.type ?? ""),
+    comfyClass: String(node?.comfyClass ?? ""),
+    title: String(node?.title ?? ""),
+  };
+}
+
+function nodeIdentityKey(identity) {
+  return `${identity.comfyClass || identity.type || "?"}::${identity.title || ""}`;
+}
+
+function isSeedNode(node) {
+  const text = nodeNameText(node);
+  if (/rgthree/i.test(text) && /seed/i.test(text)) return true;
+  if (/seed/i.test(text)) return true;
+  return (node?.widgets || []).some((widget) => SEED_HINT_RE.test(`${widget?.name ?? ""} ${widget?.label ?? ""}`));
+}
+
+function isPromptLikeNode(node) {
+  const text = nodeNameText(node);
+  if (SKIP_SETTING_NODE_RE.test(text)) return true;
+  return (node?.widgets || []).some((widget) => isTextWidget(widget) && /prompt|text|positive|negative/i.test(`${widget.name ?? ""} ${widget.label ?? ""}`));
+}
+
+function captureNodeSnapshot(node) {
+  if (!node || node.comfyClass === NODE_CLASS || isDoraLoaderNode(node)) return null;
+  const widgets = {};
+  const seedWidgets = {};
+  for (const widget of node.widgets || []) {
+    if (!widget?.name) continue;
+    if (widget.serialize === false) continue;
+    if (String(widget.type ?? "").toLowerCase() === "button") continue;
+    if (!isJsonSafeWidgetValue(widget.value)) continue;
+    widgets[widget.name] = structuredCloneCompat(widget.value);
+    if (SEED_HINT_RE.test(`${widget.name ?? ""} ${widget.label ?? ""}`)) {
+      seedWidgets[widget.name] = structuredCloneCompat(widget.value);
+    }
+  }
+  if (!Object.keys(widgets).length) return null;
+  const identity = nodeIdentity(node);
+  const seed = normalizeSeedFromWidgets(widgets, null);
+  return {
+    version: 1,
+    identity,
+    key: nodeIdentityKey(identity),
+    is_seed_node: isSeedNode(node),
+    widgets,
+    seed_widgets: seedWidgets,
+    seed,
+  };
+}
+
+function normalizeSeedFromWidgets(widgets, fallback = null) {
+  if (!widgets || typeof widgets !== "object") return fallback;
+  for (const key of ["seed", "noise_seed", "value"]) {
+    if (Object.prototype.hasOwnProperty.call(widgets, key)) return normalizeInteger(widgets[key], fallback ?? 0);
+  }
+  for (const [key, value] of Object.entries(widgets)) {
+    if (/seed/i.test(key)) return normalizeInteger(value, fallback ?? 0);
+  }
+  return fallback;
+}
+
+function normalizeNodeSnapshots(raw) {
+  if (!Array.isArray(raw)) return [];
+  return raw.filter((item) => item && typeof item === "object" && item.widgets && typeof item.widgets === "object");
+}
+
+function mergeCapturedSettings(prompt, nodes, { replaceNodes = true } = {}) {
+  const settings = normalizeSettings(prompt.settings);
+  const snapshots = nodes.map(captureNodeSnapshot).filter(Boolean);
+  if (snapshots.length) {
+    if (replaceNodes) {
+      settings.nodes = snapshots;
+    } else {
+      const byKey = new Map(normalizeNodeSnapshots(settings.nodes).map((snap) => [snap.key || nodeIdentityKey(snap.identity || {}), snap]));
+      for (const snap of snapshots) byKey.set(snap.key || nodeIdentityKey(snap.identity || {}), snap);
+      settings.nodes = [...byKey.values()];
+    }
+  }
+
+  const seedSnapshot = snapshots.find((snap) => snap.is_seed_node || snap.seed != null || Object.keys(snap.seed_widgets || {}).length);
+  if (seedSnapshot) {
+    settings.seed = normalizeInteger(seedSnapshot.seed ?? normalizeSeedFromWidgets(seedSnapshot.widgets, 0), 0);
+    settings.rgthree_seed = seedSnapshot;
+  }
+  prompt.settings = settings;
+  return snapshots;
+}
+
+function nodeMatchesSnapshot(node, snapshot) {
+  if (!node || !snapshot) return false;
+  const identity = snapshot.identity || {};
+  if (identity.id != null && node.id != null && String(identity.id) === String(node.id)) return true;
+  const nodeClass = String(node.comfyClass || node.type || "");
+  const snapClass = String(identity.comfyClass || identity.type || "");
+  const nodeTitle = String(node.title || "");
+  const snapTitle = String(identity.title || "");
+  if (nodeClass && snapClass && nodeClass === snapClass && (!snapTitle || nodeTitle === snapTitle)) return true;
+  if (snapshot.key && snapshot.key === nodeIdentityKey(nodeIdentity(node))) return true;
+  return false;
+}
+
+function findSnapshotForNode(settings, node) {
+  const normalized = normalizeSettings(settings);
+  if (isSeedNode(node) && normalized.rgthree_seed) return normalized.rgthree_seed;
+  const snapshots = normalizeNodeSnapshots(normalized.nodes);
+  return snapshots.find((snap) => nodeMatchesSnapshot(node, snap)) || null;
+}
+
+function applySnapshotToNode(node, snapshot) {
+  if (!node || !snapshot?.widgets) return 0;
+  let changed = 0;
+  const widgetMap = getWidgetMap(node);
+  for (const [name, value] of Object.entries(snapshot.widgets)) {
+    const widget = widgetMap.get(String(name).toLowerCase());
+    if (!widget) continue;
+    if (setNodeWidget(node, widget, structuredCloneCompat(value))) changed += 1;
+  }
+  return changed;
+}
+
+function extractSeedFromSettings(settings) {
+  const normalized = normalizeSettings(settings);
+  if (normalized.seed != null) return normalizeInteger(normalized.seed, 0);
+  if (normalized.rgthree_seed?.seed != null) return normalizeInteger(normalized.rgthree_seed.seed, 0);
+  const widgets = normalized.rgthree_seed?.widgets;
+  const fromWidgets = normalizeSeedFromWidgets(widgets, null);
+  if (fromWidgets != null) return fromWidgets;
+  for (const snap of normalizeNodeSnapshots(normalized.nodes)) {
+    const seed = normalizeSeedFromWidgets(snap.widgets, null);
+    if (seed != null) return seed;
+  }
+  return null;
+}
+
+function applySeedToNode(node, settings) {
+  const seed = extractSeedFromSettings(settings);
+  if (seed == null) return 0;
+  const widgetMap = getWidgetMap(node);
+  let changed = 0;
+  for (const name of ["seed", "noise_seed", "value"]) {
+    const widget = widgetMap.get(name);
+    if (widget && typeof widget.value !== "boolean") {
+      if (setNodeWidget(node, widget, seed)) changed += 1;
+      return changed;
+    }
+  }
+  for (const widget of node.widgets || []) {
+    if (SEED_HINT_RE.test(`${widget?.name ?? ""} ${widget?.label ?? ""}`) && typeof widget.value !== "boolean") {
+      if (setNodeWidget(node, widget, seed)) changed += 1;
+      break;
+    }
+  }
+  return changed;
+}
+
+function applySettingsToNodes(nodes, settings) {
+  let changedNodes = 0;
+  for (const node of nodes) {
+    const snapshot = findSnapshotForNode(settings, node);
+    let changed = snapshot ? applySnapshotToNode(node, snapshot) : 0;
+    if (isSeedNode(node)) changed += applySeedToNode(node, settings);
+    if (changed > 0) changedNodes += 1;
+  }
+  return changedNodes;
+}
+
+function saveConnectedState(targetNode, character, prompt) {
   const changes = [];
-  const stackSource = getConnectedOriginNode(node, "lora_stack");
-  const stack = extractLoraStackFromNode(stackSource);
-  if (stack) {
-    character.loras = stack.loras;
-    character.loader_globals = stack.loader_globals;
+  const loaderTargets = uniqueNodes([...getOutputTargets(targetNode, OUTPUT_NAMES.lora)]).filter(isDoraLoaderNode);
+  const loaderStack = loaderTargets.map(extractLoraStackFromNode).find(Boolean);
+  if (loaderStack) {
+    character.loras = loaderStack.loras || [];
+    character.loader_globals = loaderStack.loader_globals || {};
     changes.push("LoRA stack");
   }
 
-  const positive = extractTextFromNode(getConnectedOriginNode(node, "positive_prompt"));
-  if (positive || getInputLink(node, "positive_prompt")) {
-    prompt.positive = positive;
-    changes.push("positive prompt");
+  const positiveTargets = getOutputTargets(targetNode, OUTPUT_NAMES.positive);
+  for (const target of positiveTargets) {
+    const widget = findTextWidget(target.node, "positive", target.inputName);
+    if (widget) {
+      prompt.positive = typeof widget.value === "string" ? widget.value : "";
+      changes.push("positive prompt template");
+      break;
+    }
   }
 
-  const negative = extractTextFromNode(getConnectedOriginNode(node, "negative_prompt"));
-  if (negative || getInputLink(node, "negative_prompt")) {
-    prompt.negative = negative;
-    changes.push("negative prompt");
+  const negativeTargets = getOutputTargets(targetNode, OUTPUT_NAMES.negative);
+  for (const target of negativeTargets) {
+    const widget = findTextWidget(target.node, "negative", target.inputName);
+    if (widget) {
+      prompt.negative = typeof widget.value === "string" ? widget.value : "";
+      changes.push("negative prompt template");
+      break;
+    }
   }
 
-  const settingsText = extractTextFromNode(getConnectedOriginNode(node, "settings_json_input"));
-  if (settingsText || getInputLink(node, "settings_json_input")) {
-    const parsed = normalizeSettings(settingsText);
-    prompt.settings = parsed;
-    changes.push("settings JSON");
-  }
+  const settingTargets = uniqueNodes([
+    ...getOutputTargets(targetNode, OUTPUT_NAMES.settings),
+    ...getOutputTargets(targetNode, OUTPUT_NAMES.seed),
+  ]).filter((node) => node !== targetNode && !isDoraLoaderNode(node));
+  const snapshots = mergeCapturedSettings(prompt, settingTargets, { replaceNodes: true });
+  if (snapshots.length) changes.push(`settings from ${snapshots.length} node${snapshots.length === 1 ? "" : "s"}`);
+  if (prompt.settings?.seed != null) changes.push("seed");
+  return [...new Set(changes)];
+}
 
+function applyConnectedState(targetNode, character, prompt) {
+  const changes = [];
+  const loaderTargets = uniqueNodes([...getOutputTargets(targetNode, OUTPUT_NAMES.lora)]).filter(isDoraLoaderNode);
+  let loaderChanged = 0;
+  for (const loader of loaderTargets) if (applyLoraStackToNode(loader, character)) loaderChanged += 1;
+  if (loaderChanged) changes.push(`LoRA stack to ${loaderChanged} loader${loaderChanged === 1 ? "" : "s"}`);
+
+  let posChanged = 0;
+  for (const target of getOutputTargets(targetNode, OUTPUT_NAMES.positive)) {
+    if (applyTextToNode(target.node, prompt.positive, "positive", target.inputName)) posChanged += 1;
+  }
+  if (posChanged) changes.push(`positive template to ${posChanged} node${posChanged === 1 ? "" : "s"}`);
+
+  let negChanged = 0;
+  for (const target of getOutputTargets(targetNode, OUTPUT_NAMES.negative)) {
+    if (applyTextToNode(target.node, prompt.negative, "negative", target.inputName)) negChanged += 1;
+  }
+  if (negChanged) changes.push(`negative template to ${negChanged} node${negChanged === 1 ? "" : "s"}`);
+
+  const settingTargets = uniqueNodes([
+    ...getOutputTargets(targetNode, OUTPUT_NAMES.settings),
+    ...getOutputTargets(targetNode, OUTPUT_NAMES.seed),
+  ]).filter((node) => node !== targetNode && !isDoraLoaderNode(node));
+  const settingsChanged = applySettingsToNodes(settingTargets, prompt.settings);
+  if (settingsChanged) changes.push(`settings/seed to ${settingsChanged} node${settingsChanged === 1 ? "" : "s"}`);
   return changes;
 }
 
-function captureSelectedNodes(targetNode, character, prompt) {
+function classifySelectedTextNodes(nodes) {
+  const textNodes = nodes
+    .map((node) => ({ node, text: extractTextFromNode(node), name: nodeNameText(node) }))
+    .filter((item) => item.text || findTextWidget(item.node));
+  const negative = textNodes.find((item) => NEGATIVE_HINT_RE.test(item.name));
+  const positive = textNodes.find((item) => item !== negative && POSITIVE_HINT_RE.test(item.name)) || textNodes.find((item) => item !== negative);
+  const fallbackNegative = negative || (textNodes.length >= 2 ? textNodes.find((item) => item !== positive) : null);
+  return { positive, negative: fallbackNegative, used: [positive?.node, fallbackNegative?.node].filter(Boolean) };
+}
+
+function saveSelectedState(targetNode, character, prompt) {
   const selected = getSelectedGraphNodes().filter((node) => node && node !== targetNode);
   const changes = [];
   const loader = selected.find(isDoraLoaderNode);
   const stack = extractLoraStackFromNode(loader);
   if (stack) {
-    character.loras = stack.loras;
-    character.loader_globals = stack.loader_globals;
+    character.loras = stack.loras || [];
+    character.loader_globals = stack.loader_globals || {};
     changes.push("LoRA stack");
   }
 
-  const textNodes = selected.filter((node) => node !== loader).map((node) => ({ node, text: extractTextFromNode(node) })).filter((item) => item.text);
-  const negativeCandidate = textNodes.find((item) => /negative|neg/i.test(`${item.node?.title ?? ""} ${item.node?.type ?? ""}`));
-  const positiveCandidate = textNodes.find((item) => item !== negativeCandidate);
-  if (positiveCandidate) {
-    prompt.positive = positiveCandidate.text;
-    changes.push("positive prompt");
+  const classified = classifySelectedTextNodes(selected.filter((node) => node !== loader));
+  if (classified.positive) {
+    prompt.positive = classified.positive.text;
+    changes.push("positive prompt template");
   }
-  if (negativeCandidate) {
-    prompt.negative = negativeCandidate.text;
-    changes.push("negative prompt");
-  } else if (textNodes.length >= 2) {
-    prompt.negative = textNodes[1].text;
-    changes.push("negative prompt");
+  if (classified.negative) {
+    prompt.negative = classified.negative.text;
+    changes.push("negative prompt template");
   }
+
+  const used = new Set([loader, ...classified.used].filter(Boolean));
+  const settingNodes = selected.filter((node) => !used.has(node));
+  const snapshots = mergeCapturedSettings(prompt, settingNodes, { replaceNodes: true });
+  if (snapshots.length) changes.push(`settings from ${snapshots.length} node${snapshots.length === 1 ? "" : "s"}`);
+  if (prompt.settings?.seed != null) changes.push("seed");
+  return [...new Set(changes)];
+}
+
+function applySelectedState(targetNode, character, prompt) {
+  const selected = getSelectedGraphNodes().filter((node) => node && node !== targetNode);
+  const changes = [];
+  const loaderTargets = selected.filter(isDoraLoaderNode);
+  let loaderChanged = 0;
+  for (const loader of loaderTargets) if (applyLoraStackToNode(loader, character)) loaderChanged += 1;
+  if (loaderChanged) changes.push(`LoRA stack to ${loaderChanged} loader${loaderChanged === 1 ? "" : "s"}`);
+
+  const classified = classifySelectedTextNodes(selected.filter((node) => !isDoraLoaderNode(node)));
+  if (classified.positive && applyTextToNode(classified.positive.node, prompt.positive, "positive")) changes.push("positive template");
+  if (classified.negative && applyTextToNode(classified.negative.node, prompt.negative, "negative")) changes.push("negative template");
+
+  const used = new Set([...loaderTargets, ...classified.used].filter(Boolean));
+  const settingNodes = selected.filter((node) => !used.has(node));
+  const settingsChanged = applySettingsToNodes(settingNodes, prompt.settings);
+  if (settingsChanged) changes.push(`settings/seed to ${settingsChanged} node${settingsChanged === 1 ? "" : "s"}`);
   return changes;
 }
 
@@ -538,6 +872,7 @@ async function uploadThumbnailFile(file) {
     filename,
     subfolder: String(payload?.subfolder ?? THUMBNAIL_SUBFOLDER).trim(),
     type: String(payload?.type ?? "input").trim() || "input",
+    cacheKey: String(Date.now()),
   };
 }
 
@@ -582,8 +917,8 @@ function makeSelect(values, selected, onChange) {
   const select = document.createElement("select");
   for (const value of values) {
     const option = document.createElement("option");
-    option.value = value.value ?? value;
-    option.textContent = value.label ?? value;
+    option.value = typeof value === "object" ? value.value : value;
+    option.textContent = typeof value === "object" ? value.label : value;
     select.appendChild(option);
   }
   select.value = selected;
@@ -602,8 +937,7 @@ function labelledControl(labelText, control) {
 
 function setPanel(node, panel) {
   const { state, uiState } = getCurrentState(node);
-  uiState.panel = panel;
-  updateState(node, state, uiState, { dirty: false });
+  updateState(node, state, { ...uiState, panel });
 }
 
 function renderCharacterTile(node, state, uiState, character, selectedId) {
@@ -619,25 +953,23 @@ function renderCharacterTile(node, state, uiState, character, selectedId) {
     img.alt = character.name;
     thumb.appendChild(img);
   } else {
-    const initials = character.name.trim().slice(0, 2).toUpperCase() || "?";
-    thumb.textContent = initials;
+    thumb.textContent = character.name.trim().slice(0, 2).toUpperCase() || "?";
   }
   const name = document.createElement("div");
   name.className = "dsm-character-name";
   name.textContent = character.name;
   const meta = document.createElement("div");
   meta.className = "dsm-muted";
-  meta.textContent = `${character.loras.length} LoRA${character.loras.length === 1 ? "" : "s"} · ${character.prompts.length} preset${character.prompts.length === 1 ? "" : "s"}`;
+  meta.textContent = `${character.loras.filter((row) => row.enabled && row.name !== "None").length} LoRA · ${character.prompts.length} preset${character.prompts.length === 1 ? "" : "s"}`;
   tile.append(thumb, name, meta);
   tile.addEventListener("click", () => {
     const promptId = character.prompts[0]?.id || "";
-    updateState(node, state, uiState, { characterId: character.id, promptId });
+    updateState(node, state, uiState, { characterId: character.id, promptId, status: `Selected ${character.name}. Use Load/Apply to push it into connected nodes.` });
   });
   return tile;
 }
 
 function renderHeader(node, state, uiState, character, prompt) {
-  const widgets = getWidgets(node);
   const section = document.createElement("div");
   section.className = "dsm-section dsm-top";
 
@@ -647,29 +979,40 @@ function renderHeader(node, state, uiState, character, prompt) {
   title.className = "dsm-title";
   title.textContent = "DoRA State Manager";
 
-  const liveInputs = makeCheckbox(Boolean(widgetValue(widgets.useRuntimeInputsWidget, false)), (checked) => {
-    updateState(node, state, uiState, { useRuntimeInputs: checked, status: checked ? "Runtime inputs override saved state during execution." : "Saved state drives execution." });
-  });
-
   toolbar.append(
     title,
-    makeButton("Capture connected", () => {
-      const changes = captureConnectedInputs(node, character, prompt);
+    makeButton("Save connected", () => {
+      const changes = saveConnectedState(node, character, prompt);
       updateState(node, state, uiState, {
         characterId: character.id,
         promptId: prompt.id,
-        status: changes.length ? `Captured ${changes.join(", ")} from connected inputs.` : "No connected prompt/lora inputs found.",
+        status: changes.length ? `Saved ${changes.join(", ")} from connected nodes.` : "No connected downstream nodes had capturable state.",
       });
-    }, "Capture positive/negative/settings/lora_stack inputs into the selected character/preset"),
-    makeButton("Capture selected nodes", () => {
-      const changes = captureSelectedNodes(node, character, prompt);
+    }, "Capture current values from nodes connected to this manager's outputs"),
+    makeButton("Load connected", () => {
+      const changes = applyConnectedState(node, character, prompt);
       updateState(node, state, uiState, {
         characterId: character.id,
         promptId: prompt.id,
-        status: changes.length ? `Captured ${changes.join(", ")} from selected graph nodes.` : "Select a DoRA loader and/or text nodes first.",
+        status: changes.length ? `Loaded ${changes.join(", ")} into connected nodes.` : "No connected downstream nodes accepted this state.",
       });
-    }, "Read the selected DoRA Power LoRA Loader and selected text nodes from the graph"),
-    labelledControl("Runtime override", liveInputs)
+    }, "Push the selected character/preset into nodes connected to this manager's outputs"),
+    makeButton("Save selected", () => {
+      const changes = saveSelectedState(node, character, prompt);
+      updateState(node, state, uiState, {
+        characterId: character.id,
+        promptId: prompt.id,
+        status: changes.length ? `Saved ${changes.join(", ")} from selected nodes.` : "Select a loader, text, seed, or settings node first.",
+      });
+    }, "Capture selected graph nodes into the current character/preset"),
+    makeButton("Apply selected", () => {
+      const changes = applySelectedState(node, character, prompt);
+      updateState(node, state, uiState, {
+        characterId: character.id,
+        promptId: prompt.id,
+        status: changes.length ? `Applied ${changes.join(", ")} to selected nodes.` : "Selected nodes did not match this state.",
+      });
+    }, "Apply the current character/preset to selected graph nodes")
   );
 
   const grid = document.createElement("div");
@@ -797,7 +1140,7 @@ function renderPromptPanel(node, state, uiState, character, prompt) {
 
   const tabs = document.createElement("div");
   tabs.className = "dsm-tabs";
-  for (const [panel, label] of [["prompts", "Prompts"], ["loras", "LoRA stack"], ["settings", "Settings"]]) {
+  for (const [panel, label] of [["prompts", "Prompts"], ["loras", "LoRA stack"], ["settings", "Settings/seed"]]) {
     const btn = makeButton(label, () => setPanel(node, panel));
     if (uiState.panel === panel) btn.classList.add("selected");
     tabs.appendChild(btn);
@@ -825,7 +1168,7 @@ function renderPromptPanelContent(section, node, state, uiState, character, prom
   const header = document.createElement("div");
   header.className = "dsm-toolbar";
   const select = makeSelect(character.prompts.map((p) => ({ value: p.id, label: p.name })), prompt.id, (id) => {
-    updateState(node, state, uiState, { characterId: character.id, promptId: id });
+    updateState(node, state, uiState, { characterId: character.id, promptId: id, status: "Selected prompt preset. Use Load/Apply to push it into graph nodes." });
   });
   select.className = "dsm-flex";
   header.append(
@@ -862,27 +1205,34 @@ function renderPromptPanelContent(section, node, state, uiState, character, prom
   const positive = makeTextarea(prompt.positive, (value) => {
     prompt.positive = value;
     updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id, render: false });
-  }, { placeholder: "Positive prompt" });
+  }, { placeholder: "Positive prompt template. Wildcards stay here and expand downstream." });
 
   const negative = makeTextarea(prompt.negative, (value) => {
     prompt.negative = value;
     updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id, render: false });
-  }, { placeholder: "Negative prompt" });
+  }, { placeholder: "Negative prompt template. Wildcards stay here and expand downstream." });
 
-  section.append(header, labelledControl("Preset name", name), labelledControl("Positive", positive), labelledControl("Negative", negative));
+  section.append(header, labelledControl("Preset name", name), labelledControl("Positive template", positive), labelledControl("Negative template", negative));
 }
 
 function renderLoraPanelContent(section, node, state, uiState, character, prompt) {
   const header = document.createElement("div");
   header.className = "dsm-toolbar";
   header.append(
-    makeButton("Capture connected", () => {
-      const changed = captureConnectedLoraStack(node, character);
-      updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id, status: changed ? "Captured LoRA stack from connected input." : "No connected lora_stack input found." });
+    makeButton("Save connected loader", () => {
+      const loaders = uniqueNodes(getOutputTargets(node, OUTPUT_NAMES.lora)).filter(isDoraLoaderNode);
+      const stack = loaders.map(extractLoraStackFromNode).find(Boolean);
+      if (stack) {
+        character.loras = stack.loras;
+        character.loader_globals = stack.loader_globals;
+      }
+      updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id, status: stack ? "Saved LoRA stack from connected loader." : "No connected DoRA loader found." });
     }),
-    makeButton("Capture selected loader", () => {
-      const changed = captureSelectedLoaderStack(node, character);
-      updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id, status: changed ? "Captured LoRA stack from selected DoRA loader." : "Select a DoRA Power LoRA Loader first." });
+    makeButton("Apply connected loader", () => {
+      const loaders = uniqueNodes(getOutputTargets(node, OUTPUT_NAMES.lora)).filter(isDoraLoaderNode);
+      let count = 0;
+      for (const loader of loaders) if (applyLoraStackToNode(loader, character)) count += 1;
+      updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id, status: count ? `Applied LoRA stack to ${count} connected loader${count === 1 ? "" : "s"}.` : "No connected DoRA loader accepted the stack." });
     }),
     makeButton("Add manual row", () => {
       character.loras.push({ enabled: true, name: "None", strength_model: 1.0, strength_clip: 1.0 });
@@ -894,7 +1244,7 @@ function renderLoraPanelContent(section, node, state, uiState, character, prompt
   if (!character.loras.length) {
     const empty = document.createElement("div");
     empty.className = "dsm-muted";
-    empty.textContent = "No LoRA stack saved. Capture an existing DoRA loader or connect a lora_stack input.";
+    empty.textContent = "No LoRA stack saved. Save a connected/selected DoRA loader or add manual rows.";
     section.appendChild(empty);
     return;
   }
@@ -975,19 +1325,61 @@ function renderSettingsPanelContent(section, node, state, uiState, character, pr
     labelledControl("AdaLN swap fix", adalnFix)
   );
 
+  const seedValue = extractSeedFromSettings(prompt.settings) ?? 0;
+  const seedInput = makeInput(seedValue, (value) => {
+    const settings = normalizeSettings(prompt.settings);
+    settings.seed = normalizeInteger(value, 0);
+    if (settings.rgthree_seed?.widgets) settings.rgthree_seed.widgets.seed = settings.seed;
+    if (settings.rgthree_seed) settings.rgthree_seed.seed = settings.seed;
+    prompt.settings = settings;
+    updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id });
+  }, { type: "number", step: "1", min: "0" });
+
   const settingsJson = makeTextarea(JSON.stringify(prompt.settings || {}, null, 2), (value) => {
     const parsed = safeJsonParse(value, null);
     if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
       prompt.settings = parsed;
       updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id, render: false });
     }
-  }, { placeholder: "Prompt/settings JSON for future nodes" });
+  }, { placeholder: "Saved node settings JSON. Save connected/selected nodes to populate this." });
   settingsJson.addEventListener("change", () => {
     settingsJson.value = JSON.stringify(prompt.settings || {}, null, 2);
     updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id });
   });
 
-  section.append(grid, labelledControl("Prompt/settings JSON", settingsJson));
+  const snapshots = normalizeNodeSnapshots(prompt.settings?.nodes);
+  const summary = document.createElement("div");
+  summary.className = "dsm-lora-summary";
+  const seed = extractSeedFromSettings(prompt.settings);
+  const lines = [];
+  if (seed != null) lines.push(`Seed: ${seed}`);
+  if (prompt.settings?.rgthree_seed) lines.push("rgthree seed snapshot: yes");
+  if (snapshots.length) {
+    lines.push(`Captured settings nodes: ${snapshots.length}`);
+    lines.push(...snapshots.slice(0, 12).map((snap) => `- ${snap.identity?.title || snap.identity?.comfyClass || snap.identity?.type || snap.key || "node"}`));
+  }
+  summary.textContent = lines.length ? lines.join("\n") : "No saved settings/seed snapshots. Use Save connected or Save selected.";
+
+  const settingsToolbar = document.createElement("div");
+  settingsToolbar.className = "dsm-toolbar";
+  settingsToolbar.append(
+    makeButton("Clear settings", () => {
+      prompt.settings = {};
+      updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id, status: "Cleared prompt settings and seed." });
+    }),
+    makeButton("Save selected settings", () => {
+      const selected = getSelectedGraphNodes().filter((target) => target && target !== node && !isDoraLoaderNode(target) && !isPromptLikeNode(target));
+      const snapshots = mergeCapturedSettings(prompt, selected, { replaceNodes: true });
+      updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id, status: snapshots.length ? `Saved ${snapshots.length} selected settings node${snapshots.length === 1 ? "" : "s"}.` : "No selected settings/seed nodes found." });
+    }),
+    makeButton("Apply selected settings", () => {
+      const selected = getSelectedGraphNodes().filter((target) => target && target !== node && !isDoraLoaderNode(target));
+      const count = applySettingsToNodes(selected, prompt.settings);
+      updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id, status: count ? `Applied settings/seed to ${count} selected node${count === 1 ? "" : "s"}.` : "No selected node matched the saved settings." });
+    })
+  );
+
+  section.append(grid, labelledControl("Seed output / saved seed", seedInput), settingsToolbar, labelledControl("Settings summary", summary), labelledControl("Settings JSON", settingsJson));
 }
 
 function renderNode(node) {
@@ -1078,7 +1470,7 @@ function initializeNode(node, widget) {
   node.resizable = true;
 
   const widgets = getWidgets(node);
-  for (const hidden of [widgets.stateWidget, widgets.uiStateWidget, widgets.characterWidget, widgets.promptWidget, widgets.useRuntimeInputsWidget]) hideWidget(hidden);
+  for (const hidden of [widgets.stateWidget, widgets.uiStateWidget, widgets.characterWidget, widgets.promptWidget]) hideWidget(hidden);
 
   const oldSize = node.size || [MIN_NODE_WIDTH, MIN_NODE_HEIGHT];
   node.min_size = [MIN_NODE_WIDTH, MIN_NODE_HEIGHT];


### PR DESCRIPTION
## Summary

- Removes recursive runtime inputs from DoRA State Manager so execution is source-only and acyclic.
- Renames prompt outputs to template outputs and adds Pattern 1 outputs for `settings_json`, typed `state_settings`, and `seed`.
- Adds explicit frontend Save/Load/Apply selected/connected flows, rgthree/seed snapshot handling, and a DoRA loader JS API for replacing saved LoRA stacks in the loader UI.
- Updates README guidance and bumps the package version to `1.0.24`.

## Why

The State Manager should store saved prompt templates and state, while wildcard expansion and other runtime processing happen downstream. This avoids feeding processed prompts or runtime node state back into the manager during execution.

## Validation

- `python3 -m py_compile nodes.py`
- `node --check web/dora_state_manager.js`
- `node --check web/dora_power_lora_loader.js`

No repository tests were run per instruction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * DoRA State Manager now outputs state settings and seed values.
  * New state API for DoRA Power LoRA Loader for external state management.

* **Documentation**
  * Expanded DoRA State Manager documentation covering state separation, graph wiring, and output types.

* **Improvements**
  * Enhanced DoRA State Manager UI with improved state capture/apply, LoRA loader integration, and user feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->