### PR TITLE
Add state manager control nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,38 @@ Auto-strength support in this loader was inspired by [Comfyui-flux2klein-Lora-lo
 
 This implementation was reworked for the unified DoRA + standard LoRA path in this loader, including Flux.2 Klein and ZiT/Lumina2 compatibility handling.
 
+
+---
+
+## State Manager
+
+This package also includes a **State Manager** for character/preset workflows.
+
+The manager is designed as a save/load/apply controller, not as a permanent prompt or seed runtime source. The safe connected workflow is:
+
+```text
+State Manager.state_control -> State Text Box.state_control
+State Manager.state_control -> State Seed.state_control
+State Manager.state_control -> DoRA Power LoRA Loader.state_control
+
+State Text Box.text -> wildcard processor / CLIP Text Encode
+State Seed.seed -> sampler seed input
+DoRA Power LoRA Loader -> model/clip path
+```
+
+Use the manager buttons to mutate graph nodes explicitly:
+
+- **Save connected** captures the connected State Text Box, State Seed, DoRA loader, and supported settings nodes into the selected character/preset.
+- **Load connected** applies the selected character/preset back into those connected editable nodes.
+- **Save selected** captures currently selected nodes.
+- **Apply selected** applies the selected character/preset to currently selected nodes.
+
+The prompt templates live in editable **State Text Box** nodes. The seed lives in an editable **State Seed** node. Connecting `state_control` only identifies those nodes for save/load; it does not replace their editable values during execution.
+
+For wildcard workflows, save the unexpanded template in the State Text Box and put the wildcard processor downstream. Do not feed the processed wildcard text back into the State Manager.
+
+rgthree and other seed nodes are supported through **Save selected / Apply selected** and through generic widget snapshots where their seed widgets are available. For connected save/load without runtime replacement, use **State Seed**.
+
 ---
 
 ## Auto-strength

--- a/README.md
+++ b/README.md
@@ -17,38 +17,6 @@ Auto-strength support in this loader was inspired by [Comfyui-flux2klein-Lora-lo
 
 This implementation was reworked for the unified DoRA + standard LoRA path in this loader, including Flux.2 Klein and ZiT/Lumina2 compatibility handling.
 
-
----
-
-## State Manager
-
-This package also includes a **State Manager** for character/preset workflows.
-
-The manager is designed as a save/load/apply controller, not as a permanent prompt or seed runtime source. The safe connected workflow is:
-
-```text
-State Manager.state_control -> State Text Box.state_control
-State Manager.state_control -> State Seed.state_control
-State Manager.state_control -> DoRA Power LoRA Loader.state_control
-
-State Text Box.text -> wildcard processor / CLIP Text Encode
-State Seed.seed -> sampler seed input
-DoRA Power LoRA Loader -> model/clip path
-```
-
-Use the manager buttons to mutate graph nodes explicitly:
-
-- **Save connected** captures the connected State Text Box, State Seed, DoRA loader, and supported settings nodes into the selected character/preset.
-- **Load connected** applies the selected character/preset back into those connected editable nodes.
-- **Save selected** captures currently selected nodes.
-- **Apply selected** applies the selected character/preset to currently selected nodes.
-
-The prompt templates live in editable **State Text Box** nodes. The seed lives in an editable **State Seed** node. Connecting `state_control` only identifies those nodes for save/load; it does not replace their editable values during execution.
-
-For wildcard workflows, save the unexpanded template in the State Text Box and put the wildcard processor downstream. Do not feed the processed wildcard text back into the State Manager.
-
-rgthree and other seed nodes are supported through **Save selected / Apply selected** and through generic widget snapshots where their seed widgets are available. For connected save/load without runtime replacement, use **State Seed**.
-
 ---
 
 ## Auto-strength
@@ -535,15 +503,16 @@ This repo is meant for cases where plain ComfyUI LoRA loading is not enough, esp
 
 ---
 
-## DoRA State Manager
+## State Manager
 
-This build adds a **DoRA State Manager** node for workflow-serialized character states.
+This build adds a **State Manager** node for workflow-serialized character states. Workflows made with the older **DoRA State Manager** node name remain supported through a legacy alias.
 
 The manager separates **saved state** from **runtime execution**:
 
 - execution outputs are source-only and acyclic
 - save/load/apply actions are explicit frontend graph edits
-- no prompt, LoRA stack, settings, or seed value is captured through runtime feedback inputs
+- `state_control` links are editor/control-only and do not replace prompt text, seed values, or LoRA rows during execution
+- no prompt, LoRA stack, settings, or seed value is captured through runtime feedback inputs or wildcard feedback loops
 
 Use it to save:
 
@@ -555,20 +524,26 @@ Use it to save:
 
 ### Basic wiring
 
-Recommended one-way wiring:
+Recommended connected save/load wiring:
 
-1. Add **DoRA State Manager**.
-2. Add **DoRA Power LoRA Loader**.
-3. Connect `dora_state` from the manager to the loader's optional `dora_state` input.
-4. Connect `positive_prompt_template` and `negative_prompt_template` into the prompt/wildcard path.
-5. Connect `settings_json`, `state_settings`, or `seed` only to downstream nodes that explicitly consume them.
+1. Add **State Manager**.
+2. Add **State Text Box** nodes for editable positive and negative prompt templates.
+3. Add **State Seed** for an editable seed value.
+4. Add **DoRA Power LoRA Loader**.
+5. Connect `state_control` from the manager to each helper node's optional `state_control` input.
+6. Connect `text` from each State Text Box into the prompt/wildcard path.
+7. Connect `seed` from State Seed only to the sampler seed input.
+8. Configure LoRA rows on the DoRA Power LoRA Loader as usual.
 
-The manager should not receive the processed wildcard prompt. Store the wildcard/template prompt in the manager, then let your wildcard node expand it downstream.
+The manager should not receive processed wildcard, prompt-generation, or other runtime text outputs. Store the wildcard/template prompt in State Text Box, then let your wildcard node expand it downstream.
 
 Correct shape:
 
 ```text
-DoRA State Manager positive_prompt_template
+State Manager.state_control
+  -> State Text Box.state_control
+
+State Text Box.text
   -> Wildcards Processor
       -> CLIP Text Encode
 ```
@@ -581,18 +556,30 @@ Wildcards Processor output
   -> Wildcards Processor input
 ```
 
-The state manager no longer exposes runtime capture inputs, so this cycle is not part of the node design.
+The state manager no longer exposes runtime capture inputs, so this cycle is not part of the node design. Do not wire wildcard or prompt-processing output back into State Manager.
+
+The older runtime-output path is still available for workflows that intentionally want the manager to drive execution:
+
+```text
+State Manager.dora_state -> DoRA Power LoRA Loader.dora_state
+State Manager.positive_prompt_template -> prompt/wildcard path
+State Manager.negative_prompt_template -> prompt/wildcard path
+```
+
+Do not use that runtime path as the replacement for connected save/load. For editable prompt and seed values that survive normal execution, use `state_control` plus State Text Box / State Seed.
 
 ### Save / load / apply workflow
 
 The UI has four graph-editing actions:
 
-- **Save connected** — captures state from nodes connected downstream of the manager outputs.
-- **Load connected** — pushes the selected character/preset into connected downstream nodes.
+- **Save connected** — captures state from nodes connected downstream of `state_control`.
+- **Load connected** — pushes the selected character/preset into nodes connected downstream of `state_control`.
 - **Save selected** — captures state from selected graph nodes.
 - **Apply selected** — pushes the selected character/preset into selected graph nodes.
 
 Selecting a character tile or prompt preset only changes the manager selection. It does not mutate other nodes until **Load connected** or **Apply selected** is clicked.
+
+For older workflows that do not have `state_control` links, the frontend keeps a compatibility fallback that can inspect legacy runtime output links. Treat that as migration support, not the canonical wiring for new graphs.
 
 ### Pattern 1: deterministic downstream settings
 
@@ -601,8 +588,9 @@ The manager outputs:
 - `settings_json` — selected prompt preset settings as JSON text
 - `state_settings` — typed `DORA_STATE_SETTINGS` payload
 - `seed` — integer seed extracted from saved settings / rgthree seed snapshots
+- `state_control` — typed `STATE_MANAGER_CONTROL` payload used only by the frontend to discover connected nodes for Save connected / Load connected
 
-Future or external nodes can add optional inputs for one of these outputs to consume saved state deterministically during execution.
+Future or external nodes can add optional inputs for `settings_json`, `state_settings`, or `seed` to consume saved state deterministically during execution. `state_control` is reserved for editor save/load association.
 
 ### Pattern 2: frontend apply/capture
 
@@ -623,6 +611,7 @@ The settings snapshot stores widget values by node identity and class/title fall
 - `selected_lora_stack` — selected character's LoRA stack as a typed `DORA_LORA_STACK` payload
 - `state_settings` — typed `DORA_STATE_SETTINGS` payload for future compatible nodes
 - `seed` — integer seed extracted from saved settings / rgthree seed snapshots
+- `state_control` — typed `STATE_MANAGER_CONTROL` payload for editor/control-only save/load association
 
 ### Persistence and payload behavior
 

--- a/__init__.py
+++ b/__init__.py
@@ -1,4 +1,4 @@
-from .nodes import DoraPowerLoraLoader, DoraStateManager
+from .nodes import DoraPowerLoraLoader, DoraStateManager, StateManager, StateManagerSeed, StateManagerTextBox
 
 # Backend API for frontend LoRA dropdown (avoids relying on /object_info variants).
 import folder_paths
@@ -17,10 +17,17 @@ WEB_DIRECTORY = "./web"
 
 NODE_CLASS_MAPPINGS = {
     "DoRA Power LoRA Loader": DoraPowerLoraLoader,
+    "State Manager": StateManager,
+    "State Manager Text Box": StateManagerTextBox,
+    "State Manager Seed": StateManagerSeed,
+    # Backward-compatible alias for workflows made with the earlier patch.
     "DoRA State Manager": DoraStateManager,
 }
 
 NODE_DISPLAY_NAME_MAPPINGS = {
     "DoRA Power LoRA Loader": "DoRA Power LoRA Loader",
-    "DoRA State Manager": "DoRA State Manager",
+    "State Manager": "State Manager",
+    "State Manager Text Box": "State Text Box",
+    "State Manager Seed": "State Seed",
+    "DoRA State Manager": "State Manager (legacy)",
 }

--- a/nodes.py
+++ b/nodes.py
@@ -438,6 +438,7 @@ _DORA_STATE_MANAGER_SCHEMA_VERSION = 1
 _DORA_STATE_KIND = "dora_state_manager_state"
 _DORA_LORA_STACK_KIND = "dora_lora_stack"
 _DORA_STATE_SETTINGS_KIND = "dora_state_settings"
+_STATE_MANAGER_CONTROL_KIND = "state_manager_control"
 _DORA_STATE_LOADER_GLOBAL_KEYS: Set[str] = {
     "stack_enabled",
     "verbose",
@@ -830,6 +831,22 @@ def _build_state_settings_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
         "prompt": payload.get("prompt") if isinstance(payload.get("prompt"), dict) else {},
         "settings": settings,
         "seed": seed,
+    }
+
+
+def _build_state_control_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
+    # Editor/control token only. The State Manager frontend uses a connected
+    # STATE_MANAGER_CONTROL edge as a safe save/load relationship. It is not a
+    # prompt, seed, or LoRA runtime override.
+    character = payload.get("character") if isinstance(payload.get("character"), dict) else {}
+    prompt = payload.get("prompt") if isinstance(payload.get("prompt"), dict) else {}
+    return {
+        "version": _DORA_STATE_MANAGER_SCHEMA_VERSION,
+        "kind": _STATE_MANAGER_CONTROL_KIND,
+        "character": character,
+        "prompt": prompt,
+        "selected_character_id": character.get("id", ""),
+        "selected_prompt_id": prompt.get("id", ""),
     }
 
 
@@ -3713,7 +3730,7 @@ def _build_auto_strength_stack_text_report(stack_report: Dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
-class DoraStateManager:
+class StateManager:
     """
     Workflow-serialized preset manager for character LoRA stacks, prompt templates,
     settings, and seed state. Runtime execution is source-only and acyclic: capture/load
@@ -3743,7 +3760,7 @@ class DoraStateManager:
             }
         }
 
-    RETURN_TYPES = ("DORA_STATE", "STRING", "STRING", "STRING", "DORA_LORA_STACK", "DORA_STATE_SETTINGS", "INT")
+    RETURN_TYPES = ("DORA_STATE", "STRING", "STRING", "STRING", "DORA_LORA_STACK", "DORA_STATE_SETTINGS", "INT", "STATE_MANAGER_CONTROL")
     RETURN_NAMES = (
         "dora_state",
         "positive_prompt_template",
@@ -3752,6 +3769,7 @@ class DoraStateManager:
         "selected_lora_stack",
         "state_settings",
         "seed",
+        "state_control",
     )
     FUNCTION = "resolve_state"
     CATEGORY = "state managers"
@@ -3785,9 +3803,9 @@ class DoraStateManager:
         character = _pick_state_manager_character(state, selected_character_id)
         prompt = _pick_state_manager_prompt(character, selected_prompt_id)
         if not character:
-            return "DoRA State Manager: no character states are available."
+            return "State Manager: no character states are available."
         if not prompt:
-            return "DoRA State Manager: no prompt states are available for the selected character."
+            return "State Manager: no prompt states are available for the selected character."
         return True
 
     def resolve_state(
@@ -3810,6 +3828,7 @@ class DoraStateManager:
             payload.get("loader_globals", {}),
         )
         state_settings_payload = _build_state_settings_payload(payload)
+        state_control_payload = _build_state_control_payload(payload)
         seed = _extract_seed_from_settings(settings)
         return (
             payload,
@@ -3819,7 +3838,81 @@ class DoraStateManager:
             lora_stack_payload,
             state_settings_payload,
             seed,
+            state_control_payload,
         )
+
+
+class StateManagerTextBox:
+    """Editable prompt/text node controlled by State Manager save/load actions.
+
+    The state_control input is intentionally ignored during execution. It gives
+    the State Manager frontend a safe non-STRING edge to discover this node for
+    Save connected / Load connected without replacing the editable text widget.
+    """
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "role": (["positive", "negative", "generic"], {"default": "positive"}),
+                "text": ("STRING", {"default": "", "multiline": True}),
+            },
+            "optional": {
+                "state_control": ("STATE_MANAGER_CONTROL",),
+            },
+        }
+
+    RETURN_TYPES = ("STRING",)
+    RETURN_NAMES = ("text",)
+    FUNCTION = "emit"
+    CATEGORY = "state managers"
+
+    @classmethod
+    def IS_CHANGED(cls, role: Any, text: Any, state_control: Any = None):
+        del state_control
+        return json.dumps({"role": str(role), "text": str(text)}, ensure_ascii=False, sort_keys=True)
+
+    def emit(self, role: Any, text: Any, state_control: Any = None):
+        del role, state_control
+        return (str(text or ""),)
+
+
+class StateManagerSeed:
+    """Editable seed node controlled by State Manager save/load actions.
+
+    Widget names mirror common ComfyUI/rgthree seed widgets so the frontend can
+    capture/apply seed and control-after-generate state consistently.
+    """
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "seed": ("INT", {"default": 0, "min": 0, "max": 0xffffffffffffffff, "step": 1}),
+                "control_after_generate": (["fixed", "increment", "decrement", "randomize"], {"default": "fixed"}),
+            },
+            "optional": {
+                "state_control": ("STATE_MANAGER_CONTROL",),
+            },
+        }
+
+    RETURN_TYPES = ("INT",)
+    RETURN_NAMES = ("seed",)
+    FUNCTION = "emit"
+    CATEGORY = "state managers"
+
+    @classmethod
+    def IS_CHANGED(cls, seed: Any, control_after_generate: Any = "fixed", state_control: Any = None):
+        del state_control
+        return json.dumps({"seed": int(seed), "control_after_generate": str(control_after_generate)}, sort_keys=True)
+
+    def emit(self, seed: Any, control_after_generate: Any = "fixed", state_control: Any = None):
+        del control_after_generate, state_control
+        return (int(seed),)
+
+
+# Backward-compatible class alias for workflows created with the earlier name.
+DoraStateManager = StateManager
 
 
 class DoraPowerLoraLoader:
@@ -3842,9 +3935,14 @@ class DoraPowerLoraLoader:
             "optional": FlexibleOptionalInputType(
                 any_type,
                 data={
-                    # Optional state-manager input. When connected, this overrides local LoRA rows
+                    # Optional runtime state-manager input. When connected, this overrides local LoRA rows
                     # and any saved loader-global settings in the manager payload.
+                    # Prefer state_control for save/load-only graph-editor workflows.
                     "dora_state": ("DORA_STATE",),
+
+                    # Editor-only relationship used by State Manager Save/Load connected.
+                    # Ignored by backend execution.
+                    "state_control": ("STATE_MANAGER_CONTROL",),
 
                     # Flux2 modulation handling
                     "broadcast_modulations": ("BOOLEAN", {"default": True}),
@@ -4134,6 +4232,9 @@ class DoraPowerLoraLoader:
         return model, clip, auto_strength_report
 
     def load_loras(self, model, clip, **kwargs):
+        # Editor-only relationship token for State Manager save/load discovery.
+        # It must not participate in runtime LoRA row or settings resolution.
+        kwargs.pop("state_control", None)
         state_payload = _normalize_runtime_dora_state_payload(kwargs.get("dora_state"))
 
         # Global controls (provided by JS UI; optionally overridden by DoRA State Manager)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "dora-dynamic-lora-loader"
 description = "A ComfyUI custom node that loads and stacks regular LoRAs and DoRA LoRAs with Flux/Flux2 and OneTrainer compatibility fixes."
-version = "1.0.24"
+version = "1.0.25"
 license = { file = "LICENSE" }
 
 [project.urls]

--- a/web/dora_state_manager.js
+++ b/web/dora_state_manager.js
@@ -3,8 +3,13 @@ import { api } from "../../scripts/api.js";
 import "../../scripts/domWidget.js";
 
 const EXT_NAME = "comfyui_dora_dynamic_lora.state_manager";
-const NODE_CLASS = "DoRA State Manager";
+const NODE_CLASS = "State Manager";
+const LEGACY_NODE_CLASS = "DoRA State Manager";
 const DORA_LOADER_CLASS = "DoRA Power LoRA Loader";
+const STATE_TEXT_CLASS = "State Manager Text Box";
+const STATE_TEXT_DISPLAY_CLASS = "State Text Box";
+const STATE_SEED_CLASS = "State Manager Seed";
+const STATE_SEED_DISPLAY_CLASS = "State Seed";
 const CUSTOM_WIDGET_INPUT = "state_manager_ui";
 const CUSTOM_WIDGET_TYPE = "DORA_STATE_MANAGER_UI";
 const STATE_WIDGET = "state_json";
@@ -18,6 +23,10 @@ const MIN_NODE_HEIGHT = 680;
 const THUMBNAIL_SUBFOLDER = "dora_state_manager";
 const AUTO_STRENGTH_DEVICE_CHOICES = ["auto", "cpu", "gpu"];
 const OUTPUT_NAMES = {
+  control: ["state_control"],
+  // Legacy/runtime outputs remain readable for compatibility, but Save/Load connected
+  // should primarily use the control edge so editable prompt/seed widgets are not
+  // replaced by linked runtime values.
   lora: ["dora_state", "selected_lora_stack"],
   positive: ["positive_prompt_template", "positive_prompt"],
   negative: ["negative_prompt_template", "negative_prompt"],
@@ -392,7 +401,7 @@ function isTargetNode(nodeData, nodeType) {
   const nodeName = nodeData?.name ?? "";
   const displayName = nodeData?.display_name ?? "";
   const comfyClass = nodeType?.comfyClass ?? "";
-  return nodeName === NODE_CLASS || displayName === NODE_CLASS || comfyClass === NODE_CLASS;
+  return [nodeName, displayName, comfyClass].some((name) => name === NODE_CLASS || name === LEGACY_NODE_CLASS);
 }
 
 function nodeNameText(node) {
@@ -401,6 +410,49 @@ function nodeNameText(node) {
 
 function isDoraLoaderNode(node) {
   return nodeNameText(node).includes(DORA_LOADER_CLASS);
+}
+
+function hasExactNodeClass(node, className) {
+  return [node?.comfyClass, node?.type, node?.constructor?.title]
+    .map((value) => String(value ?? ""))
+    .some((value) => value === className);
+}
+
+function hasAnyNodeClassOrTitle(node, classNames) {
+  const values = [node?.comfyClass, node?.type, node?.title, node?.constructor?.title].map((value) => String(value ?? ""));
+  return classNames.some((className) => values.includes(className));
+}
+
+function isStateManagerNode(node) {
+  return hasExactNodeClass(node, NODE_CLASS) || hasExactNodeClass(node, LEGACY_NODE_CLASS);
+}
+
+function isStateTextNode(node) {
+  return hasAnyNodeClassOrTitle(node, [STATE_TEXT_CLASS, STATE_TEXT_DISPLAY_CLASS]);
+}
+
+function isStateSeedNode(node) {
+  return hasAnyNodeClassOrTitle(node, [STATE_SEED_CLASS, STATE_SEED_DISPLAY_CLASS]);
+}
+
+function getRoleWidget(node) {
+  const map = getWidgetMap(node);
+  return map.get("role") || null;
+}
+
+function getStateTextRole(node, fallback = "generic") {
+  const role = String(getRoleWidget(node)?.value ?? fallback).toLowerCase();
+  if (role.includes("positive")) return "positive";
+  if (role.includes("negative")) return "negative";
+  return "generic";
+}
+
+function getControlledTargets(node) {
+  return getOutputTargets(node, OUTPUT_NAMES.control);
+}
+
+function getControlledNodes(node) {
+  return uniqueNodes(getControlledTargets(node));
 }
 
 function normalizeDoraLoaderState(state) {
@@ -583,13 +635,14 @@ function isSeedNode(node) {
 }
 
 function isPromptLikeNode(node) {
+  if (isStateTextNode(node)) return true;
   const text = nodeNameText(node);
   if (SKIP_SETTING_NODE_RE.test(text)) return true;
   return (node?.widgets || []).some((widget) => isTextWidget(widget) && /prompt|text|positive|negative/i.test(`${widget.name ?? ""} ${widget.label ?? ""}`));
 }
 
 function captureNodeSnapshot(node) {
-  if (!node || node.comfyClass === NODE_CLASS || isDoraLoaderNode(node)) return null;
+  if (!node || isStateManagerNode(node) || isDoraLoaderNode(node)) return null;
   const widgets = {};
   const seedWidgets = {};
   for (const widget of node.widgets || []) {
@@ -734,7 +787,12 @@ function applySettingsToNodes(nodes, settings) {
 
 function saveConnectedState(targetNode, character, prompt) {
   const changes = [];
-  const loaderTargets = uniqueNodes([...getOutputTargets(targetNode, OUTPUT_NAMES.lora)]).filter(isDoraLoaderNode);
+  const controlledNodes = getControlledNodes(targetNode).filter((node) => node && node !== targetNode);
+
+  // Preferred save/load-only path: manager.state_control -> target.state_control.
+  const controlledLoaderTargets = controlledNodes.filter(isDoraLoaderNode);
+  const legacyLoaderTargets = controlledLoaderTargets.length ? [] : uniqueNodes([...getOutputTargets(targetNode, OUTPUT_NAMES.lora)]).filter(isDoraLoaderNode);
+  const loaderTargets = controlledLoaderTargets.length ? controlledLoaderTargets : legacyLoaderTargets;
   const loaderStack = loaderTargets.map(extractLoraStackFromNode).find(Boolean);
   if (loaderStack) {
     character.loras = loaderStack.loras || [];
@@ -742,30 +800,54 @@ function saveConnectedState(targetNode, character, prompt) {
     changes.push("LoRA stack");
   }
 
-  const positiveTargets = getOutputTargets(targetNode, OUTPUT_NAMES.positive);
-  for (const target of positiveTargets) {
-    const widget = findTextWidget(target.node, "positive", target.inputName);
-    if (widget) {
-      prompt.positive = typeof widget.value === "string" ? widget.value : "";
-      changes.push("positive prompt template");
-      break;
+  const controlledTextNodes = controlledNodes.filter(isStateTextNode);
+  let savedPositive = false;
+  let savedNegative = false;
+  for (const textNode of controlledTextNodes) {
+    const role = getStateTextRole(textNode);
+    const value = extractTextFromNode(textNode, role);
+    if (role === "positive") {
+      prompt.positive = value;
+      savedPositive = true;
+    } else if (role === "negative") {
+      prompt.negative = value;
+      savedNegative = true;
+    }
+  }
+  if (savedPositive) changes.push("positive prompt template");
+  if (savedNegative) changes.push("negative prompt template");
+
+  // Compatibility fallback for old graphs. Avoid depending on this for normal use;
+  // it can make editable widgets link-controlled if users connect STRING outputs.
+  if (!savedPositive) {
+    for (const target of getOutputTargets(targetNode, OUTPUT_NAMES.positive)) {
+      const widget = findTextWidget(target.node, "positive", target.inputName);
+      if (widget) {
+        prompt.positive = typeof widget.value === "string" ? widget.value : "";
+        changes.push("positive prompt template");
+        break;
+      }
+    }
+  }
+  if (!savedNegative) {
+    for (const target of getOutputTargets(targetNode, OUTPUT_NAMES.negative)) {
+      const widget = findTextWidget(target.node, "negative", target.inputName);
+      if (widget) {
+        prompt.negative = typeof widget.value === "string" ? widget.value : "";
+        changes.push("negative prompt template");
+        break;
+      }
     }
   }
 
-  const negativeTargets = getOutputTargets(targetNode, OUTPUT_NAMES.negative);
-  for (const target of negativeTargets) {
-    const widget = findTextWidget(target.node, "negative", target.inputName);
-    if (widget) {
-      prompt.negative = typeof widget.value === "string" ? widget.value : "";
-      changes.push("negative prompt template");
-      break;
-    }
-  }
-
-  const settingTargets = uniqueNodes([
+  const controlledSettingTargets = controlledNodes.filter((node) =>
+    node !== targetNode && !isDoraLoaderNode(node) && !isStateTextNode(node)
+  );
+  const legacySettingTargets = controlledSettingTargets.length ? [] : uniqueNodes([
     ...getOutputTargets(targetNode, OUTPUT_NAMES.settings),
     ...getOutputTargets(targetNode, OUTPUT_NAMES.seed),
-  ]).filter((node) => node !== targetNode && !isDoraLoaderNode(node));
+  ]).filter((node) => node !== targetNode && !isDoraLoaderNode(node) && !isStateTextNode(node));
+  const settingTargets = controlledSettingTargets.length ? controlledSettingTargets : legacySettingTargets;
   const snapshots = mergeCapturedSettings(prompt, settingTargets, { replaceNodes: true });
   if (snapshots.length) changes.push(`settings from ${snapshots.length} node${snapshots.length === 1 ? "" : "s"}`);
   if (prompt.settings?.seed != null) changes.push("seed");
@@ -774,27 +856,37 @@ function saveConnectedState(targetNode, character, prompt) {
 
 function applyConnectedState(targetNode, character, prompt) {
   const changes = [];
-  const loaderTargets = uniqueNodes([...getOutputTargets(targetNode, OUTPUT_NAMES.lora)]).filter(isDoraLoaderNode);
+  const controlledNodes = getControlledNodes(targetNode).filter((node) => node && node !== targetNode);
+
+  const controlledLoaderTargets = controlledNodes.filter(isDoraLoaderNode);
+  const legacyLoaderTargets = controlledLoaderTargets.length ? [] : uniqueNodes([...getOutputTargets(targetNode, OUTPUT_NAMES.lora)]).filter(isDoraLoaderNode);
+  const loaderTargets = controlledLoaderTargets.length ? controlledLoaderTargets : legacyLoaderTargets;
   let loaderChanged = 0;
   for (const loader of loaderTargets) if (applyLoraStackToNode(loader, character)) loaderChanged += 1;
   if (loaderChanged) changes.push(`LoRA stack to ${loaderChanged} loader${loaderChanged === 1 ? "" : "s"}`);
 
+  const controlledTextNodes = controlledNodes.filter(isStateTextNode);
   let posChanged = 0;
-  for (const target of getOutputTargets(targetNode, OUTPUT_NAMES.positive)) {
-    if (applyTextToNode(target.node, prompt.positive, "positive", target.inputName)) posChanged += 1;
+  let negChanged = 0;
+  for (const textNode of controlledTextNodes) {
+    const role = getStateTextRole(textNode);
+    if (role === "positive") {
+      if (applyTextToNode(textNode, prompt.positive, "positive")) posChanged += 1;
+    } else if (role === "negative") {
+      if (applyTextToNode(textNode, prompt.negative, "negative")) negChanged += 1;
+    }
   }
   if (posChanged) changes.push(`positive template to ${posChanged} node${posChanged === 1 ? "" : "s"}`);
-
-  let negChanged = 0;
-  for (const target of getOutputTargets(targetNode, OUTPUT_NAMES.negative)) {
-    if (applyTextToNode(target.node, prompt.negative, "negative", target.inputName)) negChanged += 1;
-  }
   if (negChanged) changes.push(`negative template to ${negChanged} node${negChanged === 1 ? "" : "s"}`);
 
-  const settingTargets = uniqueNodes([
+  const controlledSettingTargets = controlledNodes.filter((node) =>
+    node !== targetNode && !isDoraLoaderNode(node) && !isStateTextNode(node)
+  );
+  const legacySettingTargets = controlledSettingTargets.length ? [] : uniqueNodes([
     ...getOutputTargets(targetNode, OUTPUT_NAMES.settings),
     ...getOutputTargets(targetNode, OUTPUT_NAMES.seed),
-  ]).filter((node) => node !== targetNode && !isDoraLoaderNode(node));
+  ]).filter((node) => node !== targetNode && !isDoraLoaderNode(node) && !isStateTextNode(node));
+  const settingTargets = controlledSettingTargets.length ? controlledSettingTargets : legacySettingTargets;
   const settingsChanged = applySettingsToNodes(settingTargets, prompt.settings);
   if (settingsChanged) changes.push(`settings/seed to ${settingsChanged} node${settingsChanged === 1 ? "" : "s"}`);
   return changes;
@@ -802,10 +894,15 @@ function applyConnectedState(targetNode, character, prompt) {
 
 function classifySelectedTextNodes(nodes) {
   const textNodes = nodes
-    .map((node) => ({ node, text: extractTextFromNode(node), name: nodeNameText(node) }))
+    .map((node) => ({
+      node,
+      text: extractTextFromNode(node, isStateTextNode(node) ? getStateTextRole(node) : ""),
+      name: nodeNameText(node),
+      role: isStateTextNode(node) ? getStateTextRole(node) : "",
+    }))
     .filter((item) => item.text || findTextWidget(item.node));
-  const negative = textNodes.find((item) => NEGATIVE_HINT_RE.test(item.name));
-  const positive = textNodes.find((item) => item !== negative && POSITIVE_HINT_RE.test(item.name)) || textNodes.find((item) => item !== negative);
+  const negative = textNodes.find((item) => item.role === "negative") || textNodes.find((item) => NEGATIVE_HINT_RE.test(item.name));
+  const positive = textNodes.find((item) => item.role === "positive") || textNodes.find((item) => item !== negative && POSITIVE_HINT_RE.test(item.name)) || textNodes.find((item) => item !== negative);
   const fallbackNegative = negative || (textNodes.length >= 2 ? textNodes.find((item) => item !== positive) : null);
   return { positive, negative: fallbackNegative, used: [positive?.node, fallbackNegative?.node].filter(Boolean) };
 }
@@ -821,7 +918,7 @@ function saveSelectedState(targetNode, character, prompt) {
     changes.push("LoRA stack");
   }
 
-  const classified = classifySelectedTextNodes(selected.filter((node) => node !== loader));
+  const classified = classifySelectedTextNodes(selected.filter((node) => node !== loader && !isSeedNode(node)));
   if (classified.positive) {
     prompt.positive = classified.positive.text;
     changes.push("positive prompt template");
@@ -847,7 +944,7 @@ function applySelectedState(targetNode, character, prompt) {
   for (const loader of loaderTargets) if (applyLoraStackToNode(loader, character)) loaderChanged += 1;
   if (loaderChanged) changes.push(`LoRA stack to ${loaderChanged} loader${loaderChanged === 1 ? "" : "s"}`);
 
-  const classified = classifySelectedTextNodes(selected.filter((node) => !isDoraLoaderNode(node)));
+  const classified = classifySelectedTextNodes(selected.filter((node) => !isDoraLoaderNode(node) && !isSeedNode(node)));
   if (classified.positive && applyTextToNode(classified.positive.node, prompt.positive, "positive")) changes.push("positive template");
   if (classified.negative && applyTextToNode(classified.negative.node, prompt.negative, "negative")) changes.push("negative template");
 
@@ -977,7 +1074,7 @@ function renderHeader(node, state, uiState, character, prompt) {
   toolbar.className = "dsm-toolbar";
   const title = document.createElement("div");
   title.className = "dsm-title";
-  title.textContent = "DoRA State Manager";
+  title.textContent = "State Manager";
 
   toolbar.append(
     title,
@@ -1220,7 +1317,8 @@ function renderLoraPanelContent(section, node, state, uiState, character, prompt
   header.className = "dsm-toolbar";
   header.append(
     makeButton("Save connected loader", () => {
-      const loaders = uniqueNodes(getOutputTargets(node, OUTPUT_NAMES.lora)).filter(isDoraLoaderNode);
+      const controlledLoaders = getControlledNodes(node).filter(isDoraLoaderNode);
+      const loaders = controlledLoaders.length ? controlledLoaders : uniqueNodes(getOutputTargets(node, OUTPUT_NAMES.lora)).filter(isDoraLoaderNode);
       const stack = loaders.map(extractLoraStackFromNode).find(Boolean);
       if (stack) {
         character.loras = stack.loras;
@@ -1229,7 +1327,8 @@ function renderLoraPanelContent(section, node, state, uiState, character, prompt
       updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id, status: stack ? "Saved LoRA stack from connected loader." : "No connected DoRA loader found." });
     }),
     makeButton("Apply connected loader", () => {
-      const loaders = uniqueNodes(getOutputTargets(node, OUTPUT_NAMES.lora)).filter(isDoraLoaderNode);
+      const controlledLoaders = getControlledNodes(node).filter(isDoraLoaderNode);
+      const loaders = controlledLoaders.length ? controlledLoaders : uniqueNodes(getOutputTargets(node, OUTPUT_NAMES.lora)).filter(isDoraLoaderNode);
       let count = 0;
       for (const loader of loaders) if (applyLoraStackToNode(loader, character)) count += 1;
       updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id, status: count ? `Applied LoRA stack to ${count} connected loader${count === 1 ? "" : "s"}.` : "No connected DoRA loader accepted the stack." });
@@ -1504,7 +1603,9 @@ function initializeNode(node, widget) {
 }
 
 function maybeInjectWidgetInput(nodeData) {
-  if (nodeData?.name !== NODE_CLASS && nodeData?.display_name !== NODE_CLASS) return;
+  const name = nodeData?.name ?? "";
+  const displayName = nodeData?.display_name ?? "";
+  if (![name, displayName].some((value) => value === NODE_CLASS || value === LEGACY_NODE_CLASS)) return;
   const required = nodeData?.input?.required;
   if (!required || required[CUSTOM_WIDGET_INPUT]) return;
   nodeData.input.required = { ...required, [CUSTOM_WIDGET_INPUT]: [CUSTOM_WIDGET_TYPE, {}] };


### PR DESCRIPTION
## Summary
- Rename the main node to State Manager while preserving the legacy DoRA State Manager mapping.
- Add State Text Box and State Seed helper nodes plus a State Manager `state_control` output.
- Add editor-only `state_control` inputs for State Text Box, State Seed, and DoRA Power LoRA Loader.
- Prefer `state_control` edges for Save connected / Load connected while retaining legacy runtime-output fallbacks.

## Validation
- Applied the provided `state_manager_text_seed.patch` after pulling latest `main`.
- Reviewed backend node mappings, frontend connected save/load discovery, and loader runtime parsing.
- Confirmed `state_control` is ignored/discarded during backend execution and only used for editor save/load association.
- Ran `git diff --check`.

Repository tests were not run per instruction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a State Manager plus editable State Text Box and State Seed nodes with a dedicated control pathway for saving/applying character/preset state.

* **Documentation**
  * Updated State Manager docs: wiring recommendations, save/load/apply actions, warnings about feedback cycles, and persistence behavior.

* **UI/UX**
  * Renamed/standardized State Manager UI labels and actions; legacy manager remains available as a compatibility label.

* **Chores**
  * Project version bumped to 1.0.25.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->