### PR TITLE
Support multi-loader State Manager slots

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,11 +516,12 @@ The manager separates **saved state** from **runtime execution**:
 
 Use it to save:
 
-- character / LoRA combinations
-- per-character DoRA loader settings such as auto-strength and compatibility toggles
+- character / LoRA combinations across multiple separate DoRA loader nodes
+- per-loader DoRA settings such as auto-strength and compatibility toggles
 - multiple positive / negative prompt **templates** per character
 - arbitrary downstream node widget snapshots
 - seed state, including rgthree-style seed nodes
+- one character image / thumbnail reference; the UI preview is CSS-scaled, while the `character_image` output loads the original uploaded image file
 
 ### Basic wiring
 
@@ -529,11 +530,12 @@ Recommended connected save/load wiring:
 1. Add **State Manager**.
 2. Add **State Text Box** nodes for editable positive and negative prompt templates.
 3. Add **State Seed** for an editable seed value.
-4. Add **DoRA Power LoRA Loader**.
-5. Connect `state_control` from the manager to each helper node's optional `state_control` input.
-6. Connect `text` from each State Text Box into the prompt/wildcard path.
-7. Connect `seed` from State Seed only to the sampler seed input.
-8. Configure LoRA rows on the DoRA Power LoRA Loader as usual.
+4. Add one or more **DoRA Power LoRA Loader** nodes.
+5. Give every DoRA loader a unique **State slot** value, for example `face`, `outfit`, `style`, `refiner`.
+6. Connect `state_control` from the manager to each helper node's optional `state_control` input, including every DoRA loader you want managed.
+7. Connect `text` from each State Text Box into the prompt/wildcard path.
+8. Connect `seed` from State Seed only to the sampler seed input.
+9. Configure LoRA rows on each DoRA Power LoRA Loader as usual.
 
 The manager should not receive processed wildcard, prompt-generation, or other runtime text outputs. Store the wildcard/template prompt in State Text Box, then let your wildcard node expand it downstream.
 
@@ -562,11 +564,28 @@ The older runtime-output path is still available for workflows that intentionall
 
 ```text
 State Manager.dora_state -> DoRA Power LoRA Loader.dora_state
+DoRA loader State slot selects which saved loader stack to use
 State Manager.positive_prompt_template -> prompt/wildcard path
 State Manager.negative_prompt_template -> prompt/wildcard path
 ```
 
 Do not use that runtime path as the replacement for connected save/load. For editable prompt and seed values that survive normal execution, use `state_control` plus State Text Box / State Seed.
+
+
+### Multiple DoRA loaders
+
+A character now stores `loader_stacks`, not only one flat `loras` list. Each stack has a stable `slot`. The DoRA loader exposes a **State slot** widget; Save/Load connected matches by that slot.
+
+Example:
+
+```text
+State Manager.state_control -> DoRA Loader A.state_control  # State slot: face
+State Manager.state_control -> DoRA Loader B.state_control  # State slot: outfit
+State Manager.state_control -> DoRA Loader C.state_control  # State slot: style
+State Manager.state_control -> DoRA Loader D.state_control  # State slot: refiner
+```
+
+Click **Save connected** to capture all four stacks separately. Click **Load connected** to push each saved stack back into the matching loader.
 
 ### Save / load / apply workflow
 
@@ -589,6 +608,7 @@ The manager outputs:
 - `state_settings` — typed `DORA_STATE_SETTINGS` payload
 - `seed` — integer seed extracted from saved settings / rgthree seed snapshots
 - `state_control` — typed `STATE_MANAGER_CONTROL` payload used only by the frontend to discover connected nodes for Save connected / Load connected
+- `character_image` — original uploaded character image as an `IMAGE` tensor
 
 Future or external nodes can add optional inputs for `settings_json`, `state_settings`, or `seed` to consume saved state deterministically during execution. `state_control` is reserved for editor save/load association.
 
@@ -612,6 +632,7 @@ The settings snapshot stores widget values by node identity and class/title fall
 - `state_settings` — typed `DORA_STATE_SETTINGS` payload for future compatible nodes
 - `seed` — integer seed extracted from saved settings / rgthree seed snapshots
 - `state_control` — typed `STATE_MANAGER_CONTROL` payload for editor/control-only save/load association
+- `character_image` — original uploaded character image as an `IMAGE` tensor. The manager uploads the original image to ComfyUI's input folder and only scales it visually in the browser.
 
 ### Persistence and payload behavior
 

--- a/nodes.py
+++ b/nodes.py
@@ -1132,6 +1132,9 @@ def _state_payload_get_loader_global(state_payload: Optional[Dict[str, Any]], ke
         globals_in = stack.get("loader_globals")
         if isinstance(globals_in, dict) and key in globals_in:
             return globals_in[key]
+    stacks = state_payload.get("loader_stacks") if isinstance(state_payload, dict) else None
+    if isinstance(stacks, list) and stacks:
+        return fallback
     if isinstance(state_payload, dict):
         globals_in = state_payload.get("loader_globals")
         if isinstance(globals_in, dict) and key in globals_in:

--- a/nodes.py
+++ b/nodes.py
@@ -1101,7 +1101,11 @@ def _select_state_loader_stack(state_payload: Optional[Dict[str, Any]], state_sl
         return None
     stacks = state_payload.get("loader_stacks")
     if isinstance(stacks, list) and stacks:
-        return _pick_loader_stack(stacks, state_slot)
+        wanted = _clean_loader_slot(state_slot, "default")
+        for stack in stacks:
+            if isinstance(stack, dict) and _clean_loader_slot(stack.get("slot", ""), "default") == wanted:
+                return stack
+        return None
     if isinstance(state_payload.get("loras"), list):
         return {
             "slot": "default",

--- a/nodes.py
+++ b/nodes.py
@@ -1,6 +1,7 @@
 import logging
 import json
 import math
+import os
 import inspect
 import re
 import sys
@@ -472,6 +473,15 @@ def _state_manager_default_state() -> Dict[str, Any]:
                 "id": "default_character",
                 "name": "Default Character",
                 "thumbnail": {},
+                "loader_stacks": [
+                    {
+                        "slot": "default",
+                        "label": "Default loader",
+                        "loras": [],
+                        "loader_globals": {},
+                    }
+                ],
+                # Legacy/default stack mirror. Kept so older workflows and older JS still load.
                 "loras": [],
                 "loader_globals": {},
                 "prompts": [
@@ -630,13 +640,107 @@ def _lora_entries_to_manager_rows(entries: Iterable[Dict[str, Any]]) -> List[Dic
     return rows
 
 
-def _build_lora_stack_payload(entries: Iterable[Dict[str, Any]], loader_globals: Dict[str, Any]) -> Dict[str, Any]:
+def _build_lora_stack_payload(entries: Iterable[Dict[str, Any]], loader_globals: Dict[str, Any], state_slot: Any = "default", label: Any = None) -> Dict[str, Any]:
+    slot = _clean_loader_slot(state_slot, "default")
     return {
         "version": _DORA_STATE_MANAGER_SCHEMA_VERSION,
         "kind": _DORA_LORA_STACK_KIND,
+        "slot": slot,
+        "label": str(label or slot),
         "loras": _lora_entries_to_manager_rows(entries),
         "loader_globals": _normalize_manager_loader_globals(loader_globals),
     }
+
+
+
+
+def _clean_loader_slot(value: Any, fallback: str = "default") -> str:
+    text = str(value or "").strip()
+    if not text:
+        text = fallback
+    text = re.sub(r"[^A-Za-z0-9_.:-]+", "_", text).strip("_")
+    return text or fallback
+
+
+def _normalize_manager_loader_stack(stack: Any, index: int = 0) -> Optional[Dict[str, Any]]:
+    if not isinstance(stack, dict):
+        return None
+    slot = _clean_loader_slot(stack.get("slot", stack.get("id", stack.get("name", ""))), f"loader_{index + 1}")
+    label = str(stack.get("label", stack.get("name", slot)) or slot).strip() or slot
+    rows_in = stack.get("loras", stack.get("rows", []))
+    loras: List[Dict[str, Any]] = []
+    if isinstance(rows_in, list):
+        for row in rows_in:
+            normalized = _normalize_manager_lora_row(row)
+            if normalized is not None:
+                loras.append(normalized)
+    return {
+        "slot": slot,
+        "label": label,
+        "loras": loras,
+        "loader_globals": _normalize_manager_loader_globals(stack.get("loader_globals", stack.get("globals", {}))),
+    }
+
+
+def _normalize_manager_loader_stacks(character: Dict[str, Any]) -> List[Dict[str, Any]]:
+    stacks_in = character.get("loader_stacks")
+    raw_stacks: List[Any] = []
+    if isinstance(stacks_in, list):
+        raw_stacks = stacks_in
+    elif isinstance(stacks_in, dict):
+        for slot, value in stacks_in.items():
+            if isinstance(value, dict):
+                merged = dict(value)
+                merged.setdefault("slot", slot)
+                raw_stacks.append(merged)
+
+    stacks: List[Dict[str, Any]] = []
+    used_slots: Set[str] = set()
+    for index, stack in enumerate(raw_stacks):
+        normalized = _normalize_manager_loader_stack(stack, index)
+        if normalized is None:
+            continue
+        base_slot = normalized["slot"]
+        slot = base_slot
+        suffix = 2
+        while slot in used_slots:
+            slot = f"{base_slot}_{suffix}"
+            suffix += 1
+        used_slots.add(slot)
+        normalized["slot"] = slot
+        stacks.append(normalized)
+
+    # Legacy migration: previous versions stored one character-level LoRA stack.
+    if not stacks:
+        rows_in = character.get("loras")
+        legacy_rows: List[Dict[str, Any]] = []
+        if isinstance(rows_in, list):
+            for row in rows_in:
+                normalized = _normalize_manager_lora_row(row)
+                if normalized is not None:
+                    legacy_rows.append(normalized)
+        stacks.append({
+            "slot": "default",
+            "label": "Default loader",
+            "loras": legacy_rows,
+            "loader_globals": _normalize_manager_loader_globals(character.get("loader_globals", character.get("globals", {}))),
+        })
+
+    return stacks
+
+
+def _pick_loader_stack(loader_stacks: Any, slot: Any = "default") -> Dict[str, Any]:
+    stacks = loader_stacks if isinstance(loader_stacks, list) else []
+    if not stacks:
+        return {"slot": "default", "label": "Default loader", "loras": [], "loader_globals": {}}
+    wanted = _clean_loader_slot(slot, "default")
+    for stack in stacks:
+        if isinstance(stack, dict) and _clean_loader_slot(stack.get("slot", ""), "default") == wanted:
+            return stack
+    for stack in stacks:
+        if isinstance(stack, dict) and _clean_loader_slot(stack.get("slot", ""), "default") == "default":
+            return stack
+    return stacks[0]
 
 
 def _normalize_manager_loader_globals(globals_in: Any) -> Dict[str, Any]:
@@ -722,6 +826,9 @@ def _normalize_state_manager_state(raw: Any) -> Dict[str, Any]:
                 if normalized is not None:
                     loras.append(normalized)
 
+        loader_stacks = _normalize_manager_loader_stacks(char)
+        default_loader_stack = _pick_loader_stack(loader_stacks, "default")
+
         prompts_in = char.get("prompts")
         prompts: List[Dict[str, Any]] = []
         if isinstance(prompts_in, list):
@@ -747,8 +854,10 @@ def _normalize_state_manager_state(raw: Any) -> Dict[str, Any]:
                 "id": char_id,
                 "name": name,
                 "thumbnail": _normalize_manager_thumbnail(char.get("thumbnail", {})),
-                "loras": loras,
-                "loader_globals": _normalize_manager_loader_globals(char.get("loader_globals", char.get("globals", {}))),
+                "loader_stacks": loader_stacks,
+                # Legacy/default stack mirror for older graphs and older consumers.
+                "loras": default_loader_stack.get("loras", loras),
+                "loader_globals": default_loader_stack.get("loader_globals", _normalize_manager_loader_globals(char.get("loader_globals", char.get("globals", {})))),
                 "prompts": prompts,
             }
         )
@@ -796,8 +905,10 @@ def _resolve_dora_state_payload(
     prompt = _pick_state_manager_prompt(character, selected_prompt_id)
 
     settings = _normalize_settings_with_canonical_seed(prompt.get("settings", {}))
-    loras = character.get("loras", [])
-    loader_globals = character.get("loader_globals", {})
+    loader_stacks = _normalize_manager_loader_stacks(character)
+    default_stack = _pick_loader_stack(loader_stacks, "default")
+    loras = default_stack.get("loras", character.get("loras", []))
+    loader_globals = default_stack.get("loader_globals", character.get("loader_globals", {}))
     positive = str(prompt.get("positive", "") or "")
     negative = str(prompt.get("negative", "") or "")
 
@@ -813,6 +924,7 @@ def _resolve_dora_state_payload(
             "id": prompt.get("id", ""),
             "name": prompt.get("name", ""),
         },
+        "loader_stacks": loader_stacks,
         "loras": loras,
         "loader_globals": loader_globals,
         "settings": settings,
@@ -848,6 +960,60 @@ def _build_state_control_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
         "selected_character_id": character.get("id", ""),
         "selected_prompt_id": prompt.get("id", ""),
     }
+
+
+
+
+def _state_manager_blank_image() -> torch.Tensor:
+    return torch.zeros((1, 1, 1, 3), dtype=torch.float32)
+
+
+def _state_manager_thumbnail_path(thumbnail: Any) -> Optional[str]:
+    info = _normalize_manager_thumbnail(thumbnail)
+    filename = str(info.get("filename", "")).strip()
+    if not filename:
+        return None
+    subfolder = str(info.get("subfolder", "")).strip()
+    type_name = str(info.get("type", "input")).strip().lower() or "input"
+    if type_name == "input":
+        root = folder_paths.get_input_directory()
+    elif type_name == "output":
+        root = folder_paths.get_output_directory()
+    elif type_name == "temp":
+        root = folder_paths.get_temp_directory()
+    else:
+        root = folder_paths.get_input_directory()
+    root_abs = os.path.realpath(root)
+    path = os.path.realpath(os.path.join(root_abs, subfolder, filename))
+    try:
+        common = os.path.commonpath([root_abs, path])
+    except Exception:
+        return None
+    if common != root_abs:
+        return None
+    if not os.path.isfile(path):
+        return None
+    return path
+
+
+def _load_state_manager_character_image(character: Dict[str, Any]) -> torch.Tensor:
+    path = _state_manager_thumbnail_path(character.get("thumbnail", {}) if isinstance(character, dict) else {})
+    if not path:
+        return _state_manager_blank_image()
+    try:
+        import numpy as np
+        from PIL import Image, ImageOps
+
+        with Image.open(path) as img:
+            img = ImageOps.exif_transpose(img)
+            img = img.convert("RGB")
+            arr = np.asarray(img, dtype=np.float32) / 255.0
+        if arr.ndim != 3 or arr.shape[-1] != 3:
+            return _state_manager_blank_image()
+        return torch.from_numpy(arr)[None, ...]
+    except Exception as exc:
+        _LOG.warning("[State Manager] failed to load character image %r: %s", path, exc)
+        return _state_manager_blank_image()
 
 
 def _extract_seed_from_settings(settings: Any, fallback: int = 0) -> int:
@@ -911,20 +1077,17 @@ def _normalize_runtime_dora_state_payload(raw: Any) -> Optional[Dict[str, Any]]:
         return None
     if payload.get("kind") != _DORA_STATE_KIND:
         return None
-    rows_in = payload.get("loras")
-    if not isinstance(rows_in, list):
-        return None
-    loras = []
-    for row in rows_in:
-        normalized = _normalize_manager_lora_row(row)
-        if normalized is not None:
-            loras.append(normalized)
-    globals_out = _normalize_manager_loader_globals(payload.get("loader_globals", payload.get("globals", {})))
+
+    loader_stacks = _normalize_manager_loader_stacks(payload)
+    default_stack = _pick_loader_stack(loader_stacks, "default")
+    loras = default_stack.get("loras", [])
+    globals_out = default_stack.get("loader_globals", _normalize_manager_loader_globals(payload.get("loader_globals", payload.get("globals", {}))))
     return {
         "version": _DORA_STATE_MANAGER_SCHEMA_VERSION,
         "kind": _DORA_STATE_KIND,
         "character": payload.get("character") if isinstance(payload.get("character"), dict) else {},
         "prompt": payload.get("prompt") if isinstance(payload.get("prompt"), dict) else {},
+        "loader_stacks": loader_stacks,
         "loras": loras,
         "loader_globals": globals_out,
         "settings": _normalize_manager_settings(payload.get("settings", {})),
@@ -933,16 +1096,38 @@ def _normalize_runtime_dora_state_payload(raw: Any) -> Optional[Dict[str, Any]]:
     }
 
 
-def _parse_dora_state_lora_entries(state_payload: Optional[Dict[str, Any]]) -> Optional[List[Dict[str, Any]]]:
+def _select_state_loader_stack(state_payload: Optional[Dict[str, Any]], state_slot: Any = "default") -> Optional[Dict[str, Any]]:
     if not isinstance(state_payload, dict):
         return None
-    rows = state_payload.get("loras")
+    stacks = state_payload.get("loader_stacks")
+    if isinstance(stacks, list) and stacks:
+        return _pick_loader_stack(stacks, state_slot)
+    if isinstance(state_payload.get("loras"), list):
+        return {
+            "slot": "default",
+            "label": "Default loader",
+            "loras": state_payload.get("loras", []),
+            "loader_globals": _normalize_manager_loader_globals(state_payload.get("loader_globals", {})),
+        }
+    return None
+
+
+def _parse_dora_state_lora_entries(state_payload: Optional[Dict[str, Any]], state_slot: Any = "default") -> Optional[List[Dict[str, Any]]]:
+    stack = _select_state_loader_stack(state_payload, state_slot)
+    if not isinstance(stack, dict):
+        return None
+    rows = stack.get("loras")
     if not isinstance(rows, list):
         return None
     return _manager_rows_to_lora_entries(rows)
 
 
-def _state_payload_get_loader_global(state_payload: Optional[Dict[str, Any]], key: str, fallback: Any) -> Any:
+def _state_payload_get_loader_global(state_payload: Optional[Dict[str, Any]], key: str, fallback: Any, state_slot: Any = "default") -> Any:
+    stack = _select_state_loader_stack(state_payload, state_slot)
+    if isinstance(stack, dict):
+        globals_in = stack.get("loader_globals")
+        if isinstance(globals_in, dict) and key in globals_in:
+            return globals_in[key]
     if isinstance(state_payload, dict):
         globals_in = state_payload.get("loader_globals")
         if isinstance(globals_in, dict) and key in globals_in:
@@ -3760,7 +3945,7 @@ class StateManager:
             }
         }
 
-    RETURN_TYPES = ("DORA_STATE", "STRING", "STRING", "STRING", "DORA_LORA_STACK", "DORA_STATE_SETTINGS", "INT", "STATE_MANAGER_CONTROL")
+    RETURN_TYPES = ("DORA_STATE", "STRING", "STRING", "STRING", "DORA_LORA_STACK", "DORA_STATE_SETTINGS", "INT", "STATE_MANAGER_CONTROL", "IMAGE")
     RETURN_NAMES = (
         "dora_state",
         "positive_prompt_template",
@@ -3770,6 +3955,7 @@ class StateManager:
         "state_settings",
         "seed",
         "state_control",
+        "character_image",
     )
     FUNCTION = "resolve_state"
     CATEGORY = "state managers"
@@ -3830,6 +4016,9 @@ class StateManager:
         state_settings_payload = _build_state_settings_payload(payload)
         state_control_payload = _build_state_control_payload(payload)
         seed = _extract_seed_from_settings(settings)
+        state = _normalize_state_manager_state(state_json)
+        character = _pick_state_manager_character(state, selected_character_id)
+        character_image = _load_state_manager_character_image(character)
         return (
             payload,
             payload.get("positive_prompt", ""),
@@ -3839,6 +4028,7 @@ class StateManager:
             state_settings_payload,
             seed,
             state_control_payload,
+            character_image,
         )
 
 
@@ -3943,6 +4133,7 @@ class DoraPowerLoraLoader:
                     # Editor-only relationship used by State Manager Save/Load connected.
                     # Ignored by backend execution.
                     "state_control": ("STATE_MANAGER_CONTROL",),
+                    "state_slot": ("STRING", {"default": "default", "multiline": False}),
 
                     # Flux2 modulation handling
                     "broadcast_modulations": ("BOOLEAN", {"default": True}),
@@ -4235,41 +4426,42 @@ class DoraPowerLoraLoader:
         # Editor-only relationship token for State Manager save/load discovery.
         # It must not participate in runtime LoRA row or settings resolution.
         kwargs.pop("state_control", None)
+        state_slot = _clean_loader_slot(kwargs.get("state_slot", "default"), "default")
         state_payload = _normalize_runtime_dora_state_payload(kwargs.get("dora_state"))
 
         # Global controls (provided by JS UI; optionally overridden by DoRA State Manager)
-        stack_enabled = bool(_state_payload_get_loader_global(state_payload, "stack_enabled", kwargs.get("stack_enabled", True)))
-        verbose = bool(_state_payload_get_loader_global(state_payload, "verbose", kwargs.get("verbose", False)))
-        log_unloaded_keys = bool(_state_payload_get_loader_global(state_payload, "log_unloaded_keys", kwargs.get("log_unloaded_keys", False)))
-        broadcast_auto_scale = bool(_state_payload_get_loader_global(state_payload, "broadcast_auto_scale", kwargs.get("broadcast_auto_scale", True)))
-        broadcast_modulations = bool(_state_payload_get_loader_global(state_payload, "broadcast_modulations", kwargs.get("broadcast_modulations", True)))
-        broadcast_include_dora_scale = bool(_state_payload_get_loader_global(state_payload, "broadcast_include_dora_scale", kwargs.get("broadcast_include_dora_scale", False)))
+        stack_enabled = bool(_state_payload_get_loader_global(state_payload, "stack_enabled", kwargs.get("stack_enabled", True), state_slot))
+        verbose = bool(_state_payload_get_loader_global(state_payload, "verbose", kwargs.get("verbose", False), state_slot))
+        log_unloaded_keys = bool(_state_payload_get_loader_global(state_payload, "log_unloaded_keys", kwargs.get("log_unloaded_keys", False), state_slot))
+        broadcast_auto_scale = bool(_state_payload_get_loader_global(state_payload, "broadcast_auto_scale", kwargs.get("broadcast_auto_scale", True), state_slot))
+        broadcast_modulations = bool(_state_payload_get_loader_global(state_payload, "broadcast_modulations", kwargs.get("broadcast_modulations", True), state_slot))
+        broadcast_include_dora_scale = bool(_state_payload_get_loader_global(state_payload, "broadcast_include_dora_scale", kwargs.get("broadcast_include_dora_scale", False), state_slot))
         try:
-            broadcast_scale = float(_state_payload_get_loader_global(state_payload, "broadcast_scale", kwargs.get("broadcast_scale", 1.0)))
+            broadcast_scale = float(_state_payload_get_loader_global(state_payload, "broadcast_scale", kwargs.get("broadcast_scale", 1.0), state_slot))
         except Exception:
             broadcast_scale = 1.0
 
         # DoRA decompose debug controls (node-adjustable / state-manager overrideable)
-        dora_dbg = bool(_state_payload_get_loader_global(state_payload, "dora_decompose_debug", kwargs.get("dora_decompose_debug", False)))
+        dora_dbg = bool(_state_payload_get_loader_global(state_payload, "dora_decompose_debug", kwargs.get("dora_decompose_debug", False), state_slot))
         try:
-            dora_dbg_n = int(_state_payload_get_loader_global(state_payload, "dora_decompose_debug_n", kwargs.get("dora_decompose_debug_n", 30)))
+            dora_dbg_n = int(_state_payload_get_loader_global(state_payload, "dora_decompose_debug_n", kwargs.get("dora_decompose_debug_n", 30), state_slot))
         except Exception:
             dora_dbg_n = 30
         try:
-            dora_dbg_stack = int(_state_payload_get_loader_global(state_payload, "dora_decompose_debug_stack_depth", kwargs.get("dora_decompose_debug_stack_depth", 10)))
+            dora_dbg_stack = int(_state_payload_get_loader_global(state_payload, "dora_decompose_debug_stack_depth", kwargs.get("dora_decompose_debug_stack_depth", 10), state_slot))
         except Exception:
             dora_dbg_stack = 10
-        dora_slice_fix = bool(_state_payload_get_loader_global(state_payload, "dora_slice_fix", kwargs.get("dora_slice_fix", True)))
-        dora_adaln_swap_fix = bool(_state_payload_get_loader_global(state_payload, "dora_adaln_swap_fix", kwargs.get("dora_adaln_swap_fix", True)))
-        zimage_lumina2_compat = bool(_state_payload_get_loader_global(state_payload, "zimage_lumina2_compat", kwargs.get("zimage_lumina2_compat", True)))
-        auto_strength_enabled = bool(_state_payload_get_loader_global(state_payload, "auto_strength_enabled", kwargs.get("auto_strength_enabled", False)))
-        auto_strength_device = _normalize_auto_strength_device(_state_payload_get_loader_global(state_payload, "auto_strength_device", kwargs.get("auto_strength_device", "gpu")))
+        dora_slice_fix = bool(_state_payload_get_loader_global(state_payload, "dora_slice_fix", kwargs.get("dora_slice_fix", True), state_slot))
+        dora_adaln_swap_fix = bool(_state_payload_get_loader_global(state_payload, "dora_adaln_swap_fix", kwargs.get("dora_adaln_swap_fix", True), state_slot))
+        zimage_lumina2_compat = bool(_state_payload_get_loader_global(state_payload, "zimage_lumina2_compat", kwargs.get("zimage_lumina2_compat", True), state_slot))
+        auto_strength_enabled = bool(_state_payload_get_loader_global(state_payload, "auto_strength_enabled", kwargs.get("auto_strength_enabled", False), state_slot))
+        auto_strength_device = _normalize_auto_strength_device(_state_payload_get_loader_global(state_payload, "auto_strength_device", kwargs.get("auto_strength_device", "gpu"), state_slot))
         try:
-            auto_strength_ratio_floor = float(_state_payload_get_loader_global(state_payload, "auto_strength_ratio_floor", kwargs.get("auto_strength_ratio_floor", _AUTO_STRENGTH_RATIO_FLOOR)))
+            auto_strength_ratio_floor = float(_state_payload_get_loader_global(state_payload, "auto_strength_ratio_floor", kwargs.get("auto_strength_ratio_floor", _AUTO_STRENGTH_RATIO_FLOOR), state_slot))
         except Exception:
             auto_strength_ratio_floor = _AUTO_STRENGTH_RATIO_FLOOR
         try:
-            auto_strength_ratio_ceiling = float(_state_payload_get_loader_global(state_payload, "auto_strength_ratio_ceiling", kwargs.get("auto_strength_ratio_ceiling", _AUTO_STRENGTH_RATIO_CEILING)))
+            auto_strength_ratio_ceiling = float(_state_payload_get_loader_global(state_payload, "auto_strength_ratio_ceiling", kwargs.get("auto_strength_ratio_ceiling", _AUTO_STRENGTH_RATIO_CEILING), state_slot))
         except Exception:
             auto_strength_ratio_ceiling = _AUTO_STRENGTH_RATIO_CEILING
         if auto_strength_ratio_ceiling < auto_strength_ratio_floor:
@@ -4285,7 +4477,7 @@ class DoraPowerLoraLoader:
 
         report_rows: List[Dict[str, Any]] = []
 
-        entries = _parse_dora_state_lora_entries(state_payload) if state_payload is not None else None
+        entries = _parse_dora_state_lora_entries(state_payload, state_slot) if state_payload is not None else None
         if entries is None:
             entries = _parse_lora_stack_kwargs(kwargs)
 
@@ -4308,7 +4500,7 @@ class DoraPowerLoraLoader:
             "auto_strength_ratio_floor": auto_strength_ratio_floor,
             "auto_strength_ratio_ceiling": auto_strength_ratio_ceiling,
         }
-        lora_stack_payload = _build_lora_stack_payload(entries, loader_globals_payload)
+        lora_stack_payload = _build_lora_stack_payload(entries, loader_globals_payload, state_slot)
 
         if not stack_enabled:
             stack_report = {

--- a/web/dora_power_lora_loader.js
+++ b/web/dora_power_lora_loader.js
@@ -499,6 +499,27 @@ function parseRowsFromWidgetValues(widgetsValues) {
   return { rows: [], globals: { stack_enabled: true, verbose: false, log_unloaded_keys: false } };
 }
 
+function normalizeStateSlot(value, fallback = "default") {
+  const text = String(value ?? "")
+    .trim()
+    .replace(/[^A-Za-z0-9_.:-]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+  return text || fallback;
+}
+
+function getStateSlot(node) {
+  node.properties = node.properties || {};
+  return normalizeStateSlot(node.properties.dora_state_slot, `loader_${node.id ?? "default"}`);
+}
+
+function setStateSlot(node, value) {
+  if (!node) return "default";
+  node.properties = node.properties || {};
+  const slot = normalizeStateSlot(value, `loader_${node.id ?? "default"}`);
+  node.properties.dora_state_slot = slot;
+  return slot;
+}
+
 function defaultState() {
   return {
     rows: [makeRowDefaults()],
@@ -625,11 +646,13 @@ function normalizeExternalDoraState(external) {
 function installGlobalStateApi() {
   globalThis.__doraPowerLoraLoaderApi = {
     getState(node) {
-      return getState(node);
+      const state = getState(node);
+      return { ...state, slot: getStateSlot(node), label: String(node?.title || getStateSlot(node)) };
     },
     setState(node, externalState) {
       if (!node) return false;
       const next = normalizeExternalDoraState(externalState);
+      if (externalState?.slot) setStateSlot(node, externalState.slot);
       setState(node, next);
       node._doraRows = next.rows;
       node._doraGlobals = next.globals;
@@ -642,6 +665,16 @@ function installGlobalStateApi() {
       node.setDirtyCanvas?.(true, true);
       node.graph?.change?.();
       return true;
+    },
+    getSlot(node) {
+      return getStateSlot(node);
+    },
+    setSlot(node, value) {
+      const slot = setStateSlot(node, value);
+      try { rebuild(node); } catch (_) {}
+      node?.setDirtyCanvas?.(true, true);
+      node?.graph?.change?.();
+      return slot;
     },
   };
 }
@@ -1424,6 +1457,13 @@ function buildUI(node, state, loraValues) {
   });
   wRefresh.serialize = false;
 
+  const wStateSlot = node.addWidget("text", "state_slot", getStateSlot(node), (v) => {
+    setStateSlot(node, v);
+    node.setDirtyCanvas?.(true, true);
+    node.graph?.change?.();
+  });
+  wStateSlot.label = "State slot";
+
   node._doraRows.forEach((row, i) => {
     const widget = new DoraLoraRowWidget(`LORA_${i + 1}`, node, row);
     if (typeof node.addCustomWidget === "function") {
@@ -1707,6 +1747,7 @@ app.registerExtension({
           st = defaultState();
         }
         setState(this, st);
+        setStateSlot(this, info?.properties?.dora_state_slot ?? this.properties?.dora_state_slot ?? `loader_${this.id ?? "default"}`);
 
         if (origConfigure) {
           const safeInfo = info ? { ...info } : info;
@@ -1737,6 +1778,7 @@ app.registerExtension({
       } catch (_) {}
       o.properties = o.properties || {};
       o.properties.dora_power_lora = getState(this);
+      o.properties.dora_state_slot = getStateSlot(this);
       o.widgets_values = [];
     };
   },

--- a/web/dora_power_lora_loader.js
+++ b/web/dora_power_lora_loader.js
@@ -652,7 +652,9 @@ function installGlobalStateApi() {
     setState(node, externalState) {
       if (!node) return false;
       const next = normalizeExternalDoraState(externalState);
-      if (externalState?.slot) setStateSlot(node, externalState.slot);
+      if (externalState && Object.prototype.hasOwnProperty.call(externalState, "slot")) {
+        setStateSlot(node, externalState.slot);
+      }
       setState(node, next);
       node._doraRows = next.rows;
       node._doraGlobals = next.globals;
@@ -1458,7 +1460,7 @@ function buildUI(node, state, loraValues) {
   wRefresh.serialize = false;
 
   const wStateSlot = node.addWidget("text", "state_slot", getStateSlot(node), (v) => {
-    setStateSlot(node, v);
+    wStateSlot.value = setStateSlot(node, v);
     node.setDirtyCanvas?.(true, true);
     node.graph?.change?.();
   });

--- a/web/dora_state_manager.js
+++ b/web/dora_state_manager.js
@@ -78,13 +78,25 @@ function defaultPrompt() {
   };
 }
 
+function defaultLoaderStack(slot = "default", label = "Default loader") {
+  return {
+    slot: normalizeLoaderSlot(slot, "default"),
+    label: String(label || slot || "Default loader"),
+    loras: [],
+    loader_globals: {},
+  };
+}
+
 function defaultCharacter() {
+  const stack = defaultLoaderStack();
   return {
     id: "default_character",
     name: "Default Character",
     thumbnail: {},
-    loras: [],
-    loader_globals: {},
+    loader_stacks: [stack],
+    // Legacy/default stack mirror. Kept for old workflows and old consumers.
+    loras: stack.loras,
+    loader_globals: stack.loader_globals,
     prompts: [defaultPrompt()],
   };
 }
@@ -187,6 +199,99 @@ function normalizeLoaderGlobals(globalsIn) {
   return out;
 }
 
+function normalizeLoaderSlot(value, fallback = "default") {
+  const text = String(value ?? "")
+    .trim()
+    .replace(/[^A-Za-z0-9_.:-]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+  return text || fallback;
+}
+
+function normalizeLoaderStack(stack, index = 0) {
+  const src = stack && typeof stack === "object" ? stack : {};
+  const slot = normalizeLoaderSlot(src.slot ?? src.id ?? src.name, `loader_${index + 1}`);
+  const label = String(src.label ?? src.name ?? slot).trim() || slot;
+  const rowsIn = Array.isArray(src.loras) ? src.loras : Array.isArray(src.rows) ? src.rows : [];
+  return {
+    slot,
+    label,
+    loras: rowsIn.map(normalizeLoraRow).filter(Boolean),
+    loader_globals: normalizeLoaderGlobals(src.loader_globals ?? src.globals),
+  };
+}
+
+function normalizeLoaderStacks(character) {
+  const c = character && typeof character === "object" ? character : {};
+  const raw = [];
+  if (Array.isArray(c.loader_stacks)) {
+    raw.push(...c.loader_stacks);
+  } else if (c.loader_stacks && typeof c.loader_stacks === "object") {
+    for (const [slot, stack] of Object.entries(c.loader_stacks)) {
+      if (stack && typeof stack === "object") raw.push({ ...stack, slot: stack.slot ?? slot });
+    }
+  }
+
+  const stacks = [];
+  const used = new Set();
+  raw.forEach((stack, index) => {
+    const normalized = normalizeLoaderStack(stack, index);
+    let slot = normalized.slot;
+    const base = slot;
+    let suffix = 2;
+    while (used.has(slot)) slot = `${base}_${suffix++}`;
+    used.add(slot);
+    normalized.slot = slot;
+    stacks.push(normalized);
+  });
+
+  if (!stacks.length) {
+    stacks.push({
+      slot: "default",
+      label: "Default loader",
+      loras: Array.isArray(c.loras) ? c.loras.map(normalizeLoraRow).filter(Boolean) : [],
+      loader_globals: normalizeLoaderGlobals(c.loader_globals ?? c.globals),
+    });
+  }
+  return stacks;
+}
+
+function syncLegacyLoaderMirror(character) {
+  const stacks = normalizeLoaderStacks(character);
+  character.loader_stacks = stacks;
+  const primary = stacks.find((stack) => stack.slot === "default") || stacks[0] || defaultLoaderStack();
+  character.loras = primary.loras || [];
+  character.loader_globals = primary.loader_globals || {};
+  return character;
+}
+
+function getCharacterLoaderStacks(character) {
+  syncLegacyLoaderMirror(character);
+  return character.loader_stacks;
+}
+
+function findCharacterLoaderStack(character, slot, { allowFallback = true } = {}) {
+  const stacks = getCharacterLoaderStacks(character);
+  const wanted = normalizeLoaderSlot(slot, "default");
+  const exact = stacks.find((stack) => normalizeLoaderSlot(stack.slot, "default") === wanted);
+  if (exact) return exact;
+  if (!allowFallback) return null;
+  return stacks.find((stack) => stack.slot === "default") || stacks[0] || null;
+}
+
+function setCharacterLoaderStack(character, stack) {
+  const normalized = normalizeLoaderStack(stack, getCharacterLoaderStacks(character).length);
+  const stacks = getCharacterLoaderStacks(character);
+  const index = stacks.findIndex((existing) => normalizeLoaderSlot(existing.slot, "default") === normalized.slot);
+  if (index >= 0) stacks[index] = normalized;
+  else stacks.push(normalized);
+  syncLegacyLoaderMirror(character);
+  return normalized;
+}
+
+function loaderStackActiveRowCount(stack) {
+  return (stack?.loras || []).filter((row) => row.enabled && row.name && row.name !== "None").length;
+}
+
 function normalizeLoraRow(row) {
   const r = row && typeof row === "object" ? row : {};
   const strengthModel = normalizeNumber(r.strength_model ?? r.strengthModel ?? r.strength, 1.0);
@@ -213,15 +318,16 @@ function normalizePrompt(prompt, index) {
 function normalizeCharacter(character, index) {
   const c = character && typeof character === "object" ? character : {};
   const prompts = Array.isArray(c.prompts) ? c.prompts.map(normalizePrompt).filter(Boolean) : [];
-  return {
+  const normalized = {
     id: cleanId(c.id, `character_${index + 1}`),
     name: String(c.name ?? `Character ${index + 1}`).trim() || `Character ${index + 1}`,
     thumbnail: normalizeThumbnail(c.thumbnail),
-    loras: Array.isArray(c.loras) ? c.loras.map(normalizeLoraRow) : [],
-    loader_globals: normalizeLoaderGlobals(c.loader_globals ?? c.globals),
+    loader_stacks: normalizeLoaderStacks(c),
     prompts: prompts.length ? prompts : [defaultPrompt()],
   };
+  return syncLegacyLoaderMirror(normalized);
 }
+
 
 function normalizeState(raw) {
   const parsed = safeJsonParse(raw, defaultState());
@@ -455,38 +561,70 @@ function getControlledNodes(node) {
   return uniqueNodes(getControlledTargets(node));
 }
 
-function normalizeDoraLoaderState(state) {
+function getDoraLoaderSlot(sourceNode, fallbackIndex = 0) {
+  const loaderApi = globalThis.__doraPowerLoraLoaderApi;
+  if (loaderApi?.getSlot && isDoraLoaderNode(sourceNode)) {
+    return normalizeLoaderSlot(loaderApi.getSlot(sourceNode), `loader_${sourceNode?.id ?? fallbackIndex + 1}`);
+  }
+  const widgetMap = getWidgetMap(sourceNode);
+  const widgetValue = widgetMap.get("state_slot")?.value;
+  const propValue = sourceNode?.properties?.dora_state_slot;
+  return normalizeLoaderSlot(widgetValue ?? propValue, `loader_${sourceNode?.id ?? fallbackIndex + 1}`);
+}
+
+function getDoraLoaderLabel(sourceNode, slot) {
+  const title = String(sourceNode?.title || "").trim();
+  if (title && title !== DORA_LOADER_CLASS) return title;
+  return slot || "loader";
+}
+
+function normalizeDoraLoaderState(state, sourceNode = null, fallbackIndex = 0) {
   const st = state && typeof state === "object" ? state : {};
   const rowsIn = Array.isArray(st.rows) ? st.rows : Array.isArray(st.loras) ? st.loras : [];
   const rows = rowsIn.map(normalizeLoraRow).filter((row) => row.name && row.name !== "None");
+  const slot = normalizeLoaderSlot(st.slot ?? (sourceNode ? getDoraLoaderSlot(sourceNode, fallbackIndex) : "default"), `loader_${sourceNode?.id ?? fallbackIndex + 1}`);
   return {
+    slot,
+    label: String(st.label ?? getDoraLoaderLabel(sourceNode, slot)).trim() || slot,
     loras: rows,
     loader_globals: normalizeLoaderGlobals(st.globals ?? st.loader_globals),
   };
 }
 
-function extractLoraStackFromNode(sourceNode) {
+function extractLoraStackFromNode(sourceNode, fallbackIndex = 0) {
   if (!sourceNode) return null;
   const loaderApi = globalThis.__doraPowerLoraLoaderApi;
-  if (loaderApi?.getState && isDoraLoaderNode(sourceNode)) return normalizeDoraLoaderState(loaderApi.getState(sourceNode));
-  if (sourceNode.properties?.dora_power_lora) return normalizeDoraLoaderState(sourceNode.properties.dora_power_lora);
+  if (loaderApi?.getState && isDoraLoaderNode(sourceNode)) return normalizeDoraLoaderState(loaderApi.getState(sourceNode), sourceNode, fallbackIndex);
+  if (sourceNode.properties?.dora_power_lora) return normalizeDoraLoaderState(sourceNode.properties.dora_power_lora, sourceNode, fallbackIndex);
   if (sourceNode._doraRows || sourceNode._doraGlobals) {
-    return normalizeDoraLoaderState({ rows: sourceNode._doraRows || [], globals: sourceNode._doraGlobals || {} });
+    return normalizeDoraLoaderState({ rows: sourceNode._doraRows || [], globals: sourceNode._doraGlobals || {} }, sourceNode, fallbackIndex);
   }
   if (sourceNode.properties?.dora_state_manager?.state) {
     const state = normalizeState(sourceNode.properties.dora_state_manager.state);
     const charId = sourceNode.properties.dora_state_manager.selected_character_id;
     const character = selectedCharacter(state, charId);
-    return { loras: character.loras || [], loader_globals: character.loader_globals || {} };
+    const stack = findCharacterLoaderStack(character, getDoraLoaderSlot(sourceNode, fallbackIndex));
+    return stack ? structuredCloneCompat(stack) : null;
   }
   return null;
 }
 
 function applyLoraStackToNode(targetNode, character) {
   if (!targetNode || !isDoraLoaderNode(targetNode)) return false;
-  const payload = { loras: character.loras || [], loader_globals: character.loader_globals || {} };
+  const slot = getDoraLoaderSlot(targetNode);
+  const stack = findCharacterLoaderStack(character, slot, { allowFallback: true });
+  if (!stack) return false;
+  const payload = {
+    slot,
+    label: stack.label,
+    loras: stack.loras || [],
+    loader_globals: stack.loader_globals || {},
+  };
   const loaderApi = globalThis.__doraPowerLoraLoaderApi;
-  if (loaderApi?.setState) return !!loaderApi.setState(targetNode, payload);
+  if (loaderApi?.setState) {
+    loaderApi.setSlot?.(targetNode, slot);
+    return !!loaderApi.setState(targetNode, payload);
+  }
 
   const rows = (payload.loras || []).map((row) => ({
     enabled: !!row.enabled,
@@ -495,12 +633,14 @@ function applyLoraStackToNode(targetNode, character) {
     strengthClip: normalizeNumber(row.strength_clip, normalizeNumber(row.strength_model, 1.0)),
   }));
   targetNode.properties = targetNode.properties || {};
+  targetNode.properties.dora_state_slot = slot;
   targetNode.properties.dora_power_lora = { rows, globals: normalizeLoaderGlobals(payload.loader_globals) };
   targetNode._doraRows = rows;
   targetNode._doraGlobals = normalizeLoaderGlobals(payload.loader_globals);
   markNodeDirty(targetNode);
   return true;
 }
+
 
 function getSelectedGraphNodes() {
   const selected = app?.canvas?.selected_nodes;
@@ -793,12 +933,14 @@ function saveConnectedState(targetNode, character, prompt) {
   const controlledLoaderTargets = controlledNodes.filter(isDoraLoaderNode);
   const legacyLoaderTargets = controlledLoaderTargets.length ? [] : uniqueNodes([...getOutputTargets(targetNode, OUTPUT_NAMES.lora)]).filter(isDoraLoaderNode);
   const loaderTargets = controlledLoaderTargets.length ? controlledLoaderTargets : legacyLoaderTargets;
-  const loaderStack = loaderTargets.map(extractLoraStackFromNode).find(Boolean);
-  if (loaderStack) {
-    character.loras = loaderStack.loras || [];
-    character.loader_globals = loaderStack.loader_globals || {};
-    changes.push("LoRA stack");
-  }
+  let savedLoaders = 0;
+  loaderTargets.forEach((loader, index) => {
+    const stack = extractLoraStackFromNode(loader, index);
+    if (!stack) return;
+    setCharacterLoaderStack(character, stack);
+    savedLoaders += 1;
+  });
+  if (savedLoaders) changes.push(`${savedLoaders} LoRA loader${savedLoaders === 1 ? "" : "s"}`);
 
   const controlledTextNodes = controlledNodes.filter(isStateTextNode);
   let savedPositive = false;
@@ -854,6 +996,7 @@ function saveConnectedState(targetNode, character, prompt) {
   return [...new Set(changes)];
 }
 
+
 function applyConnectedState(targetNode, character, prompt) {
   const changes = [];
   const controlledNodes = getControlledNodes(targetNode).filter((node) => node && node !== targetNode);
@@ -863,7 +1006,7 @@ function applyConnectedState(targetNode, character, prompt) {
   const loaderTargets = controlledLoaderTargets.length ? controlledLoaderTargets : legacyLoaderTargets;
   let loaderChanged = 0;
   for (const loader of loaderTargets) if (applyLoraStackToNode(loader, character)) loaderChanged += 1;
-  if (loaderChanged) changes.push(`LoRA stack to ${loaderChanged} loader${loaderChanged === 1 ? "" : "s"}`);
+  if (loaderChanged) changes.push(`LoRA stacks to ${loaderChanged} loader${loaderChanged === 1 ? "" : "s"}`);
 
   const controlledTextNodes = controlledNodes.filter(isStateTextNode);
   let posChanged = 0;
@@ -892,6 +1035,7 @@ function applyConnectedState(targetNode, character, prompt) {
   return changes;
 }
 
+
 function classifySelectedTextNodes(nodes) {
   const textNodes = nodes
     .map((node) => ({
@@ -910,15 +1054,17 @@ function classifySelectedTextNodes(nodes) {
 function saveSelectedState(targetNode, character, prompt) {
   const selected = getSelectedGraphNodes().filter((node) => node && node !== targetNode);
   const changes = [];
-  const loader = selected.find(isDoraLoaderNode);
-  const stack = extractLoraStackFromNode(loader);
-  if (stack) {
-    character.loras = stack.loras || [];
-    character.loader_globals = stack.loader_globals || {};
-    changes.push("LoRA stack");
-  }
+  const loaders = selected.filter(isDoraLoaderNode);
+  let savedLoaders = 0;
+  loaders.forEach((loader, index) => {
+    const stack = extractLoraStackFromNode(loader, index);
+    if (!stack) return;
+    setCharacterLoaderStack(character, stack);
+    savedLoaders += 1;
+  });
+  if (savedLoaders) changes.push(`${savedLoaders} LoRA loader${savedLoaders === 1 ? "" : "s"}`);
 
-  const classified = classifySelectedTextNodes(selected.filter((node) => node !== loader && !isSeedNode(node)));
+  const classified = classifySelectedTextNodes(selected.filter((node) => !isDoraLoaderNode(node) && !isSeedNode(node)));
   if (classified.positive) {
     prompt.positive = classified.positive.text;
     changes.push("positive prompt template");
@@ -928,7 +1074,7 @@ function saveSelectedState(targetNode, character, prompt) {
     changes.push("negative prompt template");
   }
 
-  const used = new Set([loader, ...classified.used].filter(Boolean));
+  const used = new Set([...loaders, ...classified.used].filter(Boolean));
   const settingNodes = selected.filter((node) => !used.has(node));
   const snapshots = mergeCapturedSettings(prompt, settingNodes, { replaceNodes: true });
   if (snapshots.length) changes.push(`settings from ${snapshots.length} node${snapshots.length === 1 ? "" : "s"}`);
@@ -936,13 +1082,14 @@ function saveSelectedState(targetNode, character, prompt) {
   return [...new Set(changes)];
 }
 
+
 function applySelectedState(targetNode, character, prompt) {
   const selected = getSelectedGraphNodes().filter((node) => node && node !== targetNode);
   const changes = [];
   const loaderTargets = selected.filter(isDoraLoaderNode);
   let loaderChanged = 0;
   for (const loader of loaderTargets) if (applyLoraStackToNode(loader, character)) loaderChanged += 1;
-  if (loaderChanged) changes.push(`LoRA stack to ${loaderChanged} loader${loaderChanged === 1 ? "" : "s"}`);
+  if (loaderChanged) changes.push(`LoRA stacks to ${loaderChanged} loader${loaderChanged === 1 ? "" : "s"}`);
 
   const classified = classifySelectedTextNodes(selected.filter((node) => !isDoraLoaderNode(node) && !isSeedNode(node)));
   if (classified.positive && applyTextToNode(classified.positive.node, prompt.positive, "positive")) changes.push("positive template");
@@ -954,6 +1101,7 @@ function applySelectedState(targetNode, character, prompt) {
   if (settingsChanged) changes.push(`settings/seed to ${settingsChanged} node${settingsChanged === 1 ? "" : "s"}`);
   return changes;
 }
+
 
 async function uploadThumbnailFile(file) {
   const body = new FormData();
@@ -971,6 +1119,12 @@ async function uploadThumbnailFile(file) {
     type: String(payload?.type ?? "input").trim() || "input",
     cacheKey: String(Date.now()),
   };
+}
+
+function stopComfyFileDropEvent(event) {
+  event.preventDefault();
+  event.stopPropagation();
+  event.stopImmediatePropagation?.();
 }
 
 function makeButton(label, callback, title = "") {
@@ -1057,7 +1211,9 @@ function renderCharacterTile(node, state, uiState, character, selectedId) {
   name.textContent = character.name;
   const meta = document.createElement("div");
   meta.className = "dsm-muted";
-  meta.textContent = `${character.loras.filter((row) => row.enabled && row.name !== "None").length} LoRA · ${character.prompts.length} preset${character.prompts.length === 1 ? "" : "s"}`;
+  const stacks = getCharacterLoaderStacks(character);
+  const rowCount = stacks.reduce((sum, stack) => sum + loaderStackActiveRowCount(stack), 0);
+  meta.textContent = `${stacks.length} loader${stacks.length === 1 ? "" : "s"} · ${rowCount} LoRA · ${character.prompts.length} preset${character.prompts.length === 1 ? "" : "s"}`;
   tile.append(thumb, name, meta);
   tile.addEventListener("click", () => {
     const promptId = character.prompts[0]?.id || "";
@@ -1191,31 +1347,44 @@ function renderCharacterPanel(node, state, uiState, character) {
       fileInput.value = "";
     }
   });
-  preview.addEventListener("click", () => fileInput.click());
-  preview.addEventListener("dragover", (event) => {
+  preview.addEventListener("click", (event) => {
     event.preventDefault();
-    preview.classList.add("dragging");
+    event.stopPropagation();
+    fileInput.click();
   });
-  preview.addEventListener("dragleave", () => preview.classList.remove("dragging"));
+  preview.addEventListener("dragenter", (event) => {
+    stopComfyFileDropEvent(event);
+    preview.classList.add("dragging");
+  }, true);
+  preview.addEventListener("dragover", (event) => {
+    stopComfyFileDropEvent(event);
+    preview.classList.add("dragging");
+  }, true);
+  preview.addEventListener("dragleave", (event) => {
+    event.stopPropagation();
+    preview.classList.remove("dragging");
+  }, true);
   preview.addEventListener("drop", async (event) => {
-    event.preventDefault();
+    stopComfyFileDropEvent(event);
     preview.classList.remove("dragging");
     const file = [...(event.dataTransfer?.files || [])].find((candidate) => candidate.type.startsWith("image/"));
     if (!file) return;
     try {
       character.thumbnail = await uploadThumbnailFile(file);
-      updateState(node, state, uiState, { characterId: character.id, status: "Thumbnail uploaded." });
+      updateState(node, state, uiState, { characterId: character.id, status: "Original character image uploaded. UI preview is CSS-scaled only; backend image output loads the original file." });
     } catch (err) {
       setStatus(node, `Thumbnail upload failed: ${err?.message || err}`);
     }
-  });
+  }, true);
 
   const loraSummary = document.createElement("div");
   loraSummary.className = "dsm-lora-summary";
-  const activeRows = character.loras.filter((row) => row.enabled && row.name && row.name !== "None");
-  loraSummary.textContent = activeRows.length
-    ? activeRows.map((row) => `${row.name} (${row.strength_model}/${row.strength_clip})`).join("\n")
-    : "No saved LoRA stack for this character.";
+  const stackLines = getCharacterLoaderStacks(character).flatMap((stack) => {
+    const activeRows = (stack.loras || []).filter((row) => row.enabled && row.name && row.name !== "None");
+    if (!activeRows.length) return [`[${stack.slot}] ${stack.label}: empty`];
+    return [`[${stack.slot}] ${stack.label}`, ...activeRows.map((row) => `  ${row.name} (${row.strength_model}/${row.strength_clip})`)];
+  });
+  loraSummary.textContent = stackLines.length ? stackLines.join("\n") : "No saved LoRA stack for this character.";
 
   const thumbnailButtons = document.createElement("div");
   thumbnailButtons.className = "dsm-toolbar";
@@ -1227,7 +1396,11 @@ function renderCharacterPanel(node, state, uiState, character) {
     })
   );
 
-  section.append(title, labelledControl("Name", nameInput), preview, fileInput, thumbnailButtons, labelledControl("Saved LoRA stack", loraSummary));
+  const imageNote = document.createElement("div");
+  imageNote.className = "dsm-muted";
+  imageNote.textContent = "The State Manager image output loads the original uploaded file, not the CSS-scaled preview.";
+
+  section.append(title, labelledControl("Name", nameInput), preview, fileInput, thumbnailButtons, imageNote, labelledControl("Saved LoRA stacks", loraSummary));
   return section;
 }
 
@@ -1312,104 +1485,200 @@ function renderPromptPanelContent(section, node, state, uiState, character, prom
   section.append(header, labelledControl("Preset name", name), labelledControl("Positive template", positive), labelledControl("Negative template", negative));
 }
 
-function renderLoraPanelContent(section, node, state, uiState, character, prompt) {
-  const header = document.createElement("div");
-  header.className = "dsm-toolbar";
-  header.append(
-    makeButton("Save connected loader", () => {
-      const controlledLoaders = getControlledNodes(node).filter(isDoraLoaderNode);
-      const loaders = controlledLoaders.length ? controlledLoaders : uniqueNodes(getOutputTargets(node, OUTPUT_NAMES.lora)).filter(isDoraLoaderNode);
-      const stack = loaders.map(extractLoraStackFromNode).find(Boolean);
-      if (stack) {
-        character.loras = stack.loras;
-        character.loader_globals = stack.loader_globals;
+function renderLoraStackEditor(section, node, state, uiState, character, prompt, stack, stackIndex) {
+  const box = document.createElement("div");
+  box.className = "dsm-stack-box";
+
+  const title = document.createElement("div");
+  title.className = "dsm-toolbar";
+  const slot = makeInput(stack.slot, (value) => {
+    const oldSlot = stack.slot;
+    stack.slot = normalizeLoaderSlot(value, oldSlot || `loader_${stackIndex + 1}`);
+    if (stack.slot !== oldSlot) syncLegacyLoaderMirror(character);
+    updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id, status: `Renamed loader slot ${oldSlot} -> ${stack.slot}. Update the matching DoRA loader's State slot too.` });
+  });
+  const label = makeInput(stack.label, (value) => {
+    stack.label = String(value || stack.slot).trim() || stack.slot;
+    syncLegacyLoaderMirror(character);
+    updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id });
+  });
+  title.append(
+    labelledControl("Slot", slot),
+    labelledControl("Label", label),
+    makeButton("Add row", () => {
+      stack.loras.push({ enabled: true, name: "None", strength_model: 1.0, strength_clip: 1.0 });
+      syncLegacyLoaderMirror(character);
+      updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id, status: `Added LoRA row to ${stack.slot}.` });
+    }),
+    makeButton("Delete stack", () => {
+      const stacks = getCharacterLoaderStacks(character);
+      if (stacks.length <= 1) {
+        setStatus(node, "At least one loader stack must remain.");
+        return;
       }
-      updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id, status: stack ? "Saved LoRA stack from connected loader." : "No connected DoRA loader found." });
-    }),
-    makeButton("Apply connected loader", () => {
-      const controlledLoaders = getControlledNodes(node).filter(isDoraLoaderNode);
-      const loaders = controlledLoaders.length ? controlledLoaders : uniqueNodes(getOutputTargets(node, OUTPUT_NAMES.lora)).filter(isDoraLoaderNode);
-      let count = 0;
-      for (const loader of loaders) if (applyLoraStackToNode(loader, character)) count += 1;
-      updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id, status: count ? `Applied LoRA stack to ${count} connected loader${count === 1 ? "" : "s"}.` : "No connected DoRA loader accepted the stack." });
-    }),
-    makeButton("Add manual row", () => {
-      character.loras.push({ enabled: true, name: "None", strength_model: 1.0, strength_clip: 1.0 });
-      updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id, status: "Added manual LoRA row." });
+      const idx = stacks.findIndex((candidate) => normalizeLoaderSlot(candidate.slot, "default") === normalizeLoaderSlot(stack.slot, "default"));
+      if (idx >= 0) stacks.splice(idx, 1);
+      syncLegacyLoaderMirror(character);
+      updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id, status: `Deleted loader stack ${stack.slot}.` });
     })
   );
-  section.appendChild(header);
+  box.appendChild(title);
 
-  if (!character.loras.length) {
+  const globals = stack.loader_globals || (stack.loader_globals = {});
+  const globalsLine = document.createElement("div");
+  globalsLine.className = "dsm-grid2";
+  globalsLine.append(
+    labelledControl("Stack enabled", makeCheckbox(globals.stack_enabled ?? true, (checked) => {
+      stack.loader_globals = normalizeLoaderGlobals({ ...globals, stack_enabled: checked });
+      syncLegacyLoaderMirror(character);
+      updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id });
+    })),
+    labelledControl("Auto-strength", makeCheckbox(globals.auto_strength_enabled ?? false, (checked) => {
+      stack.loader_globals = normalizeLoaderGlobals({ ...globals, auto_strength_enabled: checked });
+      syncLegacyLoaderMirror(character);
+      updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id });
+    })),
+    labelledControl("Analysis device", makeSelect(AUTO_STRENGTH_DEVICE_CHOICES, normalizeDevice(globals.auto_strength_device ?? "gpu"), (value) => {
+      stack.loader_globals = normalizeLoaderGlobals({ ...globals, auto_strength_device: value });
+      syncLegacyLoaderMirror(character);
+      updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id });
+    })),
+    labelledControl("Ratio ceiling", makeInput(globals.auto_strength_ratio_ceiling ?? 1.5, (value) => {
+      stack.loader_globals = normalizeLoaderGlobals({ ...globals, auto_strength_ratio_ceiling: normalizeNumber(value, 1.5) });
+      syncLegacyLoaderMirror(character);
+      updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id });
+    }, { type: "number", step: "0.01" }))
+  );
+  box.appendChild(globalsLine);
+
+  if (!stack.loras.length) {
     const empty = document.createElement("div");
     empty.className = "dsm-muted";
-    empty.textContent = "No LoRA stack saved. Save a connected/selected DoRA loader or add manual rows.";
-    section.appendChild(empty);
-    return;
+    empty.textContent = `No LoRA rows saved for slot ${stack.slot}.`;
+    box.appendChild(empty);
   }
 
-  character.loras.forEach((row, index) => {
+  stack.loras.forEach((row, index) => {
     const line = document.createElement("div");
     line.className = "dsm-lora-row";
     const enabled = makeCheckbox(row.enabled, (checked) => {
       row.enabled = checked;
+      syncLegacyLoaderMirror(character);
       updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id });
     });
     const name = makeInput(row.name, (value) => {
       row.name = value.trim() || "None";
+      syncLegacyLoaderMirror(character);
       updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id });
     });
     const sm = makeInput(row.strength_model, (value) => {
       row.strength_model = normalizeNumber(value, row.strength_model);
+      syncLegacyLoaderMirror(character);
       updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id });
     }, { type: "number", step: "0.05" });
     const sc = makeInput(row.strength_clip, (value) => {
       row.strength_clip = normalizeNumber(value, row.strength_clip);
+      syncLegacyLoaderMirror(character);
       updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id });
     }, { type: "number", step: "0.05" });
     line.append(enabled, name, sm, sc, makeButton("×", () => {
-      character.loras.splice(index, 1);
-      updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id, status: "Removed LoRA row." });
+      stack.loras.splice(index, 1);
+      syncLegacyLoaderMirror(character);
+      updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id, status: `Removed LoRA row from ${stack.slot}.` });
     }));
-    section.appendChild(line);
+    box.appendChild(line);
   });
+
+  section.appendChild(box);
 }
 
+function renderLoraPanelContent(section, node, state, uiState, character, prompt) {
+  const header = document.createElement("div");
+  header.className = "dsm-toolbar";
+  header.append(
+    makeButton("Save connected loaders", () => {
+      const controlledLoaders = getControlledNodes(node).filter(isDoraLoaderNode);
+      const loaders = controlledLoaders.length ? controlledLoaders : uniqueNodes(getOutputTargets(node, OUTPUT_NAMES.lora)).filter(isDoraLoaderNode);
+      let count = 0;
+      loaders.forEach((loader, index) => {
+        const stack = extractLoraStackFromNode(loader, index);
+        if (!stack) return;
+        setCharacterLoaderStack(character, stack);
+        count += 1;
+      });
+      updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id, status: count ? `Saved ${count} connected DoRA loader${count === 1 ? "" : "s"}.` : "No connected DoRA loader found." });
+    }),
+    makeButton("Apply connected loaders", () => {
+      const controlledLoaders = getControlledNodes(node).filter(isDoraLoaderNode);
+      const loaders = controlledLoaders.length ? controlledLoaders : uniqueNodes(getOutputTargets(node, OUTPUT_NAMES.lora)).filter(isDoraLoaderNode);
+      let count = 0;
+      for (const loader of loaders) if (applyLoraStackToNode(loader, character)) count += 1;
+      updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id, status: count ? `Applied saved LoRA stacks to ${count} connected loader${count === 1 ? "" : "s"}.` : "No connected DoRA loader accepted a matching stack." });
+    }),
+    makeButton("Add loader stack", () => {
+      const stack = defaultLoaderStack(`loader_${getCharacterLoaderStacks(character).length + 1}`, `Loader ${getCharacterLoaderStacks(character).length + 1}`);
+      character.loader_stacks.push(stack);
+      syncLegacyLoaderMirror(character);
+      updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id, status: `Added loader stack ${stack.slot}.` });
+    })
+  );
+  section.appendChild(header);
+
+  const note = document.createElement("div");
+  note.className = "dsm-muted";
+  note.textContent = "Each DoRA loader is matched by its State slot widget. Use unique slots, e.g. face, outfit, style, refiner.";
+  section.appendChild(note);
+
+  for (const [index, stack] of getCharacterLoaderStacks(character).entries()) {
+    renderLoraStackEditor(section, node, state, uiState, character, prompt, stack, index);
+  }
+}
+
+
 function renderSettingsPanelContent(section, node, state, uiState, character, prompt) {
-  const globals = character.loader_globals || (character.loader_globals = {});
+  const primaryStack = findCharacterLoaderStack(character, "default") || getCharacterLoaderStacks(character)[0];
+  const globals = primaryStack.loader_globals || (primaryStack.loader_globals = {});
   const grid = document.createElement("div");
   grid.className = "dsm-grid2";
 
   const stackEnabled = makeCheckbox(globals.stack_enabled ?? true, (checked) => {
-    character.loader_globals = normalizeLoaderGlobals({ ...globals, stack_enabled: checked });
+    primaryStack.loader_globals = normalizeLoaderGlobals({ ...globals, stack_enabled: checked });
+    syncLegacyLoaderMirror(character);
     updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id });
   });
   const autoStrength = makeCheckbox(globals.auto_strength_enabled ?? false, (checked) => {
-    character.loader_globals = normalizeLoaderGlobals({ ...globals, auto_strength_enabled: checked });
+    primaryStack.loader_globals = normalizeLoaderGlobals({ ...globals, auto_strength_enabled: checked });
+    syncLegacyLoaderMirror(character);
     updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id });
   });
   const device = makeSelect(AUTO_STRENGTH_DEVICE_CHOICES, normalizeDevice(globals.auto_strength_device ?? "gpu"), (value) => {
-    character.loader_globals = normalizeLoaderGlobals({ ...globals, auto_strength_device: value });
+    primaryStack.loader_globals = normalizeLoaderGlobals({ ...globals, auto_strength_device: value });
+    syncLegacyLoaderMirror(character);
     updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id });
   });
   const broadcastMods = makeCheckbox(globals.broadcast_modulations ?? true, (checked) => {
-    character.loader_globals = normalizeLoaderGlobals({ ...globals, broadcast_modulations: checked });
+    primaryStack.loader_globals = normalizeLoaderGlobals({ ...globals, broadcast_modulations: checked });
+    syncLegacyLoaderMirror(character);
     updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id });
   });
   const floor = makeInput(globals.auto_strength_ratio_floor ?? 0.3, (value) => {
-    character.loader_globals = normalizeLoaderGlobals({ ...globals, auto_strength_ratio_floor: normalizeNumber(value, 0.3) });
+    primaryStack.loader_globals = normalizeLoaderGlobals({ ...globals, auto_strength_ratio_floor: normalizeNumber(value, 0.3) });
+    syncLegacyLoaderMirror(character);
     updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id });
   }, { type: "number", step: "0.01" });
   const ceiling = makeInput(globals.auto_strength_ratio_ceiling ?? 1.5, (value) => {
-    character.loader_globals = normalizeLoaderGlobals({ ...globals, auto_strength_ratio_ceiling: normalizeNumber(value, 1.5) });
+    primaryStack.loader_globals = normalizeLoaderGlobals({ ...globals, auto_strength_ratio_ceiling: normalizeNumber(value, 1.5) });
+    syncLegacyLoaderMirror(character);
     updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id });
   }, { type: "number", step: "0.01" });
   const sliceFix = makeCheckbox(globals.dora_slice_fix ?? true, (checked) => {
-    character.loader_globals = normalizeLoaderGlobals({ ...globals, dora_slice_fix: checked });
+    primaryStack.loader_globals = normalizeLoaderGlobals({ ...globals, dora_slice_fix: checked });
+    syncLegacyLoaderMirror(character);
     updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id });
   });
   const adalnFix = makeCheckbox(globals.dora_adaln_swap_fix ?? true, (checked) => {
-    character.loader_globals = normalizeLoaderGlobals({ ...globals, dora_adaln_swap_fix: checked });
+    primaryStack.loader_globals = normalizeLoaderGlobals({ ...globals, dora_adaln_swap_fix: checked });
+    syncLegacyLoaderMirror(character);
     updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id });
   });
 
@@ -1431,6 +1700,7 @@ function renderSettingsPanelContent(section, node, state, uiState, character, pr
     if (settings.rgthree_seed?.widgets) settings.rgthree_seed.widgets.seed = settings.seed;
     if (settings.rgthree_seed) settings.rgthree_seed.seed = settings.seed;
     prompt.settings = settings;
+    syncLegacyLoaderMirror(character);
     updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id });
   }, { type: "number", step: "1", min: "0" });
 
@@ -1443,6 +1713,7 @@ function renderSettingsPanelContent(section, node, state, uiState, character, pr
   }, { placeholder: "Saved node settings JSON. Save connected/selected nodes to populate this." });
   settingsJson.addEventListener("change", () => {
     settingsJson.value = JSON.stringify(prompt.settings || {}, null, 2);
+    syncLegacyLoaderMirror(character);
     updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id });
   });
 
@@ -1555,6 +1826,7 @@ function ensureStyles() {
     .dsm-character-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-weight: 600; }
     .dsm-tabs { display: flex; gap: 6px; flex-wrap: wrap; }
     .dsm-grid2 { display: grid; grid-template-columns: minmax(0, 1fr) minmax(0, 1fr); gap: 8px; }
+    .dsm-stack-box { border: 1px solid rgba(128,128,128,.28); border-radius: 7px; padding: 7px; display: flex; flex-direction: column; gap: 7px; background: rgba(0,0,0,.10); }
     .dsm-lora-row { display: grid; grid-template-columns: auto minmax(110px, 1fr) 76px 76px auto; gap: 6px; align-items: center; }
     .dsm-lora-summary { white-space: pre-wrap; border: 1px solid rgba(128,128,128,.35); border-radius: 6px; padding: 6px; min-height: 58px; max-height: 190px; overflow: auto; background: rgba(0,0,0,.16); }
     @media (max-width: 720px) { .dsm-main { grid-template-columns: 1fr; } }

--- a/web/dora_state_manager.js
+++ b/web/dora_state_manager.js
@@ -612,7 +612,13 @@ function extractLoraStackFromNode(sourceNode, fallbackIndex = 0) {
 function applyLoraStackToNode(targetNode, character) {
   if (!targetNode || !isDoraLoaderNode(targetNode)) return false;
   const slot = getDoraLoaderSlot(targetNode);
-  const stack = findCharacterLoaderStack(character, slot, { allowFallback: true });
+  let stack = findCharacterLoaderStack(character, slot, { allowFallback: false });
+  if (!stack) {
+    const stacks = getCharacterLoaderStacks(character);
+    const legacyDefault = stacks.length === 1 && normalizeLoaderSlot(stacks[0]?.slot, "default") === "default";
+    if (!legacyDefault) return false;
+    stack = stacks[0];
+  }
   if (!stack) return false;
   const payload = {
     slot,


### PR DESCRIPTION
## Summary
- add State Manager loader_stacks support for multiple DoRA loaders keyed by State slot
- expose and persist a State slot widget on DoRA Power LoRA Loader nodes
- save/apply connected and selected loaders by matching slots, with legacy default-stack compatibility
- add original character_image output with canonical root containment checks

## Validation
- rtk python3 -m py_compile nodes.py
- rtk node --check web/dora_state_manager.js
- rtk node --check web/dora_power_lora_loader.js
- rtk git diff --check

No repository tests were run per instruction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * State Manager now outputs a character image and supports multiple per-loader state slots for independent loader stacks.
  * Per-node slot selection and slot-aware workflows allow saving/applying distinct LoRA stacks to individual loaders.
  * New multi-stack LoRA editor and UI updates (stack counts, per-slot summaries, improved thumbnail drag/drop).

* **Documentation**
  * Expanded workflow instructions clarifying connected save/load vs legacy capture and how to use state slots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->