### PR TITLE
[codex] Add State Manager queue wildcarding

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -462,7 +462,7 @@ class FlexibleOptionalInputType(dict):
 # DoRA state manager payload helpers
 # --------------------------------------------------------------------------------------
 
-_DORA_STATE_MANAGER_SCHEMA_VERSION = 1
+_DORA_STATE_MANAGER_SCHEMA_VERSION = 2
 _DORA_STATE_KIND = "dora_state_manager_state"
 _DORA_LORA_STACK_KIND = "dora_lora_stack"
 _DORA_STATE_SETTINGS_KIND = "dora_state_settings"
@@ -522,6 +522,8 @@ def _state_manager_default_state() -> Dict[str, Any]:
                             {"role": "negative", "slot": "default", "label": "Default negative", "text": ""},
                         ],
                         "settings": {},
+                        "reference_image": {},
+                        "fileimage_prefix": "",
                     }
                 ],
             }
@@ -941,6 +943,8 @@ def _normalize_manager_prompt(prompt: Any, index: int) -> Optional[Dict[str, Any
     prompt_id = _clean_state_id(prompt.get("id"), _state_manager_make_id("prompt", index))
     name = str(prompt.get("name") or f"Prompt {index + 1}").strip() or f"Prompt {index + 1}"
     settings = _normalize_settings_with_canonical_seed(prompt.get("settings", {}))
+    reference_image = _normalize_manager_thumbnail(prompt.get("reference_image", prompt.get("referenceImage", prompt.get("prompt_image", prompt.get("image", {})))))
+    fileimage_prefix = str(prompt.get("fileimage_prefix", prompt.get("filename_prefix", prompt.get("file_image_prefix", ""))) or "").strip()
     text_boxes = _normalize_manager_text_boxes(prompt)
     positive_box = next((box for box in text_boxes if box.get("role") == "positive" and box.get("slot") == "default"), None) or next((box for box in text_boxes if box.get("role") == "positive"), None)
     negative_box = next((box for box in text_boxes if box.get("role") == "negative" and box.get("slot") == "default"), None) or next((box for box in text_boxes if box.get("role") == "negative"), None)
@@ -951,6 +955,8 @@ def _normalize_manager_prompt(prompt: Any, index: int) -> Optional[Dict[str, Any
         "negative": str(negative_box.get("text", "") if negative_box else prompt.get("negative", prompt.get("negative_prompt", "")) or ""),
         "text_boxes": text_boxes,
         "settings": settings,
+        "reference_image": reference_image,
+        "fileimage_prefix": fileimage_prefix,
     }
 
 
@@ -1085,6 +1091,8 @@ def _resolve_dora_state_payload(
         "prompt": {
             "id": prompt.get("id", ""),
             "name": prompt.get("name", ""),
+            "reference_image": prompt.get("reference_image", {}),
+            "fileimage_prefix": str(prompt.get("fileimage_prefix", "") or ""),
         },
         "loader_stacks": loader_stacks,
         "loras": loras,
@@ -1093,6 +1101,8 @@ def _resolve_dora_state_payload(
         "text_boxes": text_boxes,
         "positive_prompt": positive,
         "negative_prompt": negative,
+        "reference_image": prompt.get("reference_image", {}),
+        "fileimage_prefix": str(prompt.get("fileimage_prefix", "") or ""),
     }
 
 
@@ -1159,8 +1169,8 @@ def _state_manager_thumbnail_path(thumbnail: Any) -> Optional[str]:
     return path
 
 
-def _load_state_manager_character_image(character: Dict[str, Any]) -> torch.Tensor:
-    path = _state_manager_thumbnail_path(character.get("thumbnail", {}) if isinstance(character, dict) else {})
+def _load_state_manager_image_from_info(image_info: Any, label: str = "image") -> torch.Tensor:
+    path = _state_manager_thumbnail_path(image_info)
     if not path:
         return _state_manager_blank_image()
     try:
@@ -1175,8 +1185,19 @@ def _load_state_manager_character_image(character: Dict[str, Any]) -> torch.Tens
             return _state_manager_blank_image()
         return torch.from_numpy(arr)[None, ...]
     except Exception as exc:
-        _LOG.warning("[State Manager] failed to load character image %r: %s", path, exc)
+        _LOG.warning("[State Manager] failed to load %s %r: %s", label, path, exc)
         return _state_manager_blank_image()
+
+
+def _load_state_manager_character_image(character: Dict[str, Any]) -> torch.Tensor:
+    return _load_state_manager_image_from_info(character.get("thumbnail", {}) if isinstance(character, dict) else {}, "character image")
+
+
+def _load_state_manager_prompt_or_character_image(character: Dict[str, Any], prompt: Dict[str, Any]) -> torch.Tensor:
+    prompt_image = prompt.get("reference_image", {}) if isinstance(prompt, dict) else {}
+    if _state_manager_thumbnail_path(prompt_image):
+        return _load_state_manager_image_from_info(prompt_image, "prompt reference image")
+    return _load_state_manager_character_image(character)
 
 
 def _extract_seed_from_settings(settings: Any, fallback: int = 0) -> int:
@@ -1259,6 +1280,8 @@ def _normalize_runtime_dora_state_payload(raw: Any) -> Optional[Dict[str, Any]]:
         "text_boxes": text_boxes,
         "positive_prompt": str(positive_box.get("text", "") if positive_box else payload.get("positive_prompt", "") or ""),
         "negative_prompt": str(negative_box.get("text", "") if negative_box else payload.get("negative_prompt", "") or ""),
+        "reference_image": _normalize_manager_thumbnail(payload.get("reference_image", payload.get("prompt", {}).get("reference_image", {}) if isinstance(payload.get("prompt"), dict) else {})),
+        "fileimage_prefix": str(payload.get("fileimage_prefix", payload.get("prompt", {}).get("fileimage_prefix", "") if isinstance(payload.get("prompt"), dict) else "") or ""),
     }
 
 
@@ -4118,7 +4141,7 @@ class StateManager:
             }
         }
 
-    RETURN_TYPES = ("DORA_STATE", "STRING", "STRING", "STRING", "DORA_LORA_STACK", "DORA_STATE_SETTINGS", "INT", "STATE_MANAGER_CONTROL", "IMAGE")
+    RETURN_TYPES = ("DORA_STATE", "STRING", "STRING", "STRING", "DORA_LORA_STACK", "DORA_STATE_SETTINGS", "INT", "STATE_MANAGER_CONTROL", "IMAGE", "STRING")
     RETURN_NAMES = (
         "dora_state",
         "positive_prompt_template",
@@ -4129,6 +4152,7 @@ class StateManager:
         "seed",
         "state_control",
         "character_image",
+        "fileimage_prefix",
     )
     FUNCTION = "resolve_state"
     CATEGORY = "state managers"
@@ -4191,7 +4215,8 @@ class StateManager:
         seed = _extract_seed_from_settings(settings)
         state = _normalize_state_manager_state(state_json)
         character = _pick_state_manager_character(state, selected_character_id)
-        character_image = _load_state_manager_character_image(character)
+        prompt = _pick_state_manager_prompt(character, selected_prompt_id)
+        character_image = _load_state_manager_prompt_or_character_image(character, prompt)
         return (
             payload,
             payload.get("positive_prompt", ""),
@@ -4202,6 +4227,7 @@ class StateManager:
             seed,
             state_control_payload,
             character_image,
+            payload.get("fileimage_prefix", ""),
         )
 
 

--- a/nodes.py
+++ b/nodes.py
@@ -1169,10 +1169,10 @@ def _state_manager_thumbnail_path(thumbnail: Any) -> Optional[str]:
     return path
 
 
-def _load_state_manager_image_from_info(image_info: Any, label: str = "image") -> torch.Tensor:
+def _try_load_state_manager_image_from_info(image_info: Any, label: str = "image") -> Optional[torch.Tensor]:
     path = _state_manager_thumbnail_path(image_info)
     if not path:
-        return _state_manager_blank_image()
+        return None
     try:
         import numpy as np
         from PIL import Image, ImageOps
@@ -1182,11 +1182,18 @@ def _load_state_manager_image_from_info(image_info: Any, label: str = "image") -
             img = img.convert("RGB")
             arr = np.asarray(img, dtype=np.float32) / 255.0
         if arr.ndim != 3 or arr.shape[-1] != 3:
-            return _state_manager_blank_image()
+            return None
         return torch.from_numpy(arr)[None, ...]
     except Exception as exc:
         _LOG.warning("[State Manager] failed to load %s %r: %s", label, path, exc)
-        return _state_manager_blank_image()
+        return None
+
+
+def _load_state_manager_image_from_info(image_info: Any, label: str = "image") -> torch.Tensor:
+    image = _try_load_state_manager_image_from_info(image_info, label)
+    if image is not None:
+        return image
+    return _state_manager_blank_image()
 
 
 def _load_state_manager_character_image(character: Dict[str, Any]) -> torch.Tensor:
@@ -1195,8 +1202,9 @@ def _load_state_manager_character_image(character: Dict[str, Any]) -> torch.Tens
 
 def _load_state_manager_prompt_or_character_image(character: Dict[str, Any], prompt: Dict[str, Any]) -> torch.Tensor:
     prompt_image = prompt.get("reference_image", {}) if isinstance(prompt, dict) else {}
-    if _state_manager_thumbnail_path(prompt_image):
-        return _load_state_manager_image_from_info(prompt_image, "prompt reference image")
+    prompt_tensor = _try_load_state_manager_image_from_info(prompt_image, "prompt reference image")
+    if prompt_tensor is not None:
+        return prompt_tensor
     return _load_state_manager_character_image(character)
 
 

--- a/web/dora_state_manager.js
+++ b/web/dora_state_manager.js
@@ -281,7 +281,7 @@ function defaultCharacter() {
 }
 
 function defaultState() {
-  return { version: 1, characters: [defaultCharacter()] };
+  return { version: 2, characters: [defaultCharacter()] };
 }
 
 function defaultUiState() {
@@ -548,7 +548,7 @@ function normalizeState(raw) {
   const parsed = safeJsonParse(raw, defaultState());
   const charsIn = Array.isArray(parsed.characters) ? parsed.characters : [];
   const characters = charsIn.map(normalizeCharacter).filter(Boolean);
-  return { version: 1, characters: characters.length ? characters : [defaultCharacter()] };
+  return { version: 2, characters: characters.length ? characters : [defaultCharacter()] };
 }
 
 function normalizeIdList(value) {
@@ -3240,9 +3240,14 @@ function mutateQueuedLegacyTextTargets(promptPayload, managerNode, prompt) {
 
 function mutateQueuedSettingsNodes(promptPayload, managerNode, prompt) {
   const controlled = getControlledNodes(managerNode).filter((node) => node && node !== managerNode && !isDoraLoaderNode(node) && !isStateTextNode(node));
+  const legacy = controlled.length ? [] : uniqueNodes([
+    ...getOutputTargets(managerNode, OUTPUT_NAMES.settings),
+    ...getOutputTargets(managerNode, OUTPUT_NAMES.seed),
+  ]).filter((node) => node && node !== managerNode && !isDoraLoaderNode(node) && !isStateTextNode(node));
+  const targets = controlled.length ? controlled : legacy;
   const settings = normalizeSettings(prompt?.settings || {});
   let changed = 0;
-  for (const node of controlled) {
+  for (const node of targets) {
     const snapshot = findSnapshotForNode(settings, node);
     if (snapshot?.widgets) {
       for (const [name, value] of Object.entries(snapshot.widgets)) {

--- a/web/dora_state_manager.js
+++ b/web/dora_state_manager.js
@@ -32,6 +32,8 @@ const OUTPUT_NAMES = {
   negative: ["negative_prompt_template", "negative_prompt"],
   settings: ["settings_json", "state_settings"],
   seed: ["seed"],
+  image: ["character_image"],
+  fileimagePrefix: ["fileimage_prefix"],
 };
 const TEXT_WIDGET_NAMES = ["text", "prompt", "positive", "negative", "string", "value", "wildcard", "wildcards", "wildcard_text", "populated_text"];
 const STATE_TEXT_OUTPUT_NAMES = ["text"];
@@ -55,6 +57,14 @@ const BACKUP_NODE_UID_PROPERTY = "dora_state_manager_backup_node_uid";
 const BACKUP_INDEX_STORAGE_SUFFIX = "workflow_index";
 const BACKUP_EXPORT_KIND = "dora_state_manager_export";
 const BACKUP_RESTORE_STATUS_PREFIX = "Warning: this node loaded with default/empty state";
+const QUEUE_SESSION_MAX_AGE_MS = 30000;
+
+const dsmQueueSession = {
+  active: false,
+  total: 1,
+  nextIndex: 0,
+  startedAt: 0,
+};
 
 
 function structuredCloneCompat(value) {
@@ -97,6 +107,8 @@ function defaultPrompt() {
       { role: "negative", slot: "default", label: "Default negative", text: "" },
     ],
     settings: {},
+    reference_image: {},
+    fileimage_prefix: "",
   };
 }
 
@@ -513,6 +525,8 @@ function normalizePrompt(prompt, index) {
     negative: String(p.negative ?? p.negative_prompt ?? ""),
     text_boxes: normalizePromptTextBoxes(p),
     settings: normalizeSettings(p.settings),
+    reference_image: normalizeThumbnail(p.reference_image ?? p.referenceImage ?? p.prompt_image ?? p.image),
+    fileimage_prefix: String(p.fileimage_prefix ?? p.filename_prefix ?? p.file_image_prefix ?? "").trim(),
   });
 }
 
@@ -537,12 +551,23 @@ function normalizeState(raw) {
   return { version: 1, characters: characters.length ? characters : [defaultCharacter()] };
 }
 
+function normalizeIdList(value) {
+  if (Array.isArray(value)) return value.map((item) => cleanId(item, "")).filter(Boolean);
+  if (typeof value === "string") {
+    return value.split(/[\n,]+/g).map((item) => cleanId(item, "")).filter(Boolean);
+  }
+  return [];
+}
+
 function normalizeUiState(raw) {
   const parsed = safeJsonParse(raw, defaultUiState());
   return {
-    version: 1,
+    version: 2,
     panel: ["prompts", "loras", "settings"].includes(parsed.panel) ? parsed.panel : "prompts",
     status: String(parsed.status ?? ""),
+    queue_prompt_wildcard: normalizeBoolean(parsed.queue_prompt_wildcard ?? parsed.prompt_wildcard_enabled, false),
+    queue_character_wildcard: normalizeBoolean(parsed.queue_character_wildcard ?? parsed.character_wildcard_enabled, false),
+    queue_character_ids: normalizeIdList(parsed.queue_character_ids ?? parsed.selected_character_ids),
   };
 }
 
@@ -2091,6 +2116,28 @@ function setPanel(node, panel) {
   updateState(node, state, { ...uiState, panel });
 }
 
+function validQueueCharacterIds(state, uiState, fallbackId = "") {
+  const available = new Set((state?.characters || []).map((character) => character.id));
+  const ids = normalizeIdList(uiState?.queue_character_ids).filter((id) => available.has(id));
+  if (ids.length) return ids;
+  return fallbackId && available.has(fallbackId) ? [fallbackId] : [];
+}
+
+function toggleQueueCharacterId(uiState, characterId, enabled) {
+  const ids = normalizeIdList(uiState?.queue_character_ids);
+  const next = ids.filter((id) => id !== characterId);
+  if (enabled) next.push(characterId);
+  return [...new Set(next)];
+}
+
+function queueSettingsSummary(state, uiState, currentCharacterId) {
+  const selectedIds = validQueueCharacterIds(state, uiState, currentCharacterId);
+  const parts = [];
+  if (uiState.queue_prompt_wildcard) parts.push("random prompt preset per queued generation");
+  if (uiState.queue_character_wildcard) parts.push(`${selectedIds.length || 1} character chunk${(selectedIds.length || 1) === 1 ? "" : "s"}`);
+  return parts.length ? `Queue wildcard: ${parts.join("; ")}.` : "Queue wildcard disabled.";
+}
+
 function renderCharacterTile(node, state, uiState, character, selectedId) {
   const tile = document.createElement("button");
   tile.type = "button";
@@ -2191,6 +2238,24 @@ function renderHeader(node, state, uiState, character, prompt) {
     }, "Apply the current character/preset to selected graph nodes")
   );
 
+  const queueControls = document.createElement("div");
+  queueControls.className = "dsm-toolbar";
+  const promptWildcard = makeCheckbox(uiState.queue_prompt_wildcard, (checked) => {
+    updateState(node, state, { ...uiState, queue_prompt_wildcard: checked }, { characterId: character.id, promptId: prompt.id, status: checked ? "Prompt wildcard queue enabled: queued generations will randomly choose a saved prompt preset." : "Prompt wildcard queue disabled." });
+  });
+  const characterWildcard = makeCheckbox(uiState.queue_character_wildcard, (checked) => {
+    const ids = validQueueCharacterIds(state, uiState, character.id);
+    updateState(node, state, { ...uiState, queue_character_wildcard: checked, queue_character_ids: ids }, { characterId: character.id, promptId: prompt.id, status: checked ? queueSettingsSummary(state, { ...uiState, queue_character_wildcard: true, queue_character_ids: ids }, character.id) : "Character chunk queue disabled." });
+  });
+  const queueSummary = document.createElement("div");
+  queueSummary.className = "dsm-muted";
+  queueSummary.textContent = queueSettingsSummary(state, uiState, character.id);
+  queueControls.append(
+    labelledControl("Random prompt per queued generation", promptWildcard),
+    labelledControl("Linear character chunks", characterWildcard),
+    queueSummary
+  );
+
   const grid = document.createElement("div");
   grid.className = "dsm-character-grid";
   for (const item of state.characters) grid.appendChild(renderCharacterTile(node, state, uiState, item, character.id));
@@ -2226,7 +2291,7 @@ function renderHeader(node, state, uiState, character, prompt) {
     })
   );
 
-  section.append(toolbar, importInput);
+  section.append(toolbar, importInput, queueControls);
   if (node.__dsmBackupWarning) {
     const warning = document.createElement("div");
     warning.className = "dsm-warning";
@@ -2336,7 +2401,12 @@ function renderCharacterPanel(node, state, uiState, character) {
   imageNote.className = "dsm-muted";
   imageNote.textContent = "The State Manager image output loads the original uploaded file, not the CSS-scaled preview.";
 
-  section.append(title, labelledControl("Name", nameInput), preview, fileInput, thumbnailButtons, imageNote, labelledControl("Saved LoRA stacks", loraSummary));
+  const queueIncluded = makeCheckbox(validQueueCharacterIds(state, uiState, character.id).includes(character.id), (checked) => {
+    const ids = toggleQueueCharacterId(uiState, character.id, checked);
+    updateState(node, state, { ...uiState, queue_character_ids: ids }, { characterId: character.id, status: queueSettingsSummary(state, { ...uiState, queue_character_ids: ids }, character.id) });
+  });
+
+  section.append(title, labelledControl("Name", nameInput), labelledControl("Use this character in linear queue chunks", queueIncluded), preview, fileInput, thumbnailButtons, imageNote, labelledControl("Saved LoRA stacks", loraSummary));
   return section;
 }
 
@@ -2418,6 +2488,83 @@ function renderPromptPanelContent(section, node, state, uiState, character, prom
     updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id, render: false });
   }, { placeholder: "Negative prompt template. Wildcards stay here and expand downstream." });
 
+  const fileimagePrefix = makeInput(prompt.fileimage_prefix ?? "", (value) => {
+    prompt.fileimage_prefix = String(value ?? "").trim();
+    updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id });
+  }, { placeholder: "e.g. jl_dryfs2/AIM" });
+
+  const referencePreview = document.createElement("div");
+  referencePreview.className = "dsm-large-thumb";
+  const referenceUrl = thumbnailUrl(prompt.reference_image);
+  if (referenceUrl) {
+    const img = document.createElement("img");
+    img.src = referenceUrl;
+    img.alt = `${prompt.name || "Prompt"} reference`;
+    referencePreview.appendChild(img);
+  } else {
+    referencePreview.textContent = "Drop prompt reference image here";
+  }
+
+  const referenceInput = document.createElement("input");
+  referenceInput.type = "file";
+  referenceInput.accept = "image/*";
+  referenceInput.style.display = "none";
+  referenceInput.addEventListener("change", async () => {
+    const file = referenceInput.files?.[0];
+    if (!file) return;
+    try {
+      prompt.reference_image = await uploadThumbnailFile(file);
+      updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id, status: "Prompt reference image uploaded." });
+    } catch (err) {
+      setStatus(node, `Prompt reference upload failed: ${err?.message || err}`);
+    } finally {
+      referenceInput.value = "";
+    }
+  });
+  referencePreview.addEventListener("click", (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    referenceInput.click();
+  });
+  referencePreview.addEventListener("dragenter", (event) => {
+    stopComfyFileDropEvent(event);
+    referencePreview.classList.add("dragging");
+  }, true);
+  referencePreview.addEventListener("dragover", (event) => {
+    stopComfyFileDropEvent(event);
+    referencePreview.classList.add("dragging");
+  }, true);
+  referencePreview.addEventListener("dragleave", (event) => {
+    event.stopPropagation();
+    referencePreview.classList.remove("dragging");
+  }, true);
+  referencePreview.addEventListener("drop", async (event) => {
+    stopComfyFileDropEvent(event);
+    referencePreview.classList.remove("dragging");
+    const file = [...(event.dataTransfer?.files || [])].find((candidate) => candidate.type.startsWith("image/"));
+    if (!file) return;
+    try {
+      prompt.reference_image = await uploadThumbnailFile(file);
+      updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id, status: "Prompt reference image uploaded." });
+    } catch (err) {
+      setStatus(node, `Prompt reference upload failed: ${err?.message || err}`);
+    }
+  }, true);
+
+  const referenceButtons = document.createElement("div");
+  referenceButtons.className = "dsm-toolbar";
+  referenceButtons.append(
+    makeButton("Choose prompt image", () => referenceInput.click()),
+    makeButton("Clear", () => {
+      prompt.reference_image = {};
+      updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id, status: "Prompt reference image cleared. Character image fallback will be used." });
+    })
+  );
+
+  const referenceNote = document.createElement("div");
+  referenceNote.className = "dsm-muted";
+  referenceNote.textContent = "The image output uses this prompt reference first, then falls back to the character thumbnail.";
+
   const textBoxToolbar = document.createElement("div");
   textBoxToolbar.className = "dsm-toolbar";
   textBoxToolbar.append(
@@ -2490,6 +2637,11 @@ function renderPromptPanelContent(section, node, state, uiState, character, prom
   section.append(
     header,
     labelledControl("Preset name", name),
+    labelledControl("fileimage_prefix", fileimagePrefix),
+    referencePreview,
+    referenceInput,
+    referenceButtons,
+    referenceNote,
     labelledControl("Default positive template", positive),
     labelledControl("Default negative template", negative),
     textBoxToolbar,
@@ -2894,6 +3046,247 @@ function initializeNode(node, widget) {
 }
 
 
+function queueSessionTotalFromArguments(number, batchCount) {
+  const batch = Number(batchCount);
+  if (Number.isFinite(batch) && batch > 0) return Math.max(1, Math.floor(batch));
+  const count = Number(number);
+  if (Number.isFinite(count) && count > 1) return Math.max(1, Math.floor(count));
+  return 1;
+}
+
+function startDsmQueueSession(number, batchCount) {
+  dsmQueueSession.active = true;
+  dsmQueueSession.total = queueSessionTotalFromArguments(number, batchCount);
+  dsmQueueSession.nextIndex = 0;
+  dsmQueueSession.startedAt = Date.now();
+}
+
+function finishDsmQueueSession(startedAt) {
+  setTimeout(() => {
+    if (dsmQueueSession.startedAt === startedAt) dsmQueueSession.active = false;
+  }, 0);
+}
+
+function nextDsmQueueIndex(index) {
+  const now = Date.now();
+  if (!dsmQueueSession.active || now - dsmQueueSession.startedAt > QUEUE_SESSION_MAX_AGE_MS) {
+    dsmQueueSession.active = true;
+    dsmQueueSession.total = 1;
+    dsmQueueSession.nextIndex = 0;
+    dsmQueueSession.startedAt = now;
+  }
+  const queueIndex = dsmQueueSession.nextIndex;
+  dsmQueueSession.nextIndex += 1;
+  return queueIndex;
+}
+
+function queueOutputKeysForNode(promptPayload, node) {
+  const output = promptPayload?.output || {};
+  const id = String(node?.id ?? "");
+  const keys = [];
+  for (const key of Object.keys(output)) {
+    if (key === id || key.endsWith(`:${id}`)) keys.push(key);
+  }
+  if (id && !keys.includes(id)) keys.push(id);
+  return [...new Set(keys)];
+}
+
+function findWorkflowNodeForPromptNode(promptPayload, node, promptId = null) {
+  const workflowNodes = promptPayload?.workflow?.nodes;
+  if (!Array.isArray(workflowNodes)) return null;
+  const idText = String(promptId ?? node?.id ?? "");
+  return workflowNodes.find((item) => String(item?.id) === idText)
+    || workflowNodes.find((item) => String(item?.id) === String(node?.id ?? ""))
+    || null;
+}
+
+function syncQueuedWorkflowWidget(promptPayload, node, widget, value, promptId = null) {
+  if (!widget) return false;
+  const workflowNode = findWorkflowNodeForPromptNode(promptPayload, node, promptId);
+  const index = (node?.widgets || []).indexOf(widget);
+  if (!workflowNode || !Array.isArray(workflowNode.widgets_values) || index < 0) return false;
+  workflowNode.widgets_values[index] = value;
+  return true;
+}
+
+function setQueuedInput(promptPayload, node, inputName, value, { addIfMissing = false, syncWidget = true } = {}) {
+  if (!promptPayload?.output || !node || !inputName) return 0;
+  let changed = 0;
+  const widget = syncWidget ? widgetByExactName(node, inputName) : null;
+  for (const promptId of queueOutputKeysForNode(promptPayload, node)) {
+    const outputNode = promptPayload.output?.[promptId];
+    const inputs = outputNode?.inputs;
+    if (!inputs) continue;
+    if (!addIfMissing && !Object.prototype.hasOwnProperty.call(inputs, inputName)) continue;
+    inputs[inputName] = structuredCloneCompat(value);
+    syncQueuedWorkflowWidget(promptPayload, node, widget, value, promptId);
+    changed += 1;
+  }
+  return changed;
+}
+
+function setQueuedWidgetInput(promptPayload, node, widgetName, value) {
+  return setQueuedInput(promptPayload, node, widgetName, value, { addIfMissing: false, syncWidget: true });
+}
+
+function setQueuedStateManagerSelection(promptPayload, node, characterId, promptId) {
+  let changed = 0;
+  changed += setQueuedInput(promptPayload, node, SELECTED_CHARACTER_WIDGET, characterId, { addIfMissing: false, syncWidget: true });
+  changed += setQueuedInput(promptPayload, node, SELECTED_PROMPT_WIDGET, promptId, { addIfMissing: false, syncWidget: true });
+  return changed;
+}
+
+function selectQueuedCharacterAndPrompt(state, uiState, currentCharacterId, currentPromptId, queueIndex, total) {
+  const current = selectedCharacter(state, currentCharacterId) || state.characters[0];
+  let character = current;
+  if (uiState.queue_character_wildcard) {
+    const ids = validQueueCharacterIds(state, uiState, current?.id || currentCharacterId);
+    if (ids.length) {
+      const safeTotal = Math.max(1, Number(total) || 1);
+      const chunkIndex = Math.min(ids.length - 1, Math.floor((Math.max(0, queueIndex) * ids.length) / safeTotal));
+      character = selectedCharacter(state, ids[chunkIndex]) || current;
+    }
+  }
+
+  let prompt = selectedPrompt(character, character?.id === current?.id ? currentPromptId : "") || character?.prompts?.[0];
+  const prompts = Array.isArray(character?.prompts) ? character.prompts : [];
+  if (uiState.queue_prompt_wildcard && prompts.length) {
+    prompt = prompts[Math.floor(Math.random() * prompts.length)] || prompt;
+  }
+  return { character, prompt };
+}
+
+function buildQueuedDoraStatePayload(character, prompt) {
+  syncLegacyLoaderMirror(character);
+  syncPromptTextMirror(prompt);
+  const loaderStacks = getCharacterLoaderStacks(character).map((stack) => structuredCloneCompat(stack));
+  const defaultStack = findCharacterLoaderStack(character, "default") || loaderStacks[0] || defaultLoaderStack();
+  const textBoxes = normalizePromptTextBoxes(prompt);
+  const positiveBox = findPromptTextBox(prompt, "positive", "default") || textBoxes.find((box) => box.role === "positive");
+  const negativeBox = findPromptTextBox(prompt, "negative", "default") || textBoxes.find((box) => box.role === "negative");
+  const referenceImage = normalizeThumbnail(prompt?.reference_image);
+  const fileimagePrefix = String(prompt?.fileimage_prefix ?? "").trim();
+  return {
+    version: 2,
+    kind: "dora_state_manager_state",
+    character: {
+      id: String(character?.id ?? ""),
+      name: String(character?.name ?? ""),
+      thumbnail: normalizeThumbnail(character?.thumbnail),
+    },
+    prompt: {
+      id: String(prompt?.id ?? ""),
+      name: String(prompt?.name ?? ""),
+      reference_image: referenceImage,
+      fileimage_prefix: fileimagePrefix,
+    },
+    loader_stacks: loaderStacks,
+    loras: structuredCloneCompat(defaultStack?.loras || []),
+    loader_globals: normalizeLoaderGlobals(defaultStack?.loader_globals || character?.loader_globals || {}),
+    settings: normalizeSettings(prompt?.settings || {}),
+    text_boxes: textBoxes.map((box) => structuredCloneCompat(box)),
+    positive_prompt: String(positiveBox?.text ?? prompt?.positive ?? ""),
+    negative_prompt: String(negativeBox?.text ?? prompt?.negative ?? ""),
+    reference_image: referenceImage,
+    fileimage_prefix: fileimagePrefix,
+  };
+}
+
+function mutateQueuedDoraLoaders(promptPayload, managerNode, character, payload) {
+  const controlled = getControlledNodes(managerNode).filter((node) => node && node !== managerNode);
+  const controlledLoaders = controlled.filter(isDoraLoaderNode);
+  const legacyLoaders = controlledLoaders.length ? [] : uniqueNodes(getOutputTargets(managerNode, OUTPUT_NAMES.lora)).filter(isDoraLoaderNode);
+  const loaders = controlledLoaders.length ? controlledLoaders : legacyLoaders;
+  let changed = 0;
+  for (const loader of loaders) {
+    changed += setQueuedInput(promptPayload, loader, "dora_state", payload, { addIfMissing: true, syncWidget: false });
+  }
+  return changed;
+}
+
+function mutateQueuedStateTextBoxes(promptPayload, managerNode, prompt) {
+  const controlled = getControlledNodes(managerNode).filter((node) => node && node !== managerNode);
+  const textNodes = controlled.filter(isStateTextNode);
+  let changed = 0;
+  for (const [index, textNode] of textNodes.entries()) {
+    const role = getStateTextRole(textNode);
+    const slot = getStateTextSlot(textNode, role, `${role}_${textNode?.id ?? index + 1}`);
+    const saved = findPromptTextBox(prompt, role, slot, { allowRoleFallback: false }) || findPromptTextBox(prompt, role, slot, { allowRoleFallback: true });
+    if (!saved) continue;
+    changed += setQueuedWidgetInput(promptPayload, textNode, "text", String(saved.text ?? ""));
+  }
+  return changed;
+}
+
+function mutateQueuedLegacyTextTargets(promptPayload, managerNode, prompt) {
+  let changed = 0;
+  const legacyTargets = [
+    { targets: getOutputTargets(managerNode, OUTPUT_NAMES.positive), role: "positive", text: getPromptText(prompt, "positive", "default") },
+    { targets: getOutputTargets(managerNode, OUTPUT_NAMES.negative), role: "negative", text: getPromptText(prompt, "negative", "default") },
+  ];
+  for (const group of legacyTargets) {
+    for (const target of group.targets) {
+      const inputName = target.inputName || (group.role === "negative" ? "negative" : "text");
+      changed += setQueuedInput(promptPayload, target.node, inputName, String(group.text ?? ""), { addIfMissing: true, syncWidget: true });
+      if (isImpactWildcardNode(target.node)) {
+        changed += setQueuedInput(promptPayload, target.node, "wildcard_text", String(group.text ?? ""), { addIfMissing: true, syncWidget: true });
+        changed += setQueuedInput(promptPayload, target.node, "populated_text", String(group.text ?? ""), { addIfMissing: true, syncWidget: true });
+      }
+    }
+  }
+  return changed;
+}
+
+
+function mutateQueuedSettingsNodes(promptPayload, managerNode, prompt) {
+  const controlled = getControlledNodes(managerNode).filter((node) => node && node !== managerNode && !isDoraLoaderNode(node) && !isStateTextNode(node));
+  const settings = normalizeSettings(prompt?.settings || {});
+  let changed = 0;
+  for (const node of controlled) {
+    const snapshot = findSnapshotForNode(settings, node);
+    if (snapshot?.widgets) {
+      for (const [name, value] of Object.entries(snapshot.widgets)) {
+        changed += setQueuedInput(promptPayload, node, String(name), value, { addIfMissing: false, syncWidget: true });
+      }
+    }
+    if (isSeedNode(node)) {
+      const seed = extractSeedFromSettings(settings);
+      if (seed != null) {
+        for (const name of ["seed", "noise_seed", "value"]) {
+          const before = changed;
+          changed += setQueuedInput(promptPayload, node, name, seed, { addIfMissing: false, syncWidget: true });
+          if (changed !== before) break;
+        }
+      }
+    }
+  }
+  return changed;
+}
+
+function mutatePromptForStateManagers(promptPayload, queueIndex, total) {
+  if (!promptPayload?.output) return 0;
+  let changed = 0;
+  const graphNodes = app?.graph?._nodes || [];
+  for (const node of graphNodes) {
+    if (!isStateManagerNode(node)) continue;
+    const widgets = getWidgets(node);
+    const { state, uiState } = getCurrentState(node);
+    if (!uiState.queue_prompt_wildcard && !uiState.queue_character_wildcard) continue;
+    const currentCharacterId = String(widgetValue(widgets.characterWidget, "") || "");
+    const currentPromptId = String(widgetValue(widgets.promptWidget, "") || "");
+    const { character, prompt } = selectQueuedCharacterAndPrompt(state, uiState, currentCharacterId, currentPromptId, queueIndex, total);
+    if (!character || !prompt) continue;
+    const payload = buildQueuedDoraStatePayload(character, prompt);
+    changed += setQueuedStateManagerSelection(promptPayload, node, character.id, prompt.id);
+    changed += mutateQueuedDoraLoaders(promptPayload, node, character, payload);
+    changed += mutateQueuedStateTextBoxes(promptPayload, node, prompt);
+    changed += mutateQueuedLegacyTextTargets(promptPayload, node, prompt);
+    changed += mutateQueuedSettingsNodes(promptPayload, node, prompt);
+  }
+  return changed;
+}
+
+
 function getStateSeedWidget(node) {
   return widgetByExactName(node, "seed") || (node?.widgets || []).find((widget) => /seed/i.test(`${widget?.name ?? ""} ${widget?.label ?? ""}`)) || null;
 }
@@ -3072,12 +3465,30 @@ function patchStateSeedNodeDef(nodeType) {
 function installStateSeedQueuePatch() {
   if (api.__dsmStateSeedQueuePatchInstalled || typeof api.queuePrompt !== "function") return;
   api.__dsmStateSeedQueuePatchInstalled = true;
+
+  if (!app.__dsmQueueSessionPatchInstalled && typeof app.queuePrompt === "function") {
+    app.__dsmQueueSessionPatchInstalled = true;
+    const originalAppQueuePrompt = app.queuePrompt;
+    app.queuePrompt = async function (number, batchCount, ...args) {
+      startDsmQueueSession(number, batchCount);
+      const startedAt = dsmQueueSession.startedAt;
+      try {
+        return await originalAppQueuePrompt.apply(this, [number, batchCount, ...args]);
+      } finally {
+        finishDsmQueueSession(startedAt);
+      }
+    };
+  }
+
   const originalQueuePrompt = api.queuePrompt;
   api.queuePrompt = async function (index, promptPayload, ...args) {
+    const queueIndex = nextDsmQueueIndex(index);
+    const total = Math.max(1, dsmQueueSession.total || 1);
     try {
       mutatePromptForStateSeeds(promptPayload);
+      mutatePromptForStateManagers(promptPayload, queueIndex, total);
     } catch (err) {
-      console.warn(`[${EXT_NAME}] failed to resolve State Manager Seed values before queue`, err);
+      console.warn(`[${EXT_NAME}] failed to resolve State Manager queue values before queue`, err);
     }
     return originalQueuePrompt.apply(this, [index, promptPayload, ...args]);
   };


### PR DESCRIPTION
## Summary
- Add queue-time State Manager prompt wildcarding and linear selected-character chunking.
- Inject runtime `dora_state` payloads into controlled DoRA loader nodes for queued generations.
- Add prompt-specific reference images and append the `fileimage_prefix` State Manager output after `character_image`.

## Notes
- Queue mutation is applied to the queued prompt payload, including payload output inputs and workflow widget values, rather than persistently changing the visible graph UI.
- Prompt reference images are preferred for `character_image`; character thumbnails remain the fallback.
- The separate Impact Pack hunk in `state_manager_wildcard_complete.patch` targets `modules/impact/impact_server.py`, which is outside this repository and was not applied here.

## Validation
- `python3 -m py_compile nodes.py`
- `node --check web/dora_state_manager.js`
- `/ouroboros:qa` structured review passed at 0.84

Repository tests were not run per instruction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reference image upload/preview for prompts and preference over character thumbnail
  * Per-prompt file image prefix field and persisted prompt defaults
  * Queue wildcard controls, character-inclusion checkboxes, and header queue summary
  * Queue session handling with indexed selection for batch/linear processing

* **Bug Fixes**
  * Robust image loading with fallback to blank image on load failure
  * Prompt normalization accepts legacy field names for compatibility
<!-- end of auto-generated comment: release notes by coderabbit.ai -->