### PR TITLE
[codex] Fix queued State Manager state control payload

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -1119,6 +1119,17 @@ def _build_state_settings_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
+def _queued_runtime_state_from_ui_state(ui_state_json: Any) -> Optional[Dict[str, Any]]:
+    parsed = _safe_json_load(ui_state_json, {})
+    if not isinstance(parsed, dict):
+        return None
+    raw = parsed.get("__dsm_queued_runtime_state")
+    payload = _normalize_runtime_dora_state_payload(raw)
+    if payload is not None:
+        return payload
+    return None
+
+
 def _build_state_control_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
     # Preferred State Manager edge. It remains usable as an editor relationship for
     # Save/Load connected, and it now also carries the resolved selected state at
@@ -4255,12 +4266,27 @@ class StateManager:
         selected_character_id: Any = "",
         selected_prompt_id: Any = "",
     ):
-        del ui_state_json
-        payload = _resolve_dora_state_payload(
-            state_json,
-            selected_character_id,
-            selected_prompt_id,
-        )
+        runtime_payload = _queued_runtime_state_from_ui_state(ui_state_json)
+        if runtime_payload is not None:
+            payload = runtime_payload
+            state = _normalize_state_manager_state(state_json)
+            character = _pick_state_manager_character(
+                state,
+                (payload.get("character") or {}).get("id", selected_character_id) if isinstance(payload.get("character"), dict) else selected_character_id,
+            )
+            prompt = _pick_state_manager_prompt(
+                character,
+                (payload.get("prompt") or {}).get("id", selected_prompt_id) if isinstance(payload.get("prompt"), dict) else selected_prompt_id,
+            )
+        else:
+            payload = _resolve_dora_state_payload(
+                state_json,
+                selected_character_id,
+                selected_prompt_id,
+            )
+            state = _normalize_state_manager_state(state_json)
+            character = _pick_state_manager_character(state, selected_character_id)
+            prompt = _pick_state_manager_prompt(character, selected_prompt_id)
         settings = _normalize_settings_with_canonical_seed(payload.get("settings", {}))
         settings_json = json.dumps(settings, ensure_ascii=False, sort_keys=True, indent=2)
         lora_stack_payload = _build_lora_stack_payload(
@@ -4270,9 +4296,6 @@ class StateManager:
         state_settings_payload = _build_state_settings_payload(payload)
         state_control_payload = _build_state_control_payload(payload)
         seed = _extract_seed_from_settings(settings)
-        state = _normalize_state_manager_state(state_json)
-        character = _pick_state_manager_character(state, selected_character_id)
-        prompt = _pick_state_manager_prompt(character, selected_prompt_id)
         character_image = _load_state_manager_prompt_or_character_image(character, prompt)
         return (
             payload,

--- a/nodes.py
+++ b/nodes.py
@@ -1124,10 +1124,57 @@ def _queued_runtime_state_from_ui_state(ui_state_json: Any) -> Optional[Dict[str
     if not isinstance(parsed, dict):
         return None
     raw = parsed.get("__dsm_queued_runtime_state")
-    payload = _normalize_runtime_dora_state_payload(raw)
-    if payload is not None:
-        return payload
-    return None
+    return _normalize_runtime_dora_state_payload(raw)
+
+
+def _settings_with_runtime_seed(settings: Any, seed: int) -> Dict[str, Any]:
+    normalized = dict(_normalize_manager_settings(settings))
+    normalized["seed"] = seed
+    rgthree_seed = normalized.get("rgthree_seed")
+    if isinstance(rgthree_seed, dict):
+        rgthree_seed = dict(rgthree_seed)
+        rgthree_seed["seed"] = seed
+        widgets = rgthree_seed.get("widgets")
+        if isinstance(widgets, dict):
+            widgets = dict(widgets)
+            for key in ("seed", "noise_seed", "value"):
+                if key in widgets:
+                    widgets[key] = seed
+            rgthree_seed["widgets"] = widgets
+        normalized["rgthree_seed"] = rgthree_seed
+    nodes = normalized.get("nodes")
+    if isinstance(nodes, list):
+        updated_nodes = []
+        for node in nodes:
+            if not isinstance(node, dict):
+                updated_nodes.append(node)
+                continue
+            updated_node = dict(node)
+            widgets = updated_node.get("widgets")
+            if isinstance(widgets, dict):
+                widgets = dict(widgets)
+                for key in ("seed", "noise_seed", "value"):
+                    if key in widgets:
+                        widgets[key] = seed
+                updated_node["widgets"] = widgets
+            if updated_node.get("is_seed_node") or updated_node.get("seed") is not None or updated_node.get("seed_widgets"):
+                updated_node["seed"] = seed
+                seed_widgets = updated_node.get("seed_widgets")
+                if isinstance(seed_widgets, dict):
+                    updated_node["seed_widgets"] = {key: seed for key in seed_widgets}
+            updated_nodes.append(updated_node)
+        normalized["nodes"] = updated_nodes
+    return normalized
+
+
+def _resolve_state_manager_runtime_seed(payload: Dict[str, Any]) -> Dict[str, Any]:
+    normalized = _normalize_runtime_dora_state_payload(payload) or dict(payload)
+    settings = _normalize_settings_with_canonical_seed(normalized.get("settings", {}))
+    seed = _extract_seed_from_settings(settings)
+    if seed in _STATE_SEED_SPECIALS:
+        settings = _settings_with_runtime_seed(settings, _state_manager_new_random_seed())
+    normalized["settings"] = settings
+    return normalized
 
 
 def _build_state_control_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
@@ -4239,6 +4286,13 @@ class StateManager:
             "selected_character_id": selected_character_id,
             "selected_prompt_id": selected_prompt_id,
         }
+        resolved = _queued_runtime_state_from_ui_state(ui_state_json) or _resolve_dora_state_payload(
+            state_json,
+            selected_character_id,
+            selected_prompt_id,
+        )
+        if _extract_seed_from_settings(resolved.get("settings", {})) in _STATE_SEED_SPECIALS:
+            payload["runtime_seed_nonce"] = _state_manager_new_random_seed()
         return json.dumps(payload, sort_keys=True, default=str)
 
     @classmethod
@@ -4268,7 +4322,7 @@ class StateManager:
     ):
         runtime_payload = _queued_runtime_state_from_ui_state(ui_state_json)
         if runtime_payload is not None:
-            payload = runtime_payload
+            payload = _resolve_state_manager_runtime_seed(runtime_payload)
             state = _normalize_state_manager_state(state_json)
             character = _pick_state_manager_character(
                 state,
@@ -4284,6 +4338,7 @@ class StateManager:
                 selected_character_id,
                 selected_prompt_id,
             )
+            payload = _resolve_state_manager_runtime_seed(payload)
             state = _normalize_state_manager_state(state_json)
             character = _pick_state_manager_character(state, selected_character_id)
             prompt = _pick_state_manager_prompt(character, selected_prompt_id)

--- a/web/dora_state_manager.js
+++ b/web/dora_state_manager.js
@@ -3280,6 +3280,31 @@ function setQueuedWidgetInput(promptPayload, node, widgetName, value) {
   return setQueuedInput(promptPayload, node, widgetName, value, { addIfMissing: false, syncWidget: true });
 }
 
+function serializeQueuedUiStateOverride(uiState, payload, queueIndex, total) {
+  return JSON.stringify({
+    ...stripBackupRestoreStatus(uiState || defaultUiState()),
+    __dsm_queued_runtime_state: structuredCloneCompat(payload),
+    __dsm_queued_runtime_character_id: String(payload?.character?.id ?? ""),
+    __dsm_queued_runtime_prompt_id: String(payload?.prompt?.id ?? ""),
+    __dsm_queued_runtime_queue_index: Math.max(0, Number(queueIndex) || 0),
+    __dsm_queued_runtime_queue_total: Math.max(1, Number(total) || 1),
+    // The runtime override must differ per queued prompt even if the same prompt
+    // is selected again after a prompt-pool reshuffle. This prevents executor
+    // cache reuse from keeping a stale STATE_MANAGER_CONTROL payload alive.
+    __dsm_queued_runtime_nonce: `${Date.now()}:${Math.random()}:${queueIndex}`,
+  }, null, 0);
+}
+
+function setQueuedStateManagerRuntimeState(promptPayload, node, uiState, payload, queueIndex, total) {
+  return setQueuedInput(
+    promptPayload,
+    node,
+    UI_STATE_WIDGET,
+    serializeQueuedUiStateOverride(uiState, payload, queueIndex, total),
+    { addIfMissing: true, syncWidget: true }
+  );
+}
+
 function setQueuedStateManagerSelection(promptPayload, node, characterId, promptId) {
   let changed = 0;
   changed += setQueuedInput(promptPayload, node, SELECTED_CHARACTER_WIDGET, characterId, { addIfMissing: false, syncWidget: true });
@@ -3464,6 +3489,7 @@ function mutatePromptForStateManagers(promptPayload, queueIndex, total) {
     if (!character || !prompt) continue;
     const payload = buildQueuedDoraStatePayload(character, prompt);
     changed += setQueuedStateManagerSelection(promptPayload, node, character.id, prompt.id);
+    changed += setQueuedStateManagerRuntimeState(promptPayload, node, uiState, payload, queueIndex, total);
     changed += mutateQueuedDoraLoaders(promptPayload, node, character, payload);
     changed += mutateQueuedStateTextBoxes(promptPayload, node, prompt);
     changed += mutateQueuedLegacyTextTargets(promptPayload, node, prompt);

--- a/web/dora_state_manager.js
+++ b/web/dora_state_manager.js
@@ -286,7 +286,7 @@ function defaultState() {
 }
 
 function defaultUiState() {
-  return { version: 1, panel: "prompts", status: "" };
+  return { version: 1, panel: "prompts", status: "", queue_randomize_saved_seed: false };
 }
 
 function isBackupRestoreStatus(value) {
@@ -332,6 +332,10 @@ function normalizeSeedInteger(value, fallback = 0) {
 
 function isStateSeedSpecial(value) {
   return STATE_SEED_SPECIALS.includes(normalizeSeedInteger(value, 0));
+}
+
+function generateStateManagerRuntimeSeed() {
+  return Math.floor(Math.random() * STATE_SEED_MAX) + 1;
 }
 
 function normalizeBoolean(value, fallback = false) {
@@ -568,6 +572,7 @@ function normalizeUiState(raw) {
     status: String(parsed.status ?? ""),
     queue_prompt_wildcard: normalizeBoolean(parsed.queue_prompt_wildcard ?? parsed.prompt_wildcard_enabled, false),
     queue_character_wildcard: normalizeBoolean(parsed.queue_character_wildcard ?? parsed.character_wildcard_enabled, false),
+    queue_randomize_saved_seed: normalizeBoolean(parsed.queue_randomize_saved_seed ?? parsed.randomize_saved_seed, false),
     queue_character_ids: normalizeIdList(parsed.queue_character_ids ?? parsed.selected_character_ids),
   };
 }
@@ -1708,8 +1713,7 @@ function mergeCapturedSettings(prompt, nodes, { replaceNodes = true } = {}) {
   const seedSnapshot = snapshots.find((snap) => snap.is_seed_node || snap.seed != null || Object.keys(snap.seed_widgets || {}).length);
   if (seedSnapshot) {
     const seed = normalizeSeedInteger(seedSnapshot.seed ?? normalizeSeedFromWidgets(seedSnapshot.widgets, 0), 0);
-    if (isStateSeedSpecial(seed)) delete settings.seed;
-    else settings.seed = seed;
+    settings.seed = seed;
     settings.rgthree_seed = seedSnapshot;
   }
   prompt.settings = settings;
@@ -1751,19 +1755,17 @@ function applySnapshotToNode(node, snapshot) {
 function extractSeedFromSettings(settings) {
   const normalized = normalizeSettings(settings);
   if (normalized.seed != null) {
-    const seed = normalizeSeedInteger(normalized.seed, 0);
-    if (!isStateSeedSpecial(seed)) return seed;
+    return normalizeSeedInteger(normalized.seed, 0);
   }
   if (normalized.rgthree_seed?.seed != null) {
-    const seed = normalizeSeedInteger(normalized.rgthree_seed.seed, 0);
-    if (!isStateSeedSpecial(seed)) return seed;
+    return normalizeSeedInteger(normalized.rgthree_seed.seed, 0);
   }
   const widgets = normalized.rgthree_seed?.widgets;
   const fromWidgets = normalizeSeedFromWidgets(widgets, null);
-  if (fromWidgets != null && !isStateSeedSpecial(fromWidgets)) return fromWidgets;
+  if (fromWidgets != null) return fromWidgets;
   for (const snap of normalizeNodeSnapshots(normalized.nodes)) {
     const seed = normalizeSeedFromWidgets(snap.widgets, null);
-    if (seed != null && !isStateSeedSpecial(seed)) return seed;
+    if (seed != null) return seed;
   }
   return null;
 }
@@ -2165,7 +2167,7 @@ function characterNamesForIds(state, ids) {
 function queueSettingsSummary(state, uiState, currentCharacterId) {
   const explicitIds = queueCharacterIdsExplicit(state, uiState);
   const runtimeIds = validQueueCharacterIds(state, uiState, currentCharacterId);
-  if (!uiState.queue_prompt_wildcard && !uiState.queue_character_wildcard) {
+  if (!uiState.queue_prompt_wildcard && !uiState.queue_character_wildcard && !uiState.queue_randomize_saved_seed) {
     return "Queue wildcarding is off. Queued jobs use the selected character and selected prompt preset.";
   }
 
@@ -2183,6 +2185,9 @@ function queueSettingsSummary(state, uiState, currentCharacterId) {
   lines.push(uiState.queue_prompt_wildcard
     ? "Prompts: each queued job randomly selects one saved prompt preset from the active character."
     : "Prompts: selected prompt preset only.");
+  if (uiState.queue_randomize_saved_seed) {
+    lines.push("Saved prompt preset seeds are randomized for every queued job.");
+  }
   return lines.join(" ");
 }
 
@@ -2353,6 +2358,15 @@ function renderHeader(node, state, uiState, character, prompt) {
         updateState(node, state, nextUiState, { characterId: character.id, promptId: prompt.id, status: queueSettingsSummary(state, nextUiState, character.id) });
       },
       "Each queued job samples one saved prompt preset from whichever character is active for that job."
+    ),
+    makeInlineCheckbox(
+      "Always randomize saved prompt seed",
+      uiState.queue_randomize_saved_seed,
+      (checked) => {
+        const nextUiState = { ...uiState, queue_randomize_saved_seed: checked };
+        updateState(node, state, nextUiState, { characterId: character.id, promptId: prompt.id, status: queueSettingsSummary(state, nextUiState, character.id) });
+      },
+      "Each queued job uses a fresh runtime seed even when the saved prompt preset has a fixed seed."
     ),
     makeInlineCheckbox(
       "Split queued images into contiguous character chunks",
@@ -3398,6 +3412,46 @@ function buildQueuedDoraStatePayload(character, prompt) {
   };
 }
 
+function applyRuntimeSeedToSettings(settings, seed) {
+  const normalized = normalizeSettings(settings);
+  normalized.seed = seed;
+  if (normalized.rgthree_seed) {
+    normalized.rgthree_seed = structuredCloneCompat(normalized.rgthree_seed);
+    normalized.rgthree_seed.seed = seed;
+    if (normalized.rgthree_seed.widgets && typeof normalized.rgthree_seed.widgets === "object") {
+      for (const name of ["seed", "noise_seed", "value"]) {
+        if (Object.prototype.hasOwnProperty.call(normalized.rgthree_seed.widgets, name)) {
+          normalized.rgthree_seed.widgets[name] = seed;
+        }
+      }
+    }
+  }
+  if (Array.isArray(normalized.nodes)) {
+    normalized.nodes = normalizeNodeSnapshots(normalized.nodes).map((snapshot) => {
+      const next = structuredCloneCompat(snapshot);
+      if (!next.widgets || typeof next.widgets !== "object") return next;
+      for (const name of ["seed", "noise_seed", "value"]) {
+        if (Object.prototype.hasOwnProperty.call(next.widgets, name)) next.widgets[name] = seed;
+      }
+      if (next.is_seed_node || next.seed != null || Object.keys(next.seed_widgets || {}).length) {
+        next.seed = seed;
+        if (next.seed_widgets && typeof next.seed_widgets === "object") {
+          for (const name of Object.keys(next.seed_widgets)) next.seed_widgets[name] = seed;
+        }
+      }
+      return next;
+    });
+  }
+  return normalized;
+}
+
+function withRuntimeSeed(payload, seed) {
+  return {
+    ...structuredCloneCompat(payload),
+    settings: applyRuntimeSeedToSettings(payload?.settings, seed),
+  };
+}
+
 function mutateQueuedDoraLoaders(promptPayload, managerNode, character, payload) {
   const controlled = getControlledNodes(managerNode).filter((node) => node && node !== managerNode);
   const controlledLoaders = controlled.filter(isDoraLoaderNode);
@@ -3444,14 +3498,14 @@ function mutateQueuedLegacyTextTargets(promptPayload, managerNode, prompt) {
 }
 
 
-function mutateQueuedSettingsNodes(promptPayload, managerNode, prompt) {
+function mutateQueuedSettingsNodes(promptPayload, managerNode, settingsSource) {
   const controlled = getControlledNodes(managerNode).filter((node) => node && node !== managerNode && !isDoraLoaderNode(node) && !isStateTextNode(node));
   const legacy = controlled.length ? [] : uniqueNodes([
     ...getOutputTargets(managerNode, OUTPUT_NAMES.settings),
     ...getOutputTargets(managerNode, OUTPUT_NAMES.seed),
   ]).filter((node) => node && node !== managerNode && !isDoraLoaderNode(node) && !isStateTextNode(node));
   const targets = controlled.length ? controlled : legacy;
-  const settings = normalizeSettings(prompt?.settings || {});
+  const settings = normalizeSettings(settingsSource || {});
   let changed = 0;
   for (const node of targets) {
     const snapshot = findSnapshotForNode(settings, node);
@@ -3482,18 +3536,21 @@ function mutatePromptForStateManagers(promptPayload, queueIndex, total) {
     if (!isStateManagerNode(node)) continue;
     const widgets = getWidgets(node);
     const { state, uiState } = getCurrentState(node);
-    if (!uiState.queue_prompt_wildcard && !uiState.queue_character_wildcard) continue;
+    if (!uiState.queue_prompt_wildcard && !uiState.queue_character_wildcard && !uiState.queue_randomize_saved_seed) continue;
     const currentCharacterId = String(widgetValue(widgets.characterWidget, "") || "");
     const currentPromptId = String(widgetValue(widgets.promptWidget, "") || "");
     const { character, prompt } = selectQueuedCharacterAndPrompt(node, state, uiState, currentCharacterId, currentPromptId, queueIndex, total);
     if (!character || !prompt) continue;
-    const payload = buildQueuedDoraStatePayload(character, prompt);
+    let payload = buildQueuedDoraStatePayload(character, prompt);
+    if (uiState.queue_randomize_saved_seed) {
+      payload = withRuntimeSeed(payload, generateStateManagerRuntimeSeed());
+    }
     changed += setQueuedStateManagerSelection(promptPayload, node, character.id, prompt.id);
     changed += setQueuedStateManagerRuntimeState(promptPayload, node, uiState, payload, queueIndex, total);
     changed += mutateQueuedDoraLoaders(promptPayload, node, character, payload);
     changed += mutateQueuedStateTextBoxes(promptPayload, node, prompt);
     changed += mutateQueuedLegacyTextTargets(promptPayload, node, prompt);
-    changed += mutateQueuedSettingsNodes(promptPayload, node, prompt);
+    changed += mutateQueuedSettingsNodes(promptPayload, node, payload.settings);
   }
   return changed;
 }


### PR DESCRIPTION
## Summary
- Embed a transient queued runtime State Manager payload into queued `ui_state_json`.
- Make `StateManager.resolve_state()` prefer that normalized queued payload before falling back to selected IDs.
- Add a per-queued-job nonce so executor caching cannot reuse stale `STATE_MANAGER_CONTROL` payloads when prompts repeat.

## Root cause
Queued random prompt mutation updated selected IDs and downstream nodes, but the backend discarded `ui_state_json`, so the State Manager source node rebuilt `state_control` from the normal selected prompt state instead of the queued prompt payload.

## Validation
- `git diff HEAD --check`
- `python3 -m py_compile nodes.py`
- `/ouroboros:qa` structured patch review: PASS 0.93

Repository tests were not run per workspace instructions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a queue option "Always randomize saved prompt seed" and per-queued runtime seed handling so each queued job can use its own randomized seed and avoid reusing cached executors.

* **Bug Fixes**
  * Improved queued-execution state resolution so character/prompt selections, settings and seeds are preserved correctly per queued item, preventing stale or shared runtime state across batch runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->