### PR TITLE
[codex] Add DoRA loader cache invalidation state

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -867,6 +867,8 @@ def _normalize_manager_loader_stacks(character: Dict[str, Any]) -> List[Dict[str
         normalized["slot"] = slot
         stacks.append(normalized)
 
+    legacy_loader_globals = _normalize_manager_loader_globals(character.get("loader_globals", character.get("globals", {})))
+
     # Legacy migration: previous versions stored one character-level LoRA stack.
     if not stacks:
         rows_in = character.get("loras")
@@ -880,8 +882,18 @@ def _normalize_manager_loader_stacks(character: Dict[str, Any]) -> List[Dict[str
             "slot": "default",
             "label": "Default loader",
             "loras": legacy_rows,
-            "loader_globals": _normalize_manager_loader_globals(character.get("loader_globals", character.get("globals", {}))),
+            "loader_globals": legacy_loader_globals,
         })
+    elif legacy_loader_globals:
+        # Older State Manager saves can contain loader_stacks plus the actual loader
+        # globals only on the legacy character mirror. Preserve those globals for the
+        # default stack instead of normalizing them away.
+        default_stack = next(
+            (stack for stack in stacks if isinstance(stack, dict) and _clean_loader_slot(stack.get("slot", ""), "default") == "default"),
+            stacks[0],
+        )
+        if isinstance(default_stack, dict) and not default_stack.get("loader_globals"):
+            default_stack["loader_globals"] = legacy_loader_globals
 
     return stacks
 
@@ -1444,6 +1456,123 @@ def _state_payload_get_loader_global(state_payload: Optional[Dict[str, Any]], ke
         if isinstance(globals_in, dict) and key in globals_in:
             return globals_in[key]
     return fallback
+
+
+def _loader_cache_lora_file_signature(lora_name: Any) -> Dict[str, Any]:
+    name = str(lora_name or "None")
+    out: Dict[str, Any] = {"name": name}
+    if not name or name in {"None", "NONE"}:
+        return out
+    try:
+        path = folder_paths.get_full_path("loras", name)
+    except Exception:
+        path = None
+    if not path:
+        out["missing"] = True
+        return out
+    try:
+        st = os.stat(path)
+        out["size"] = int(st.st_size)
+        out["mtime_ns"] = int(getattr(st, "st_mtime_ns", int(st.st_mtime * 1000000000)))
+    except Exception:
+        out["path"] = str(path)
+    return out
+
+
+def _loader_cache_float(value: Any, fallback: float = 0.0) -> float:
+    try:
+        out = float(value)
+    except Exception:
+        out = float(fallback)
+    return out if math.isfinite(out) else float(fallback)
+
+
+def _loader_cache_entries(entries: Optional[List[Dict[str, Any]]]) -> List[Dict[str, Any]]:
+    out: List[Dict[str, Any]] = []
+    for entry in entries or []:
+        if not isinstance(entry, dict):
+            continue
+        name = str(entry.get("lora", entry.get("name", "None")) or "None")
+        sm = _loader_cache_float(entry.get("strength_model", entry.get("strength", 0.0)), 0.0)
+        sc = _loader_cache_float(entry.get("strength_clip", entry.get("strengthTwo", sm)), sm)
+        out.append({
+            "on": bool(entry.get("on", entry.get("enabled", True))),
+            "lora": name,
+            "strength_model": sm,
+            "strength_clip": sc,
+            "file": _loader_cache_lora_file_signature(name),
+        })
+    return out
+
+
+def _loader_cache_globals(kwargs: Dict[str, Any], state_payload: Optional[Dict[str, Any]], state_slot: Any) -> Dict[str, Any]:
+    out: Dict[str, Any] = {}
+    for key in sorted(_DORA_STATE_LOADER_GLOBAL_KEYS):
+        if key == "stack_enabled":
+            fallback = kwargs.get(key, True)
+        elif key in {"broadcast_auto_scale", "broadcast_modulations", "dora_slice_fix", "dora_adaln_swap_fix", "zimage_lumina2_compat"}:
+            fallback = kwargs.get(key, True)
+        elif key == "auto_strength_device":
+            fallback = kwargs.get(key, "gpu")
+        elif key == "auto_strength_ratio_floor":
+            fallback = kwargs.get(key, _AUTO_STRENGTH_RATIO_FLOOR)
+        elif key == "auto_strength_ratio_ceiling":
+            fallback = kwargs.get(key, _AUTO_STRENGTH_RATIO_CEILING)
+        elif key == "broadcast_scale":
+            fallback = kwargs.get(key, 1.0)
+        elif key in {"dora_decompose_debug_n"}:
+            fallback = kwargs.get(key, 30)
+        elif key in {"dora_decompose_debug_stack_depth"}:
+            fallback = kwargs.get(key, 10)
+        else:
+            fallback = kwargs.get(key, False)
+        value = _state_payload_get_loader_global(state_payload, key, fallback, state_slot) if state_payload is not None else fallback
+        if key in {
+            "stack_enabled",
+            "verbose",
+            "log_unloaded_keys",
+            "broadcast_auto_scale",
+            "broadcast_modulations",
+            "broadcast_include_dora_scale",
+            "dora_decompose_debug",
+            "dora_slice_fix",
+            "dora_adaln_swap_fix",
+            "zimage_lumina2_compat",
+            "auto_strength_enabled",
+        }:
+            out[key] = _state_manager_bool(value)
+        elif key in {"dora_decompose_debug_n", "dora_decompose_debug_stack_depth"}:
+            try:
+                out[key] = int(value)
+            except Exception:
+                out[key] = int(fallback)
+        elif key == "auto_strength_device":
+            out[key] = _normalize_auto_strength_device(value)
+        else:
+            out[key] = _loader_cache_float(value, _loader_cache_float(fallback, 0.0))
+    return out
+
+
+def _dora_loader_cache_key_from_inputs(model: Any, clip: Any, kwargs: Dict[str, Any]) -> str:
+    state_slot = _clean_loader_slot(kwargs.get("state_slot", "default"), "default")
+    state_payload = _normalize_runtime_dora_state_payload(kwargs.get("dora_state"))
+    if state_payload is None:
+        state_payload = _normalize_runtime_dora_state_payload(kwargs.get("state_control"))
+
+    entries = _parse_dora_state_lora_entries(state_payload, state_slot) if state_payload is not None else None
+    if entries is None:
+        entries = _parse_lora_stack_kwargs(kwargs)
+
+    payload = {
+        "schema": 2,
+        "kind": "dora_power_lora_loader_cache_key",
+        "model_identity": id(model) if model is not None else None,
+        "clip_identity": id(clip) if clip is not None else None,
+        "state_slot": state_slot,
+        "loras": _loader_cache_entries(entries),
+        "loader_globals": _loader_cache_globals(kwargs, state_payload, state_slot),
+    }
+    return json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"), default=str)
 
 _LORA_MAGNITUDE_VECTOR_RE = re.compile(
     r"^(?P<base>.+?)\.lora_magnitude_vector(?:\.(?P<adapter>[A-Za-z0-9_-]+))?(?:\.weight)?$"
@@ -4738,6 +4867,10 @@ class DoraPowerLoraLoader:
     HAS_INTERMEDIATE_OUTPUT = True
     FUNCTION = "load_loras"
     CATEGORY = "loaders"
+
+    @classmethod
+    def IS_CHANGED(cls, model: Any = None, clip: Any = None, **kwargs):
+        return _dora_loader_cache_key_from_inputs(model, clip, kwargs)
 
     def _load_one(
         self,

--- a/nodes.py
+++ b/nodes.py
@@ -839,6 +839,17 @@ def _normalize_manager_loader_stack(stack: Any, index: int = 0) -> Optional[Dict
     }
 
 
+def _normalize_manager_legacy_loader_globals(character: Dict[str, Any]) -> Dict[str, Any]:
+    globals_in = character.get("globals")
+    loader_globals = character.get("loader_globals")
+    merged: Dict[str, Any] = {}
+    if isinstance(globals_in, dict):
+        merged.update(globals_in)
+    if isinstance(loader_globals, dict):
+        merged.update(loader_globals)
+    return _normalize_manager_loader_globals(merged)
+
+
 def _normalize_manager_loader_stacks(character: Dict[str, Any]) -> List[Dict[str, Any]]:
     stacks_in = character.get("loader_stacks")
     raw_stacks: List[Any] = []
@@ -867,7 +878,7 @@ def _normalize_manager_loader_stacks(character: Dict[str, Any]) -> List[Dict[str
         normalized["slot"] = slot
         stacks.append(normalized)
 
-    legacy_loader_globals = _normalize_manager_loader_globals(character.get("loader_globals", character.get("globals", {})))
+    legacy_loader_globals = _normalize_manager_legacy_loader_globals(character)
 
     # Legacy migration: previous versions stored one character-level LoRA stack.
     if not stacks:
@@ -1492,11 +1503,16 @@ def _loader_cache_entries(entries: Optional[List[Dict[str, Any]]]) -> List[Dict[
     for entry in entries or []:
         if not isinstance(entry, dict):
             continue
+        enabled = bool(entry.get("on", entry.get("enabled", True)))
+        if not enabled:
+            continue
         name = str(entry.get("lora", entry.get("name", "None")) or "None")
+        if name in {"", "None", "NONE"}:
+            continue
         sm = _loader_cache_float(entry.get("strength_model", entry.get("strength", 0.0)), 0.0)
         sc = _loader_cache_float(entry.get("strength_clip", entry.get("strengthTwo", sm)), sm)
         out.append({
-            "on": bool(entry.get("on", entry.get("enabled", True))),
+            "on": True,
             "lora": name,
             "strength_model": sm,
             "strength_clip": sc,

--- a/web/dora_state_manager.js
+++ b/web/dora_state_manager.js
@@ -461,7 +461,10 @@ function normalizeLoaderStacks(character) {
     stacks.push(normalized);
   });
 
-  const legacyGlobals = normalizeLoaderGlobals(c.loader_globals ?? c.globals);
+  const legacyGlobals = normalizeLoaderGlobals({
+    ...(c.globals && typeof c.globals === "object" ? c.globals : {}),
+    ...(c.loader_globals && typeof c.loader_globals === "object" ? c.loader_globals : {}),
+  });
   if (!stacks.length) {
     stacks.push({
       slot: "default",

--- a/web/dora_state_manager.js
+++ b/web/dora_state_manager.js
@@ -461,13 +461,17 @@ function normalizeLoaderStacks(character) {
     stacks.push(normalized);
   });
 
+  const legacyGlobals = normalizeLoaderGlobals(c.loader_globals ?? c.globals);
   if (!stacks.length) {
     stacks.push({
       slot: "default",
       label: "Default loader",
       loras: Array.isArray(c.loras) ? c.loras.map(normalizeLoraRow).filter(Boolean) : [],
-      loader_globals: normalizeLoaderGlobals(c.loader_globals ?? c.globals),
+      loader_globals: legacyGlobals,
     });
+  } else if (Object.keys(legacyGlobals).length) {
+    const primary = stacks.find((stack) => normalizeLoaderSlot(stack.slot, "default") === "default") || stacks[0];
+    if (primary && !Object.keys(primary.loader_globals || {}).length) primary.loader_globals = legacyGlobals;
   }
   return stacks;
 }
@@ -493,6 +497,19 @@ function findCharacterLoaderStack(character, slot, { allowFallback = true } = {}
   if (exact) return exact;
   if (!allowFallback) return null;
   return stacks.find((stack) => stack.slot === "default") || stacks[0] || null;
+}
+
+function updateCharacterLoaderGlobals(character, stackOrSlot, patch) {
+  const slot = normalizeLoaderSlot(
+    typeof stackOrSlot === "string" ? stackOrSlot : stackOrSlot?.slot,
+    "default"
+  );
+  const stack = findCharacterLoaderStack(character, slot, { allowFallback: false });
+  if (!stack) return {};
+  const current = normalizeLoaderGlobals(stack.loader_globals || {});
+  stack.loader_globals = normalizeLoaderGlobals({ ...current, ...(patch || {}) });
+  syncLegacyLoaderMirror(character);
+  return stack.loader_globals;
 }
 
 function setCharacterLoaderStack(character, stack) {
@@ -2841,23 +2858,19 @@ function renderLoraStackEditor(section, node, state, uiState, character, prompt,
   globalsLine.className = "dsm-grid2";
   globalsLine.append(
     labelledControl("Stack enabled", makeCheckbox(globals.stack_enabled ?? true, (checked) => {
-      stack.loader_globals = normalizeLoaderGlobals({ ...globals, stack_enabled: checked });
-      syncLegacyLoaderMirror(character);
+      updateCharacterLoaderGlobals(character, stack, { stack_enabled: checked });
       updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id });
     })),
     labelledControl("Auto-strength", makeCheckbox(globals.auto_strength_enabled ?? false, (checked) => {
-      stack.loader_globals = normalizeLoaderGlobals({ ...globals, auto_strength_enabled: checked });
-      syncLegacyLoaderMirror(character);
+      updateCharacterLoaderGlobals(character, stack, { auto_strength_enabled: checked });
       updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id });
     })),
     labelledControl("Analysis device", makeSelect(AUTO_STRENGTH_DEVICE_CHOICES, normalizeDevice(globals.auto_strength_device ?? "gpu"), (value) => {
-      stack.loader_globals = normalizeLoaderGlobals({ ...globals, auto_strength_device: value });
-      syncLegacyLoaderMirror(character);
+      updateCharacterLoaderGlobals(character, stack, { auto_strength_device: value });
       updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id });
     })),
     labelledControl("Ratio ceiling", makeInput(globals.auto_strength_ratio_ceiling ?? 1.5, (value) => {
-      stack.loader_globals = normalizeLoaderGlobals({ ...globals, auto_strength_ratio_ceiling: normalizeNumber(value, 1.5) });
-      syncLegacyLoaderMirror(character);
+      updateCharacterLoaderGlobals(character, stack, { auto_strength_ratio_ceiling: normalizeNumber(value, 1.5) });
       updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id });
     }, { type: "number", step: "0.01" }))
   );
@@ -2954,43 +2967,35 @@ function renderSettingsPanelContent(section, node, state, uiState, character, pr
   grid.className = "dsm-grid2";
 
   const stackEnabled = makeCheckbox(globals.stack_enabled ?? true, (checked) => {
-    primaryStack.loader_globals = normalizeLoaderGlobals({ ...globals, stack_enabled: checked });
-    syncLegacyLoaderMirror(character);
+    updateCharacterLoaderGlobals(character, primaryStack, { stack_enabled: checked });
     updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id });
   });
   const autoStrength = makeCheckbox(globals.auto_strength_enabled ?? false, (checked) => {
-    primaryStack.loader_globals = normalizeLoaderGlobals({ ...globals, auto_strength_enabled: checked });
-    syncLegacyLoaderMirror(character);
+    updateCharacterLoaderGlobals(character, primaryStack, { auto_strength_enabled: checked });
     updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id });
   });
   const device = makeSelect(AUTO_STRENGTH_DEVICE_CHOICES, normalizeDevice(globals.auto_strength_device ?? "gpu"), (value) => {
-    primaryStack.loader_globals = normalizeLoaderGlobals({ ...globals, auto_strength_device: value });
-    syncLegacyLoaderMirror(character);
+    updateCharacterLoaderGlobals(character, primaryStack, { auto_strength_device: value });
     updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id });
   });
   const broadcastMods = makeCheckbox(globals.broadcast_modulations ?? true, (checked) => {
-    primaryStack.loader_globals = normalizeLoaderGlobals({ ...globals, broadcast_modulations: checked });
-    syncLegacyLoaderMirror(character);
+    updateCharacterLoaderGlobals(character, primaryStack, { broadcast_modulations: checked });
     updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id });
   });
   const floor = makeInput(globals.auto_strength_ratio_floor ?? 0.3, (value) => {
-    primaryStack.loader_globals = normalizeLoaderGlobals({ ...globals, auto_strength_ratio_floor: normalizeNumber(value, 0.3) });
-    syncLegacyLoaderMirror(character);
+    updateCharacterLoaderGlobals(character, primaryStack, { auto_strength_ratio_floor: normalizeNumber(value, 0.3) });
     updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id });
   }, { type: "number", step: "0.01" });
   const ceiling = makeInput(globals.auto_strength_ratio_ceiling ?? 1.5, (value) => {
-    primaryStack.loader_globals = normalizeLoaderGlobals({ ...globals, auto_strength_ratio_ceiling: normalizeNumber(value, 1.5) });
-    syncLegacyLoaderMirror(character);
+    updateCharacterLoaderGlobals(character, primaryStack, { auto_strength_ratio_ceiling: normalizeNumber(value, 1.5) });
     updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id });
   }, { type: "number", step: "0.01" });
   const sliceFix = makeCheckbox(globals.dora_slice_fix ?? true, (checked) => {
-    primaryStack.loader_globals = normalizeLoaderGlobals({ ...globals, dora_slice_fix: checked });
-    syncLegacyLoaderMirror(character);
+    updateCharacterLoaderGlobals(character, primaryStack, { dora_slice_fix: checked });
     updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id });
   });
   const adalnFix = makeCheckbox(globals.dora_adaln_swap_fix ?? true, (checked) => {
-    primaryStack.loader_globals = normalizeLoaderGlobals({ ...globals, dora_adaln_swap_fix: checked });
-    syncLegacyLoaderMirror(character);
+    updateCharacterLoaderGlobals(character, primaryStack, { dora_adaln_swap_fix: checked });
     updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id });
   });
 
@@ -3412,6 +3417,31 @@ function buildQueuedDoraStatePayload(character, prompt) {
   };
 }
 
+function buildQueuedDoraLoaderPayload(character) {
+  syncLegacyLoaderMirror(character);
+  const loaderStacks = getCharacterLoaderStacks(character).map((stack) => structuredCloneCompat(stack));
+  const defaultStack = findCharacterLoaderStack(character, "default") || loaderStacks[0] || defaultLoaderStack();
+  return {
+    version: 2,
+    kind: "dora_state_manager_state",
+    character: {
+      id: String(character?.id ?? ""),
+      name: String(character?.name ?? ""),
+      thumbnail: normalizeThumbnail(character?.thumbnail),
+    },
+    prompt: { id: "", name: "" },
+    loader_stacks: loaderStacks,
+    loras: structuredCloneCompat(defaultStack?.loras || []),
+    loader_globals: normalizeLoaderGlobals(defaultStack?.loader_globals || character?.loader_globals || {}),
+    settings: {},
+    text_boxes: [],
+    positive_prompt: "",
+    negative_prompt: "",
+    reference_image: {},
+    fileimage_prefix: "",
+  };
+}
+
 function applyRuntimeSeedToSettings(settings, seed) {
   const normalized = normalizeSettings(settings);
   normalized.seed = seed;
@@ -3452,14 +3482,16 @@ function withRuntimeSeed(payload, seed) {
   };
 }
 
-function mutateQueuedDoraLoaders(promptPayload, managerNode, character, payload) {
+function mutateQueuedDoraLoaders(promptPayload, managerNode, character) {
   const controlled = getControlledNodes(managerNode).filter((node) => node && node !== managerNode);
   const controlledLoaders = controlled.filter(isDoraLoaderNode);
   const legacyLoaders = controlledLoaders.length ? [] : uniqueNodes(getOutputTargets(managerNode, OUTPUT_NAMES.lora)).filter(isDoraLoaderNode);
   const loaders = controlledLoaders.length ? controlledLoaders : legacyLoaders;
+  if (!loaders.length) return 0;
+  const loaderPayload = buildQueuedDoraLoaderPayload(character);
   let changed = 0;
   for (const loader of loaders) {
-    changed += setQueuedInput(promptPayload, loader, "dora_state", payload, { addIfMissing: true, syncWidget: false });
+    changed += setQueuedInput(promptPayload, loader, "dora_state", loaderPayload, { addIfMissing: true, syncWidget: false });
   }
   return changed;
 }
@@ -3547,7 +3579,7 @@ function mutatePromptForStateManagers(promptPayload, queueIndex, total) {
     }
     changed += setQueuedStateManagerSelection(promptPayload, node, character.id, prompt.id);
     changed += setQueuedStateManagerRuntimeState(promptPayload, node, uiState, payload, queueIndex, total);
-    changed += mutateQueuedDoraLoaders(promptPayload, node, character, payload);
+    changed += mutateQueuedDoraLoaders(promptPayload, node, character);
     changed += mutateQueuedStateTextBoxes(promptPayload, node, prompt);
     changed += mutateQueuedLegacyTextTargets(promptPayload, node, prompt);
     changed += mutateQueuedSettingsNodes(promptPayload, node, payload.settings);


### PR DESCRIPTION
## Summary

- preserve legacy State Manager loader globals when older saves have stacks but globals only on the character mirror
- add a DoRA loader `IS_CHANGED` cache key that includes effective LoRA rows, loader globals, auto-strength settings, model/clip identity, state slot, and LoRA file signatures
- queue loader-only State Manager payloads for DoRA Loader nodes so prompt-only wildcard state does not unnecessarily invalidate loader execution

## Validation

- `rtk python3 -m py_compile nodes.py`
- `/ouroboros:qa` structured review: PASS, score 0.86

Repository tests were not run per instruction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable re-execution and caching for LoRA/loader updates so changes to LoRAs, loader globals, or state reliably trigger reloads.
  * Restored and preserved legacy loader globals so older character configurations continue to behave correctly.

* **Chores**
  * Refined loader state handling and payload construction for queued loader operations.
  * Updated UI controls to sync loader globals through a centralized update path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->