### PR TITLE
[codex] Guard unsafe reshape_weight LoRA metadata

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -1667,7 +1667,6 @@ _BASE_SUFFIXES = [
     ".diff",
     ".diff_b",
     ".set_weight",
-    ".reshape_weight",
 ]
 
 _SCALEABLE_SUFFIXES = (
@@ -1675,7 +1674,6 @@ _SCALEABLE_SUFFIXES = (
     ".diff",
     ".diff_b",
     ".set_weight",
-    ".reshape_weight",
     # mochi-style (no .weight suffix)
     ".lora_A",
     ".lora_B",
@@ -1693,6 +1691,82 @@ _UP_ONLY_SCALE_SUFFIXES = (
     # mochi-style (no .weight suffix)
     ".lora_A",
 )
+
+_RESHAPE_WEIGHT_MAX_DIMS = 8
+
+
+def _sanitize_reshape_weight_metadata(lora_sd: Dict[str, Any], lora_name: str = "", verbose: bool = False) -> int:
+    """
+    Keep .reshape_weight keys only when they are small shape metadata.
+
+    ComfyUI's LoRAAdapter.load() treats <base>.reshape_weight as a shape list and
+    calls .tolist() on it while constructing the adapter. If a malformed/exported
+    LoRA stores a real tensor under that suffix, the direct .tolist() can allocate a
+    huge nested Python object or crash in native code before Python can raise a
+    normal exception. The loader does not support .reshape_weight as an independent
+    weight patch, so invalid entries are report/debug data at best and must not be
+    passed into comfy.lora.load_lora(...).
+    """
+    removed = 0
+    for key in list(lora_sd.keys()):
+        if not str(key).endswith(".reshape_weight"):
+            continue
+        value = lora_sd.get(key)
+        valid = False
+        reason = "unsupported value"
+
+        try:
+            if isinstance(value, torch.Tensor):
+                numel = int(value.numel())
+                ndim = int(value.ndim)
+                if numel <= 0:
+                    reason = "empty tensor"
+                elif numel > _RESHAPE_WEIGHT_MAX_DIMS or ndim > 1:
+                    reason = f"not shape metadata (shape={tuple(value.shape)} numel={numel})"
+                else:
+                    vals = value.detach().cpu().flatten().tolist()
+                    valid = 0 < len(vals) <= _RESHAPE_WEIGHT_MAX_DIMS and all(
+                        isinstance(v, (int, float))
+                        and math.isfinite(float(v))
+                        and int(v) > 0
+                        and abs(float(v) - int(v)) <= 1e-6
+                        for v in vals
+                    )
+                    if not valid:
+                        reason = f"non-integer shape values ({vals!r})"
+            elif isinstance(value, (list, tuple)):
+                vals = list(value)
+                valid = 0 < len(vals) <= _RESHAPE_WEIGHT_MAX_DIMS and all(
+                    isinstance(v, (int, float))
+                    and math.isfinite(float(v))
+                    and int(v) > 0
+                    and abs(float(v) - int(v)) <= 1e-6
+                    for v in vals
+                )
+                if not valid:
+                    reason = f"invalid shape list ({vals!r})"
+            else:
+                reason = f"unsupported type {type(value).__name__}"
+        except Exception as exc:
+            valid = False
+            reason = str(exc)
+
+        if valid:
+            continue
+
+        lora_sd.pop(key, None)
+        removed += 1
+        _LOG.warning(
+            "[DoRA Power LoRA Loader] %s: dropping unsafe %s before comfy.lora.load_lora: %s",
+            lora_name or "LoRA",
+            key,
+            reason,
+        )
+
+    if verbose and removed:
+        _LOG.info("[DoRA Power LoRA Loader] %s: dropped %d unsafe reshape_weight metadata entries", lora_name, removed)
+    return removed
+
 
 _LORA_DIRECTION_SUFFIX_PAIRS = (
     (".lora_up.weight", ".lora_down.weight"),
@@ -1729,7 +1803,6 @@ _BROADCAST_DELTA_SUFFIXES = (
     ".diff",
     ".diff_b",
     ".set_weight",
-    ".reshape_weight",
 )
 
 # For OneTrainer DoRA exports, modulation modules often include DoRA params.
@@ -2249,7 +2322,6 @@ _ZIMAGE_QKV_CAT_SUFFIXES = (
     ".diff",
     ".diff_b",
     ".set_weight",
-    ".reshape_weight",
 )
 
 _ZIMAGE_ATTN_ALIAS_REWRITES = (
@@ -3230,7 +3302,7 @@ def _auto_strength_measure_base_delta_on_device(
     Supported cases:
       - standard LoRA / DoRA low-rank pairs / direct deltas: RMS(delta)
       - DoRA low-rank pairs: RMS(actual post-normalization DoRA update)
-      - direct delta tensors (.diff / .diff_b / .set_weight / .reshape_weight)
+      - direct delta tensors (.diff / .diff_b / .set_weight)
 
     Invariant: scores must be comparable across destination tensor sizes. Using raw
     Frobenius norms violates that invariant because ||ΔW||_F scales with sqrt(numel),
@@ -3255,7 +3327,7 @@ def _auto_strength_measure_base_delta_on_device(
             analysis_device=analysis_device,
         )
 
-    for suffix in (".diff", ".diff_b", ".set_weight", ".reshape_weight"):
+    for suffix in (".diff", ".diff_b", ".set_weight"):
         key = base + suffix
         tensor = lora_sd.get(key)
         if not isinstance(tensor, torch.Tensor):
@@ -3788,7 +3860,7 @@ def _apply_base_strength_ratios(
             should_scale = False
             if ks.endswith(".alpha"):
                 should_scale = True
-            elif ks.endswith((".diff", ".diff_b", ".set_weight", ".reshape_weight")):
+            elif ks.endswith((".diff", ".diff_b", ".set_weight")):
                 should_scale = True
             elif (not has_alpha) and ks.endswith(_UP_ONLY_SCALE_SUFFIXES):
                 should_scale = True
@@ -5030,6 +5102,8 @@ class DoraPowerLoraLoader:
                 broadcast_include_dora_scale=broadcast_include_dora_scale,
                 auto_strength_logical_groups=auto_strength_logical_groups,
             )
+
+        _sanitize_reshape_weight_metadata(lora_sd, lora_name=lora_name, verbose=verbose)
 
         # Extract base module names from file keys (after compat rewrites/broadcast).
         lora_bases = _extract_lora_bases(lora_sd.keys())

--- a/nodes.py
+++ b/nodes.py
@@ -1695,6 +1695,19 @@ _UP_ONLY_SCALE_SUFFIXES = (
 _RESHAPE_WEIGHT_MAX_DIMS = 8
 
 
+def _canonical_reshape_weight_dim(value: Any) -> Optional[int]:
+    """Return a positive integer dimension when value is safe shape metadata."""
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value if value > 0 else None
+    if isinstance(value, float) and math.isfinite(value) and value > 0:
+        rounded = round(value)
+        if abs(value - rounded) <= 1e-6:
+            return int(rounded)
+    return None
+
+
 def _sanitize_reshape_weight_metadata(lora_sd: Dict[str, Any], lora_name: str = "", verbose: bool = False) -> int:
     """
     Keep .reshape_weight keys only when they are small shape metadata.
@@ -1713,6 +1726,7 @@ def _sanitize_reshape_weight_metadata(lora_sd: Dict[str, Any], lora_name: str = 
             continue
         value = lora_sd.get(key)
         valid = False
+        canonical_vals = None
         reason = "unsupported value"
 
         try:
@@ -1725,34 +1739,30 @@ def _sanitize_reshape_weight_metadata(lora_sd: Dict[str, Any], lora_name: str = 
                     reason = f"not shape metadata (shape={tuple(value.shape)} numel={numel})"
                 else:
                     vals = value.detach().cpu().flatten().tolist()
-                    valid = 0 < len(vals) <= _RESHAPE_WEIGHT_MAX_DIMS and all(
-                        isinstance(v, (int, float))
-                        and math.isfinite(float(v))
-                        and int(v) > 0
-                        and abs(float(v) - int(v)) <= 1e-6
-                        for v in vals
-                    )
+                    if 0 < len(vals) <= _RESHAPE_WEIGHT_MAX_DIMS:
+                        canonical_vals = [_canonical_reshape_weight_dim(v) for v in vals]
+                        valid = all(v is not None for v in canonical_vals)
                     if not valid:
                         reason = f"non-integer shape values ({vals!r})"
             elif isinstance(value, (list, tuple)):
                 vals = list(value)
-                valid = 0 < len(vals) <= _RESHAPE_WEIGHT_MAX_DIMS and all(
-                    isinstance(v, (int, float))
-                    and math.isfinite(float(v))
-                    and int(v) > 0
-                    and abs(float(v) - int(v)) <= 1e-6
-                    for v in vals
-                )
+                if 0 < len(vals) <= _RESHAPE_WEIGHT_MAX_DIMS:
+                    canonical_vals = [_canonical_reshape_weight_dim(v) for v in vals]
+                    valid = all(v is not None for v in canonical_vals)
                 if not valid:
                     reason = f"invalid shape list ({vals!r})"
             else:
                 reason = f"unsupported type {type(value).__name__}"
-        except Exception as exc:
+        except (RuntimeError, TypeError, ValueError, OverflowError) as exc:
             valid = False
             reason = str(exc)
 
         if valid:
-            continue
+            try:
+                lora_sd[key] = torch.tensor(canonical_vals, dtype=torch.int64)
+                continue
+            except (RuntimeError, TypeError, ValueError, OverflowError) as exc:
+                reason = str(exc)
 
         lora_sd.pop(key, None)
         removed += 1


### PR DESCRIPTION
## Summary

- Drop unsafe or malformed `.reshape_weight` entries from LoRA state dicts before calling `comfy.lora.load_lora(...)`.
- Stop treating `.reshape_weight` as a direct delta for base extraction, broadcast, auto-strength measurement, and scaling.
- Preserve valid small shape metadata and keep the existing extended `key_map` behavior unchanged.

## Root Cause

ComfyUI's LoRA adapter probes `<base>.reshape_weight` as shape metadata and calls `.tolist()` while building the adapter. If an exported or malformed LoRA stores a real tensor under that suffix, that conversion can allocate a huge nested Python object or crash before normal Python error handling can recover.

## Validation

- Applied the provided patch to a fresh worktree after pulling `main`.
- Narrowed the patch to avoid changing `load_lora` key-map behavior.
- Ran `rtk python3 -m py_compile nodes.py` successfully.
- Ran `/ouroboros:qa` on the revised patch: PASS, score 0.89.

Repository tests were not run per repo instruction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stronger validation and automatic removal of unsafe or invalid LoRA metadata to prevent errant behavior and loading issues with advanced adapters.

* **Improvements**
  * Refined automatic strength measurement and scaling so metadata-only entries no longer skew compatibility scoring or per-base strength application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->