### PR TITLE
[codex] Route queued DoRA loaders through state_control

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -1571,19 +1571,26 @@ def _loader_cache_globals(kwargs: Dict[str, Any], state_payload: Optional[Dict[s
 
 def _dora_loader_cache_key_from_inputs(model: Any, clip: Any, kwargs: Dict[str, Any]) -> str:
     state_slot = _clean_loader_slot(kwargs.get("state_slot", "default"), "default")
-    state_payload = _normalize_runtime_dora_state_payload(kwargs.get("dora_state"))
+    # Prefer state_control. It is the intended State Manager edge. dora_state remains
+    # a compatibility fallback for old workflows or direct runtime payload wiring.
+    state_payload = _normalize_runtime_dora_state_payload(kwargs.get("state_control"))
     if state_payload is None:
-        state_payload = _normalize_runtime_dora_state_payload(kwargs.get("state_control"))
+        state_payload = _normalize_runtime_dora_state_payload(kwargs.get("dora_state"))
 
     entries = _parse_dora_state_lora_entries(state_payload, state_slot) if state_payload is not None else None
     if entries is None:
         entries = _parse_lora_stack_kwargs(kwargs)
 
+    # Do not include Python object identity here. ComfyUI may recreate ModelPatcher / CLIP
+    # wrapper objects between queued prompts even when the actual checkpoint and LoRA stack
+    # are unchanged. Real upstream model/clip dependency invalidation is handled by Comfy's
+    # graph cache; this key is only the loader's own stack/global/file signature.
+    #
+    # Also deliberately ignore prompt/seed/text/reference fields from state_control. The
+    # DoRA loader consumes only the selected loader stack and loader globals.
     payload = {
-        "schema": 2,
+        "schema": 3,
         "kind": "dora_power_lora_loader_cache_key",
-        "model_identity": id(model) if model is not None else None,
-        "clip_identity": id(clip) if clip is not None else None,
         "state_slot": state_slot,
         "loras": _loader_cache_entries(entries),
         "loader_globals": _loader_cache_globals(kwargs, state_payload, state_slot),
@@ -5230,14 +5237,14 @@ class DoraPowerLoraLoader:
         return model, clip, auto_strength_report
 
     def load_loras(self, model, clip, **kwargs):
-        # state_control is the preferred State Manager relationship edge. When it
-        # carries a runtime payload, use it as the fallback source for LoRA rows
+        # state_control is the intended State Manager relationship edge. When it
+        # carries a runtime payload, use it as the primary source for LoRA rows
         # and loader-global settings so state_control-only graphs follow queued
-        # character/prompt wildcarding. A direct dora_state input still wins.
+        # character/prompt wildcarding. dora_state is only a compatibility fallback.
         state_slot = _clean_loader_slot(kwargs.get("state_slot", "default"), "default")
-        state_payload = _normalize_runtime_dora_state_payload(kwargs.get("dora_state"))
+        state_payload = _normalize_runtime_dora_state_payload(kwargs.get("state_control"))
         if state_payload is None:
-            state_payload = _normalize_runtime_dora_state_payload(kwargs.get("state_control"))
+            state_payload = _normalize_runtime_dora_state_payload(kwargs.get("dora_state"))
         kwargs.pop("state_control", None)
 
         # Global controls (provided by JS UI; optionally overridden by DoRA State Manager)

--- a/web/dora_state_manager.js
+++ b/web/dora_state_manager.js
@@ -3508,7 +3508,7 @@ function withRuntimeSeed(payload, seed) {
 function mutateQueuedDoraLoaders(promptPayload, managerNode, character) {
   const controlled = getControlledNodes(managerNode).filter((node) => node && node !== managerNode);
   const controlledLoaders = controlled.filter(isDoraLoaderNode);
-  const legacyLoaders = controlledLoaders.length ? [] : uniqueNodes(getOutputTargets(managerNode, OUTPUT_NAMES.control)).filter(isDoraLoaderNode);
+  const legacyLoaders = controlledLoaders.length ? [] : uniqueNodes(getOutputTargets(managerNode, OUTPUT_NAMES.lora)).filter(isDoraLoaderNode);
   const loaders = controlledLoaders.length ? controlledLoaders : legacyLoaders;
   if (!loaders.length) return 0;
   let changed = 0;

--- a/web/dora_state_manager.js
+++ b/web/dora_state_manager.js
@@ -6,6 +6,8 @@ const EXT_NAME = "comfyui_dora_dynamic_lora.state_manager";
 const NODE_CLASS = "State Manager";
 const LEGACY_NODE_CLASS = "DoRA State Manager";
 const DORA_LOADER_CLASS = "DoRA Power LoRA Loader";
+const DORA_STATE_KIND = "dora_state_manager_state";
+const STATE_MANAGER_CONTROL_KIND = "state_manager_control";
 const STATE_TEXT_CLASS = "State Manager Text Box";
 const STATE_TEXT_DISPLAY_CLASS = "State Text Box";
 const STATE_SEED_CLASS = "State Manager Seed";
@@ -3420,28 +3422,46 @@ function buildQueuedDoraStatePayload(character, prompt) {
   };
 }
 
-function buildQueuedDoraLoaderPayload(character) {
+function buildQueuedDoraLoaderStatePayload(character, loader = null, fallbackIndex = 0) {
   syncLegacyLoaderMirror(character);
-  const loaderStacks = getCharacterLoaderStacks(character).map((stack) => structuredCloneCompat(stack));
-  const defaultStack = findCharacterLoaderStack(character, "default") || loaderStacks[0] || defaultLoaderStack();
+  const slot = loader ? getDoraLoaderSlot(loader, fallbackIndex) : "default";
+  const stack = findCharacterLoaderStack(character, slot, { allowFallback: false })
+    || findCharacterLoaderStack(character, "default", { allowFallback: true })
+    || defaultLoaderStack();
+  const normalizedStack = normalizeLoaderStack({
+    ...structuredCloneCompat(stack),
+    slot,
+    label: stack?.label || slot,
+  });
+  const globals = normalizeLoaderGlobals(normalizedStack.loader_globals || {});
+
+  // Loader-only runtime state. Keep prompts, settings, seeds, text boxes,
+  // thumbnails, reference images, and unrelated loader stacks out of the DoRA
+  // loader's state_control payload so prompt-only queue wildcarding cannot
+  // invalidate/reload LoRA patches.
   return {
     version: 2,
-    kind: "dora_state_manager_state",
-    character: {
-      id: String(character?.id ?? ""),
-      name: String(character?.name ?? ""),
-      thumbnail: normalizeThumbnail(character?.thumbnail),
-    },
-    prompt: { id: "", name: "" },
-    loader_stacks: loaderStacks,
-    loras: structuredCloneCompat(defaultStack?.loras || []),
-    loader_globals: normalizeLoaderGlobals(defaultStack?.loader_globals || character?.loader_globals || {}),
-    settings: {},
-    text_boxes: [],
-    positive_prompt: "",
-    negative_prompt: "",
-    reference_image: {},
-    fileimage_prefix: "",
+    kind: DORA_STATE_KIND,
+    loader_stacks: [{
+      slot: normalizedStack.slot,
+      label: normalizedStack.label,
+      loras: structuredCloneCompat(normalizedStack.loras || []),
+      loader_globals: globals,
+    }],
+    loras: structuredCloneCompat(normalizedStack.loras || []),
+    loader_globals: globals,
+  };
+}
+
+function buildQueuedDoraLoaderControlPayload(character, loader = null, fallbackIndex = 0) {
+  const state = buildQueuedDoraLoaderStatePayload(character, loader, fallbackIndex);
+  return {
+    version: 2,
+    kind: STATE_MANAGER_CONTROL_KIND,
+    state,
+    loader_stacks: structuredCloneCompat(state.loader_stacks || []),
+    loras: structuredCloneCompat(state.loras || []),
+    loader_globals: structuredCloneCompat(state.loader_globals || {}),
   };
 }
 
@@ -3488,13 +3508,17 @@ function withRuntimeSeed(payload, seed) {
 function mutateQueuedDoraLoaders(promptPayload, managerNode, character) {
   const controlled = getControlledNodes(managerNode).filter((node) => node && node !== managerNode);
   const controlledLoaders = controlled.filter(isDoraLoaderNode);
-  const legacyLoaders = controlledLoaders.length ? [] : uniqueNodes(getOutputTargets(managerNode, OUTPUT_NAMES.lora)).filter(isDoraLoaderNode);
+  const legacyLoaders = controlledLoaders.length ? [] : uniqueNodes(getOutputTargets(managerNode, OUTPUT_NAMES.control)).filter(isDoraLoaderNode);
   const loaders = controlledLoaders.length ? controlledLoaders : legacyLoaders;
   if (!loaders.length) return 0;
-  const loaderPayload = buildQueuedDoraLoaderPayload(character);
   let changed = 0;
-  for (const loader of loaders) {
-    changed += setQueuedInput(promptPayload, loader, "dora_state", loaderPayload, { addIfMissing: true, syncWidget: false });
+  for (const [index, loader] of loaders.entries()) {
+    const loaderControlPayload = buildQueuedDoraLoaderControlPayload(character, loader, index);
+
+    // state_control is the intended State Manager edge. During queued wildcarding,
+    // keep using state_control, but replace the queued API input with a loader-only
+    // control payload. The editor graph remains connected through state_control.
+    changed += setQueuedInput(promptPayload, loader, "state_control", loaderControlPayload, { addIfMissing: true, syncWidget: false });
   }
   return changed;
 }


### PR DESCRIPTION
## Summary
- Make DoRA loader runtime state prefer `state_control`, with `dora_state` retained only as a compatibility fallback.
- Queue DoRA loader wildcard overrides through `state_control` instead of writing `dora_state`.
- Limit queued loader payloads to the selected loader stack, LoRA rows, and loader globals.
- Remove volatile `model`/`clip` wrapper identities from the loader cache key while keeping loader/file signatures.

## Validation
- `python3 -m py_compile nodes.py`
- `node --check web/dora_state_manager.js`
- Ouroboros QA pass: 0.92 / 1.00

Repository test suites were not run per instruction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Broadened cache key format to improve cache reuse and reduce redundant reloads.
  * Loader runtime now prefers centralized State Manager control for consistent state selection.
  * Queued loader payloads no longer include prompt/seed/text-related fields—only loader configuration and globals—improving privacy and cache stability.
  * Queued loader updates now use control-wrapped payloads per loader slot for more predictable state propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->