### PR TITLE
Preserve live State Seed precedence

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -4840,7 +4840,11 @@ class StateManagerSeed:
         del prompt, extra_pnginfo, unique_id, control_after_generate
         state_payload = _normalize_runtime_dora_state_payload(state_control)
         controlled_seed = _state_payload_seed(state_payload)
-        seed_i = _coerce_state_manager_seed(controlled_seed if controlled_seed is not None else seed, -1)
+        local_seed = _coerce_state_manager_seed(seed, -1)
+        seed_i = local_seed if local_seed not in _STATE_SEED_SPECIALS else _coerce_state_manager_seed(
+            controlled_seed if controlled_seed is not None else local_seed,
+            -1,
+        )
         if seed_i in _STATE_SEED_SPECIALS:
             return _state_manager_new_random_seed()
         return json.dumps(
@@ -4865,7 +4869,11 @@ class StateManagerSeed:
         del control_after_generate
         state_payload = _normalize_runtime_dora_state_payload(state_control)
         controlled_seed = _state_payload_seed(state_payload)
-        original_seed = _coerce_state_manager_seed(controlled_seed if controlled_seed is not None else seed, -1)
+        local_seed = _coerce_state_manager_seed(seed, -1)
+        original_seed = local_seed if local_seed not in _STATE_SEED_SPECIALS else _coerce_state_manager_seed(
+            controlled_seed if controlled_seed is not None else local_seed,
+            -1,
+        )
         seed_i = original_seed
         if seed_i in _STATE_SEED_SPECIALS:
             if seed_i in (-2, -3):

--- a/web/dora_state_manager.js
+++ b/web/dora_state_manager.js
@@ -2208,7 +2208,7 @@ function queueSettingsSummary(state, uiState, currentCharacterId) {
     ? "Prompts: each queued job randomly selects one saved prompt preset from the active character."
     : "Prompts: selected prompt preset only.");
   if (uiState.queue_randomize_saved_seed) {
-    lines.push("Saved prompt preset seeds are randomized for every queued job.");
+    lines.push("Saved prompt preset seeds randomize only when no connected State Seed provides a fixed live seed.");
   }
   return lines.join(" ");
 }
@@ -2382,13 +2382,13 @@ function renderHeader(node, state, uiState, character, prompt) {
       "Each queued job samples one saved prompt preset from whichever character is active for that job."
     ),
     makeInlineCheckbox(
-      "Always randomize saved prompt seed",
+      "Randomize saved prompt seed when live seed is random",
       uiState.queue_randomize_saved_seed,
       (checked) => {
         const nextUiState = { ...uiState, queue_randomize_saved_seed: checked };
         updateState(node, state, nextUiState, { characterId: character.id, promptId: prompt.id, status: queueSettingsSummary(state, nextUiState, character.id) });
       },
-      "Each queued job uses a fresh runtime seed even when the saved prompt preset has a fixed seed."
+      "If a connected State Seed node is set to -1, the resolved queued seed is used. A fixed live State Seed takes precedence over saved prompt seeds."
     ),
     makeInlineCheckbox(
       "Split queued images into contiguous character chunks",
@@ -3304,6 +3304,31 @@ function setQueuedWidgetInput(promptPayload, node, widgetName, value) {
   return setQueuedInput(promptPayload, node, widgetName, value, { addIfMissing: false, syncWidget: true });
 }
 
+function readQueuedInput(promptPayload, node, inputName) {
+  if (!promptPayload?.output || !node || !inputName) return undefined;
+  for (const promptId of queueOutputKeysForNode(promptPayload, node)) {
+    const inputs = promptPayload.output?.[promptId]?.inputs;
+    if (inputs && Object.prototype.hasOwnProperty.call(inputs, inputName)) return inputs[inputName];
+  }
+  return undefined;
+}
+
+function readQueuedStateSeed(promptPayload, node) {
+  const raw = readQueuedInput(promptPayload, node, "seed");
+  if (raw === undefined) return null;
+  const seed = normalizeSeedInteger(raw, STATE_SEED_RANDOM);
+  return STATE_SEED_SPECIALS.includes(seed) ? null : seed;
+}
+
+function firstControlledStateSeed(managerNode, promptPayload) {
+  const controlled = getControlledNodes(managerNode).filter((node) => node && node !== managerNode && isStateSeedNode(node));
+  for (const node of controlled) {
+    const seed = readQueuedStateSeed(promptPayload, node);
+    if (seed != null) return { node, seed };
+  }
+  return null;
+}
+
 function serializeQueuedUiStateOverride(uiState, payload, queueIndex, total) {
   return JSON.stringify({
     ...stripBackupRestoreStatus(uiState || defaultUiState()),
@@ -3567,13 +3592,15 @@ function mutateQueuedSettingsNodes(promptPayload, managerNode, settingsSource) {
   const settings = normalizeSettings(settingsSource || {});
   let changed = 0;
   for (const node of targets) {
+    const preserveLiveStateSeed = isStateSeedNode(node) && readQueuedStateSeed(promptPayload, node) != null;
     const snapshot = findSnapshotForNode(settings, node);
     if (snapshot?.widgets) {
       for (const [name, value] of Object.entries(snapshot.widgets)) {
+        if (preserveLiveStateSeed && String(name) === "seed") continue;
         changed += setQueuedInput(promptPayload, node, String(name), value, { addIfMissing: false, syncWidget: true });
       }
     }
-    if (isSeedNode(node)) {
+    if (isSeedNode(node) && !preserveLiveStateSeed) {
       const seed = extractSeedFromSettings(settings);
       if (seed != null) {
         for (const name of ["seed", "noise_seed", "value"]) {
@@ -3601,7 +3628,10 @@ function mutatePromptForStateManagers(promptPayload, queueIndex, total) {
     const { character, prompt } = selectQueuedCharacterAndPrompt(node, state, uiState, currentCharacterId, currentPromptId, queueIndex, total);
     if (!character || !prompt) continue;
     let payload = buildQueuedDoraStatePayload(character, prompt);
-    if (uiState.queue_randomize_saved_seed) {
+    const liveStateSeed = firstControlledStateSeed(node, promptPayload);
+    if (liveStateSeed) {
+      payload = withRuntimeSeed(payload, liveStateSeed.seed);
+    } else if (uiState.queue_randomize_saved_seed) {
       payload = withRuntimeSeed(payload, generateStateManagerRuntimeSeed());
     }
     changed += setQueuedStateManagerSelection(promptPayload, node, character.id, prompt.id);


### PR DESCRIPTION
## Summary
- make connected queued State Seed values authoritative over State Manager saved prompt seed randomization
- preserve resolved live State Seed inputs during queued settings mutation
- prefer non-special local StateManagerSeed values over state_control on the backend

## Validation
- python3 -m py_compile nodes.py
- node --check web/dora_state_manager.js
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved seed value handling so user-provided integer seeds are no longer overridden by state control settings
  * Enhanced saved prompt seed randomization behavior with clearer distinction between always-randomizing and conditional randomization modes

* **UI Updates**
  * Updated queued-generation interface text to better communicate saved prompt seed wildcarding behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->