### PR TITLE
Avoid lazy module lookups in DoRA patch scan

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -325,8 +325,11 @@ def _patch_comfy_weight_decompose() -> None:
         if m is None:
             continue
         try:
-            if getattr(m, "weight_decompose", None) is orig:
-                setattr(m, "weight_decompose", weight_decompose_fixed)
+            # Avoid getattr(): module-level __getattr__ may resolve deprecated or
+            # lazy aliases and emit warnings merely because this scan probes them.
+            module_dict = vars(m)
+            if module_dict.get("weight_decompose") is orig:
+                module_dict["weight_decompose"] = weight_decompose_fixed
                 patched_refs += 1
         except Exception:
             pass


### PR DESCRIPTION
## Summary
- inspect cached `weight_decompose` references through module dictionaries
- avoid triggering module-level `__getattr__` and deprecated alias warnings during import
- preserve identity-based replacement of already-materialized cached imports

## Validation
- `git diff --check`
- Ouroboros QA: 0.95/1.00 PASS
- Repository tests not run per repository instructions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved module initialization scanning to eliminate spurious warnings during system startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->