### PR TITLE
Fix auto-strength reports inside subgraphs

### DIFF
--- a/web/dora_power_lora_loader.js
+++ b/web/dora_power_lora_loader.js
@@ -367,6 +367,58 @@ function isTargetNodeInstance(node) {
   return !!node && (node.type === NODE_CLASS || node.comfyClass === NODE_CLASS || node.title === NODE_CLASS);
 }
 
+function getGraphNodeById(graph, rawId) {
+  if (!graph || typeof graph.getNodeById !== "function" || rawId == null) {
+    return null;
+  }
+
+  const direct = graph.getNodeById(rawId);
+  if (direct) return direct;
+
+  const numericId = Number(rawId);
+  return Number.isFinite(numericId) ? graph.getNodeById(numericId) : null;
+}
+
+function resolveExecutionNode(rootGraph, executionId) {
+  const parts = String(executionId ?? "")
+    .split(":")
+    .filter(Boolean);
+
+  if (!parts.length) return null;
+
+  let graph = rootGraph;
+  for (let index = 0; index < parts.length - 1; index += 1) {
+    const containerNode = getGraphNodeById(graph, parts[index]);
+    const subgraph = containerNode?.subgraph;
+    if (!subgraph || typeof subgraph.getNodeById !== "function") {
+      return null;
+    }
+    graph = subgraph;
+  }
+
+  return getGraphNodeById(graph, parts[parts.length - 1]);
+}
+
+function resolveReportTargetNode(rootGraph, detail) {
+  // The node field identifies the actual executing node. The display_node field
+  // may identify an enclosing subgraph or group, so use it only as a fallback.
+  const candidates = [detail?.node, detail?.display_node];
+  const seen = new Set();
+
+  for (const candidate of candidates) {
+    if (candidate == null) continue;
+
+    const executionId = String(candidate);
+    if (seen.has(executionId)) continue;
+    seen.add(executionId);
+
+    const node = resolveExecutionNode(rootGraph, executionId);
+    if (isTargetNodeInstance(node)) return node;
+  }
+
+  return null;
+}
+
 function applyExecutionReportToNode(node, reportJson, reportText) {
   if (!node) return;
   let parsed = null;
@@ -398,11 +450,8 @@ function installExecutionListener() {
     const reportText = parseExecutionOutputValue(output, "analysis_report");
     if (typeof reportJson !== "string" && typeof reportText !== "string") return;
 
-    const rawNodeId = detail?.display_node ?? detail?.node;
-    const nodeId = Number(rawNodeId);
-    const graph = app.graph;
-    const node = Number.isFinite(nodeId) && graph?.getNodeById ? graph.getNodeById(nodeId) : null;
-    if (!isTargetNodeInstance(node)) return;
+    const node = resolveReportTargetNode(app.graph, detail);
+    if (!node) return;
 
     applyExecutionReportToNode(node, reportJson, reportText);
   });


### PR DESCRIPTION
## Summary

- resolve colon-separated ComfyUI execution IDs through nested subgraphs
- prefer the actual executing `node` when attaching auto-strength reports
- fall back to `display_node` only when it resolves to the DoRA loader
- keep invalid or stale paths mutation-free

## Root cause

The execution listener converted `display_node ?? node` with `Number(...)` and queried only the root graph. A nested execution ID such as `105:149` therefore became `NaN`, so the completed backend report was discarded before it reached the loader UI. In addition, `display_node` can refer to an enclosing subgraph rather than the loader that produced the report.

## Scope and impact

This changes only frontend report routing in `web/dora_power_lora_loader.js`. LoRA key mapping, auto-strength calculations, tensor scaling, patch ordering, caching, and backend report generation are unchanged.

Root-level numeric and string IDs remain supported. Nested paths are traversed one graph at a time, so identical local node IDs in separate subgraphs do not collide.

## Validation

A targeted JavaScript resolver harness passed 8 cases:

- root numeric ID
- root string ID
- one-level nested ID
- multi-level nested ID
- actual `node` preferred over enclosing `display_node`
- `display_node` fallback
- invalid/stale path
- empty path

The branch is one commit ahead of `main`, with one modified file.

## Manual verification

1. Restart ComfyUI and hard-refresh the browser.
2. Change a loader value to avoid a cached execution.
3. Run the workflow with the loader inside the same subgraph.
4. Confirm the auto-strength card is populated.
5. Repeat with a root-level loader to confirm existing behavior.
