### PR TITLE
Fix State Manager character naming and preserve library scroll

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -1111,7 +1111,9 @@ def _resolve_dora_state_payload(
         "kind": _DORA_STATE_KIND,
         "character": {
             "id": character.get("id", ""),
-            "name": character.get("name", ""),
+            # The UI's per-state character name is stored in the legacy prompt-name
+            # slot so sibling states remain independently renameable.
+            "name": prompt.get("name", character.get("name", "")),
             "thumbnail": character.get("thumbnail", {}),
         },
         "prompt": {

--- a/web/dora_state_manager.js
+++ b/web/dora_state_manager.js
@@ -2416,6 +2416,7 @@ function rememberLibraryScroll(node, element, key) {
   if (!ctx || !element) return;
   ctx.scrollPositions = ctx.scrollPositions || {};
   element.addEventListener("scroll", () => {
+    if (!element.isConnected) return;
     ctx.scrollPositions[key] = element.scrollTop;
   }, { passive: true });
   requestAnimationFrame(() => {
@@ -3396,11 +3397,17 @@ function renderNode(node) {
   const mode = ctx.libraryMode === "characters" ? "characters" : "presets";
   const key = libraryRenderKey(node, state, uiState, mode);
   let library = ctx.libraryElement;
+  let preservedScroll = null;
   if (!library || ctx.libraryKey !== key) {
     library = renderLibrary(node, state, uiState, character, prompt);
     ctx.libraryElement = library;
     ctx.libraryKey = key;
   } else {
+    const grid = library.querySelector(`[data-scroll-key="${mode}"]`);
+    if (grid) {
+      preservedScroll = { element: grid, top: grid.scrollTop };
+      ctx.scrollPositions[mode] = preservedScroll.top;
+    }
     library.remove();
     updateLibrarySelection(library, character.id, prompt.id);
   }
@@ -3411,6 +3418,15 @@ function renderNode(node) {
   main.className = "dsm-main";
   main.append(library, renderPromptPanel(node, state, uiState, character, prompt));
   ctx.root.appendChild(main);
+  if (preservedScroll) {
+    const restoreScroll = () => {
+      if (!preservedScroll.element.isConnected) return;
+      preservedScroll.element.scrollTop = preservedScroll.top;
+      ctx.scrollPositions[mode] = preservedScroll.element.scrollTop;
+    };
+    restoreScroll();
+    requestAnimationFrame(restoreScroll);
+  }
 }
 
 function ensureStyles() {

--- a/web/dora_state_manager.js
+++ b/web/dora_state_manager.js
@@ -578,6 +578,18 @@ function normalizeState(raw) {
   return { version: 2, characters: characters.length ? characters : [defaultCharacter()] };
 }
 
+function updatePromptName(state, characterId, promptId, value) {
+  const nextState = normalizeState(state);
+  const character = nextState.characters.find((item) => item.id === characterId);
+  const promptIndex = character?.prompts.findIndex((item) => item.id === promptId) ?? -1;
+  if (!character || promptIndex < 0) return nextState;
+
+  const prompt = { ...character.prompts[promptIndex] };
+  prompt.name = String(value ?? "").trim() || prompt.name;
+  character.prompts[promptIndex] = prompt;
+  return nextState;
+}
+
 function normalizeIdList(value) {
   if (Array.isArray(value)) return value.map((item) => cleanId(item, "")).filter(Boolean);
   if (typeof value === "string") {
@@ -2332,7 +2344,7 @@ function renderPresetTile(node, character, prompt, selectedCharacterId, selected
   tile.dataset.promptId = prompt.id;
   tile.dataset.search = searchText || librarySearchText(character, prompt);
   tile.className = `dsm-preset-tile${isSelected ? " selected" : ""}`;
-  tile.setAttribute("aria-label", `${character.name} — ${prompt.name}`);
+  tile.setAttribute("aria-label", prompt.name);
   if (isSelected) tile.setAttribute("aria-current", "true");
 
   const thumb = document.createElement("div");
@@ -2341,12 +2353,12 @@ function renderPresetTile(node, character, prompt, selectedCharacterId, selected
   if (url) {
     const img = document.createElement("img");
     img.src = url;
-    img.alt = `${character.name} — ${prompt.name}`;
+    img.alt = prompt.name;
     img.loading = "lazy";
     img.decoding = "async";
     thumb.appendChild(img);
   } else {
-    thumb.textContent = character.name.trim().slice(0, 2).toUpperCase() || "?";
+    thumb.textContent = prompt.name.trim().slice(0, 2).toUpperCase() || "?";
   }
 
   const body = document.createElement("div");
@@ -2355,16 +2367,12 @@ function renderPresetTile(node, character, prompt, selectedCharacterId, selected
   name.className = "dsm-preset-name";
   name.textContent = prompt.name;
   name.title = prompt.name;
-  const owner = document.createElement("div");
-  owner.className = "dsm-preset-character";
-  owner.textContent = character.name;
-  owner.title = character.name;
   const meta = document.createElement("div");
   meta.className = "dsm-muted dsm-preset-meta";
   const seed = extractSeedFromSettings(prompt.settings);
   const textBoxCount = normalizePromptTextBoxes(prompt).length;
   meta.textContent = `${textBoxCount} text box${textBoxCount === 1 ? "" : "es"}${seed == null ? "" : ` · seed ${seed}`}`;
-  body.append(owner, name, meta);
+  body.append(name, meta);
   tile.append(thumb, body);
 
   const selectPreset = () => {
@@ -2375,7 +2383,7 @@ function renderPresetTile(node, character, prompt, selectedCharacterId, selected
     updateState(node, current.state, current.uiState, {
       characterId: character.id,
       promptId: prompt.id,
-      status: `Selected ${nextCharacter.name} / ${nextPrompt.name}. Use Load/Apply to push it into graph nodes.`,
+      status: `Selected ${nextPrompt.name}. Use Load/Apply to push it into graph nodes.`,
     });
   };
   tile.addEventListener("click", selectPreset);
@@ -2442,7 +2450,7 @@ function renderHeader(node, state, uiState, character, prompt) {
   title.textContent = "State Manager";
   const selection = document.createElement("div");
   selection.className = "dsm-selection-path";
-  selection.textContent = `${character.name} / ${prompt.name}`;
+  selection.textContent = prompt.name;
   selection.title = selection.textContent;
   heading.append(title, selection);
 
@@ -2855,7 +2863,7 @@ function renderCharacterPanel(node, state, uiState, character) {
   imageNote.className = "dsm-muted";
   imageNote.textContent = "The State Manager image output loads the original uploaded file, not the CSS-scaled preview.";
 
-  section.append(title, labelledControl("Name", nameInput), preview, fileInput, thumbnailButtons, imageNote, labelledControl("Saved LoRA stacks", loraSummary));
+  section.append(title, labelledControl("Shared group name (all states)", nameInput), preview, fileInput, thumbnailButtons, imageNote, labelledControl("Saved LoRA stacks", loraSummary));
   return section;
 }
 
@@ -2935,8 +2943,9 @@ function renderPromptPanelContent(section, node, state, uiState, character, prom
   );
 
   const name = makeInput(prompt.name, (value) => {
-    prompt.name = value.trim() || prompt.name;
-    updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id });
+    const current = getRenderableState(node);
+    const nextState = updatePromptName(current.state, character.id, prompt.id, value);
+    updateState(node, nextState, current.uiState, { characterId: character.id, promptId: prompt.id });
   });
 
   const positive = makeTextarea(getPromptText(prompt, "positive", "default"), (value) => {
@@ -3097,7 +3106,7 @@ function renderPromptPanelContent(section, node, state, uiState, character, prom
 
   section.append(
     header,
-    labelledControl("Preset name", name),
+    labelledControl("Character name", name),
     labelledControl("fileimage_prefix", fileimagePrefix),
     referencePreview,
     referenceInput,
@@ -3519,19 +3528,13 @@ function ensureStyles() {
       align-items: stretch;
     }
     .dsm-preset-body { min-width: 0; display: flex; flex-direction: column; justify-content: center; gap: 2px; }
-    .dsm-preset-character, .dsm-character-name {
+    .dsm-preset-name, .dsm-character-name {
       font-size: 13px;
       font-weight: 700;
       line-height: 1.25;
       overflow-wrap: anywhere;
       word-break: break-word;
       white-space: normal;
-    }
-    .dsm-preset-name {
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-      opacity: .72;
     }
     .dsm-preset-meta { font-size: 11px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
     .dsm-preset-thumb, .dsm-thumb, .dsm-large-thumb {

--- a/web/dora_state_manager.js
+++ b/web/dora_state_manager.js
@@ -7,6 +7,7 @@ const NODE_CLASS = "State Manager";
 const LEGACY_NODE_CLASS = "DoRA State Manager";
 const DORA_LOADER_CLASS = "DoRA Power LoRA Loader";
 const DORA_STATE_KIND = "dora_state_manager_state";
+const STATE_SCHEMA_VERSION = 3;
 const STATE_MANAGER_CONTROL_KIND = "state_manager_control";
 const STATE_TEXT_CLASS = "State Manager Text Box";
 const STATE_TEXT_DISPLAY_CLASS = "State Text Box";
@@ -99,10 +100,10 @@ function cleanId(value, fallback) {
   return text || fallback;
 }
 
-function defaultPrompt() {
+function defaultPrompt(name = "Default Character") {
   return {
     id: "default_prompt",
-    name: "Default Prompt",
+    name: String(name || "Default Character"),
     positive: "",
     negative: "",
     text_boxes: [
@@ -279,12 +280,12 @@ function defaultCharacter() {
     // Legacy/default stack mirror. Kept for old workflows and old consumers.
     loras: stack.loras,
     loader_globals: stack.loader_globals,
-    prompts: [defaultPrompt()],
+    prompts: [defaultPrompt("Default Character")],
   };
 }
 
 function defaultState() {
-  return { version: 2, characters: [defaultCharacter()] };
+  return { version: STATE_SCHEMA_VERSION, characters: [defaultCharacter()] };
 }
 
 function defaultUiState() {
@@ -543,11 +544,12 @@ function normalizeLoraRow(row) {
   };
 }
 
-function normalizePrompt(prompt, index) {
+function normalizePrompt(prompt, index, nameOverride = "") {
   const p = prompt && typeof prompt === "object" ? prompt : {};
+  const fallbackName = `Character ${index + 1}`;
   return syncPromptTextMirror({
     id: cleanId(p.id, `prompt_${index + 1}`),
-    name: String(p.name ?? `Prompt ${index + 1}`).trim() || `Prompt ${index + 1}`,
+    name: String(nameOverride || p.name || fallbackName).trim() || fallbackName,
     positive: String(p.positive ?? p.positive_prompt ?? ""),
     negative: String(p.negative ?? p.negative_prompt ?? ""),
     text_boxes: normalizePromptTextBoxes(p),
@@ -557,15 +559,18 @@ function normalizePrompt(prompt, index) {
   });
 }
 
-function normalizeCharacter(character, index) {
+function normalizeCharacter(character, index, { migrateLegacyPresetNames = false } = {}) {
   const c = character && typeof character === "object" ? character : {};
-  const prompts = Array.isArray(c.prompts) ? c.prompts.map(normalizePrompt).filter(Boolean) : [];
+  const name = String(c.name ?? `Character ${index + 1}`).trim() || `Character ${index + 1}`;
+  const prompts = Array.isArray(c.prompts)
+    ? c.prompts.map((prompt, promptIndex) => normalizePrompt(prompt, promptIndex, migrateLegacyPresetNames ? name : "")).filter(Boolean)
+    : [];
   const normalized = {
     id: cleanId(c.id, `character_${index + 1}`),
-    name: String(c.name ?? `Character ${index + 1}`).trim() || `Character ${index + 1}`,
+    name,
     thumbnail: normalizeThumbnail(c.thumbnail),
     loader_stacks: normalizeLoaderStacks(c),
-    prompts: prompts.length ? prompts : [defaultPrompt()],
+    prompts: prompts.length ? prompts : [defaultPrompt(name)],
   };
   return syncLegacyLoaderMirror(normalized);
 }
@@ -574,8 +579,11 @@ function normalizeCharacter(character, index) {
 function normalizeState(raw) {
   const parsed = safeJsonParse(raw, defaultState());
   const charsIn = Array.isArray(parsed.characters) ? parsed.characters : [];
-  const characters = charsIn.map(normalizeCharacter).filter(Boolean);
-  return { version: 2, characters: characters.length ? characters : [defaultCharacter()] };
+  const migrateLegacyPresetNames = Number(parsed.version ?? 0) < STATE_SCHEMA_VERSION;
+  const characters = charsIn
+    .map((character, index) => normalizeCharacter(character, index, { migrateLegacyPresetNames }))
+    .filter(Boolean);
+  return { version: STATE_SCHEMA_VERSION, characters: characters.length ? characters : [defaultCharacter()] };
 }
 
 function updatePromptName(state, characterId, promptId, value) {
@@ -2616,9 +2624,8 @@ function renderLibrary(node, state, uiState, character, prompt) {
     controls.append(
       makeButton("New preset", () => {
         const current = currentLibrarySelection();
-        const next = defaultPrompt();
+        const next = defaultPrompt(current.prompt.name);
         next.id = makeId("prompt");
-        next.name = `Prompt ${current.character.prompts.length + 1}`;
         current.character.prompts.push(next);
         ctx.focusLibrarySelection = true;
         updateState(node, current.state, current.uiState, { characterId: current.character.id, promptId: next.id, status: `Created preset for ${current.character.name}.` });
@@ -2650,6 +2657,7 @@ function renderLibrary(node, state, uiState, character, prompt) {
         next.id = makeId("character");
         next.name = `Character ${current.state.characters.length + 1}`;
         next.prompts[0].id = makeId("prompt");
+        next.prompts[0].name = next.name;
         current.state.characters.push(next);
         ctx.focusLibrarySelection = true;
         updateState(node, current.state, current.uiState, { characterId: next.id, promptId: next.prompts[0].id, status: "Created character." });
@@ -2659,7 +2667,7 @@ function renderLibrary(node, state, uiState, character, prompt) {
         const copy = structuredCloneCompat(current.character);
         copy.id = makeId("character");
         copy.name = `${copy.name} Copy`;
-        copy.prompts = copy.prompts.map((item) => ({ ...item, id: makeId("prompt") }));
+        copy.prompts = copy.prompts.map((item) => ({ ...item, id: makeId("prompt"), name: `${item.name} Copy` }));
         current.state.characters.push(copy);
         ctx.focusLibrarySelection = true;
         updateState(node, current.state, current.uiState, { characterId: copy.id, promptId: copy.prompts[0]?.id || "", status: "Duplicated character." });
@@ -2919,9 +2927,8 @@ function renderPromptPanelContent(section, node, state, uiState, character, prom
   header.append(
     select,
     makeButton("New", () => {
-      const p = defaultPrompt();
+      const p = defaultPrompt(prompt.name);
       p.id = makeId("prompt");
-      p.name = `Prompt ${character.prompts.length + 1}`;
       character.prompts.push(p);
       updateState(node, state, uiState, { characterId: character.id, promptId: p.id, status: "Created prompt preset." });
     }),
@@ -3882,7 +3889,7 @@ function buildQueuedDoraStatePayload(character, prompt) {
     kind: "dora_state_manager_state",
     character: {
       id: String(character?.id ?? ""),
-      name: String(character?.name ?? ""),
+      name: String(prompt?.name ?? character?.name ?? ""),
       thumbnail: normalizeThumbnail(character?.thumbnail),
     },
     prompt: {

--- a/web/dora_state_manager.js
+++ b/web/dora_state_manager.js
@@ -2226,6 +2226,7 @@ function renderCharacterTile(node, state, uiState, character, selectedId, select
   tile.dataset.libraryItem = "character";
   tile.dataset.characterId = character.id;
   tile.dataset.search = librarySearchText(character);
+  tile.setAttribute("aria-label", character.name);
   if (isSelected) tile.setAttribute("aria-current", "true");
   tile.className = `dsm-character-tile${isSelected ? " selected" : ""}${isActiveQueueChunk ? " queued" : ""}${isQueued && !isActiveQueueChunk ? " prepared" : ""}`;
 
@@ -2246,6 +2247,7 @@ function renderCharacterTile(node, state, uiState, character, selectedId, select
   const name = document.createElement("div");
   name.className = "dsm-character-name";
   name.textContent = character.name;
+  name.title = character.name;
 
   const meta = document.createElement("div");
   meta.className = "dsm-muted";
@@ -2330,6 +2332,7 @@ function renderPresetTile(node, character, prompt, selectedCharacterId, selected
   tile.dataset.promptId = prompt.id;
   tile.dataset.search = searchText || librarySearchText(character, prompt);
   tile.className = `dsm-preset-tile${isSelected ? " selected" : ""}`;
+  tile.setAttribute("aria-label", `${character.name} — ${prompt.name}`);
   if (isSelected) tile.setAttribute("aria-current", "true");
 
   const thumb = document.createElement("div");
@@ -2338,12 +2341,12 @@ function renderPresetTile(node, character, prompt, selectedCharacterId, selected
   if (url) {
     const img = document.createElement("img");
     img.src = url;
-    img.alt = `${prompt.name} — ${character.name}`;
+    img.alt = `${character.name} — ${prompt.name}`;
     img.loading = "lazy";
     img.decoding = "async";
     thumb.appendChild(img);
   } else {
-    thumb.textContent = prompt.name.trim().slice(0, 2).toUpperCase() || "?";
+    thumb.textContent = character.name.trim().slice(0, 2).toUpperCase() || "?";
   }
 
   const body = document.createElement("div");
@@ -2361,7 +2364,7 @@ function renderPresetTile(node, character, prompt, selectedCharacterId, selected
   const seed = extractSeedFromSettings(prompt.settings);
   const textBoxCount = normalizePromptTextBoxes(prompt).length;
   meta.textContent = `${textBoxCount} text box${textBoxCount === 1 ? "" : "es"}${seed == null ? "" : ` · seed ${seed}`}`;
-  body.append(name, owner, meta);
+  body.append(owner, name, meta);
   tile.append(thumb, body);
 
   const selectPreset = () => {
@@ -3500,9 +3503,20 @@ function ensureStyles() {
       align-items: stretch;
     }
     .dsm-preset-body { min-width: 0; display: flex; flex-direction: column; justify-content: center; gap: 2px; }
-    .dsm-preset-name, .dsm-preset-character, .dsm-character-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-    .dsm-preset-name, .dsm-character-name { font-weight: 650; }
-    .dsm-preset-character { opacity: .74; }
+    .dsm-preset-character, .dsm-character-name {
+      font-size: 13px;
+      font-weight: 700;
+      line-height: 1.25;
+      overflow-wrap: anywhere;
+      word-break: break-word;
+      white-space: normal;
+    }
+    .dsm-preset-name {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      opacity: .72;
+    }
     .dsm-preset-meta { font-size: 11px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
     .dsm-preset-thumb, .dsm-thumb, .dsm-large-thumb {
       display: flex;


### PR DESCRIPTION
## What changed

- makes the actual saved character name the one and only prominent preset-card name
- discards legacy prompt/preset labels during the v2 -> v3 frontend migration
- stores the migrated character name independently on each state, so renaming one state cannot rename siblings
- removes the secondary preset-name line
- labels the independent editor field **Character name**
- keeps the parent field explicitly labeled **Shared group name (all states)** because it still owns shared LoRA stacks and the fallback thumbnail
- makes new states inherit the current character name; duplicates receive a `Copy` suffix
- wraps long names fully, including long unbroken names
- sends the same per-state character name through direct backend resolution and queued runtime payloads
- preserves the State library's exact scroll position during selection changes

## Root cause

The data model has a shared parent `character.name` and a per-state legacy `prompt.name`. Binding cards directly to the parent made sibling cards rename together. Binding cards directly to the old prompt field exposed values such as `Default Prompt`, which is the backwards direction shown in the reported screenshot.

The corrected migration copies each v2 parent character name into every child state's independent name slot once, marks the serialized state as v3, and preserves those independent names on subsequent normalization. The old prompt labels are intentionally discarded. The rename handler resolves the current character ID and state ID, clones normalized state, and replaces only that exact state's name.

## Compatibility

Existing v2 workflows and JSON exports migrate automatically in the frontend. IDs, widget names/order, node classes, loader stacks, prompt text, settings, seeds, images, queue behavior, and output shapes remain unchanged. The Python normalizer accepts the v3 state and continues emitting the existing runtime schema version. Both `character.name` and legacy `prompt.name` in resolved payloads carry the selected state's character name for downstream compatibility.

## Validation

- ECMAScript module syntax check
- Python bytecode compilation
- v2 migration test with three differently named legacy prompts, proving all three acquire the actual parent character name
- three-sibling isolation test proving one rename leaves siblings and the input state unchanged
- repeat-normalization test proving v3 names remain stable
- DOM test proving the card has one visible long character name and no discarded secondary name
- backend resolution test proving `character.name` and `prompt.name` match the selected state's name
- detached-library scroll reset/restoration regression test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Character and preset names are now generated more consistently based on their source context.
  * Selected prompt names are used in runtime and resolved character details when available.
  * Existing saved data is updated to the latest naming format automatically.

* **Bug Fixes**
  * Presets now correctly inherit character names where appropriate.
  * Library scroll position is preserved when the interface refreshes.

* **UI Improvements**
  * Names wrap instead of being truncated.
  * Editor labels and library metadata are clearer and more concise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->