### PR TITLE
Add opt-in runtime bypass LoRA mode

### DIFF
--- a/.comfyignore
+++ b/.comfyignore
@@ -1,0 +1,4 @@
+# Development-only files must not be shipped in Comfy Registry archives.
+
+.github/
+tests/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,5 @@
 name: Publish to Comfy registry
+
 on:
   workflow_dispatch:
   push:
@@ -18,10 +19,11 @@ jobs:
     if: ${{ github.repository_owner == 'xmarre' }}
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
+          persist-credentials: false
           submodules: true
       - name: Publish Custom Node
-        uses: Comfy-Org/publish-node-action@v1
+        uses: Comfy-Org/publish-node-action@0eb6cd742945443bee7f79eeddd4f732780029a1 # v1
         with:
           personal_access_token: ${{ secrets.REGISTRY_ACCESS_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,82 @@
+name: release
+
+on:
+  workflow_run:
+    workflows: [tests]
+    types: [completed]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out tested commit
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Read package version
+        id: version
+        shell: bash
+        run: |
+          version="$(python -c 'import pathlib, tomllib; print(tomllib.loads(pathlib.Path("pyproject.toml").read_text())["project"]["version"])')"
+          if [[ ! "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid project version: ${version}" >&2
+            exit 1
+          fi
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+          echo "tag=v${version}" >> "${GITHUB_OUTPUT}"
+
+      - name: Build release archive
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        shell: bash
+        run: |
+          mkdir -p dist
+          archive="ComfyUI-DoRA-Dynamic-LoRA-Loader-v${VERSION}.zip"
+          git archive \
+            --format=zip \
+            --prefix="ComfyUI-DoRA-Dynamic-LoRA-Loader-v${VERSION}/" \
+            --output="dist/${archive}" \
+            HEAD
+          (cd dist && sha256sum "${archive}" > SHA256SUMS)
+
+      - name: Verify release inputs
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        shell: bash
+        run: |
+          test -s "dist/ComfyUI-DoRA-Dynamic-LoRA-Loader-v${VERSION}.zip"
+          test -s dist/SHA256SUMS
+          test -s RELEASE_NOTES.md
+          grep -F "ComfyUI-DoRA-Dynamic-LoRA-Loader-v${VERSION}.zip" dist/SHA256SUMS
+
+      - name: Publish GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_SHA: ${{ github.event.workflow_run.head_sha }}
+          TAG: ${{ steps.version.outputs.tag }}
+          VERSION: ${{ steps.version.outputs.version }}
+        shell: bash
+        run: |
+          if gh release view "${TAG}" >/dev/null 2>&1; then
+            echo "Release ${TAG} already exists; leaving it unchanged."
+            exit 0
+          fi
+          gh release create "${TAG}" \
+            "dist/ComfyUI-DoRA-Dynamic-LoRA-Loader-v${VERSION}.zip" \
+            dist/SHA256SUMS \
+            --target "${RELEASE_SHA}" \
+            --title "DoRA Dynamic LoRA Loader ${TAG}" \
+            --notes-file RELEASE_NOTES.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,9 +70,13 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
         shell: bash
         run: |
-          if gh release view "${TAG}" >/dev/null 2>&1; then
-            echo "Release ${TAG} already exists; leaving it unchanged."
-            exit 0
+          if existing_target="$(gh release view "${TAG}" --json targetCommitish --jq .targetCommitish 2>/dev/null)"; then
+            if [[ "${existing_target}" == "${RELEASE_SHA}" ]]; then
+              echo "Release ${TAG} already exists for this tested commit; leaving it unchanged."
+              exit 0
+            fi
+            echo "Release ${TAG} already targets ${existing_target}, not tested commit ${RELEASE_SHA}." >&2
+            exit 1
           fi
           gh release create "${TAG}" \
             "dist/ComfyUI-DoRA-Dynamic-LoRA-Loader-v${VERSION}.zip" \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,4 +91,4 @@ jobs:
         env:
           COMFYUI_PATH: ${{ github.workspace }}/ComfyUI
           PYTHONPATH: ${{ github.workspace }}/ComfyUI
-        run: python -m pytest -q
+        run: python -m pytest -q tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,13 +53,26 @@ jobs:
           echo "Built ${wheels[0]}"
 
   compatibility-and-runtime-bypass:
+    name: ComfyUI ${{ matrix.comfy_version }} compatibility/runtime tests
     strategy:
       fail-fast: false
       matrix:
-        comfy_ref:
-          - 322122449c9d2ba8b8df1bb517364527dd0615f1 # v0.29.2
-          - dec5d9450a5290bcf63430409ea41018e67f41c3 # v0.30.2
-          - fe4195f7f4275f2626cbafc703acc3ddde1e5490 # v0.31.1
+        include:
+          - comfy_version: v0.29.2
+            comfy_ref: 322122449c9d2ba8b8df1bb517364527dd0615f1
+            torch_version: "2.7.1"
+            torchvision_version: "0.22.1"
+            torchaudio_version: "2.7.1"
+          - comfy_version: v0.30.2
+            comfy_ref: dec5d9450a5290bcf63430409ea41018e67f41c3
+            torch_version: "2.8.0"
+            torchvision_version: "0.23.0"
+            torchaudio_version: "2.8.0"
+          - comfy_version: v0.31.1
+            comfy_ref: fe4195f7f4275f2626cbafc703acc3ddde1e5490
+            torch_version: "2.10.0"
+            torchvision_version: "0.25.0"
+            torchaudio_version: "2.10.0"
     runs-on: ubuntu-latest
     steps:
       - name: Check out custom node
@@ -84,14 +97,26 @@ jobs:
       - name: Install pinned ComfyUI runtime and test dependencies
         run: |
           python -m pip install --upgrade pip
-          # Install the CPU builds first so the hosted runner never pulls CUDA
-          # PyTorch packages just to exercise pure loader/adapter behavior.
-          python -m pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
-          # Each matrix entry owns its runtime dependency set. Installing the
-          # checked-out requirements keeps this compatibility test faithful to
-          # that exact ComfyUI release instead of maintaining a partial duplicate.
+          # Pin a known CPU-only PyTorch family for every reviewed ComfyUI
+          # revision. This keeps the compatibility matrix reproducible instead
+          # of silently changing when PyTorch publishes a new stable wheel.
+          python -m pip install \
+            "torch==${{ matrix.torch_version }}" \
+            "torchvision==${{ matrix.torchvision_version }}" \
+            "torchaudio==${{ matrix.torchaudio_version }}" \
+            --index-url https://download.pytorch.org/whl/cpu
+          # Each matrix entry still owns the rest of its runtime dependency set.
           python -m pip install -r ComfyUI/requirements.txt
           python -m pip install pytest
+
+      - name: Report pinned runtime versions
+        shell: bash
+        run: |
+          python - <<'PY'
+          import importlib.metadata as metadata
+          for package in ("torch", "torchvision", "torchaudio"):
+              print(f"{package}={metadata.version(package)}")
+          PY
 
       - name: Stage compatibility tests outside package tree
         shell: bash

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,70 @@
+name: tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  compatibility-and-runtime-bypass:
+    strategy:
+      fail-fast: false
+      matrix:
+        comfy_ref:
+          - 322122449c9d2ba8b8df1bb517364527dd0615f1 # v0.29.2
+          - dec5d9450a5290bcf63430409ea41018e67f41c3 # v0.30.2
+          - fe4195f7f4275f2626cbafc703acc3ddde1e5490 # v0.31.1
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out custom node
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+
+      - name: Check out reviewed ComfyUI source
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+          repository: Comfy-Org/ComfyUI
+          ref: ${{ matrix.comfy_ref }}
+          path: ComfyUI
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Set up Node.js
+        uses: actions/setup-node@1e60f620b9541d85473a9c9a8ec0bbfdc60bff7c # v4
+        with:
+          node-version: "22"
+
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install torch --index-url https://download.pytorch.org/whl/cpu
+          python -m pip install pytest numpy psutil safetensors einops tqdm pyyaml pillow packaging aiohttp comfy-kitchen==0.2.26 comfy-aimdo==0.4.13
+
+      - name: Compile Python sources
+        run: python -m py_compile __init__.py nodes.py runtime_bypass.py
+
+      - name: Check frontend JavaScript syntax
+        shell: bash
+        run: |
+          while IFS= read -r -d '' file; do
+            echo "Checking ${file}"
+            node --check "${file}"
+          done < <(find web -type f -name '*.js' -print0)
+
+      - name: Build package wheel
+        run: python -m pip wheel --no-deps --wheel-dir /tmp/dora-loader-wheel .
+
+      - name: Run compatibility and runtime-bypass tests
+        env:
+          COMFYUI_PATH: ${{ github.workspace }}/ComfyUI
+          PYTHONPATH: ${{ github.workspace }}/ComfyUI
+        run: python -m pytest -q

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
           cache: pip
 
       - name: Set up Node.js
-        uses: actions/setup-node@1e60f620b9541d85473a9c9a8ec0bbfdc60bff7c # v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "22"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -87,9 +87,16 @@ jobs:
           python -m pip install torch --index-url https://download.pytorch.org/whl/cpu
           python -m pip install pytest numpy psutil safetensors einops tqdm pyyaml pillow packaging aiohttp comfy-kitchen==0.2.26 comfy-aimdo==0.4.13
 
+      - name: Stage compatibility tests outside package tree
+        shell: bash
+        run: |
+          rm -rf /tmp/dora-loader-tests
+          cp -R tests /tmp/dora-loader-tests
+
       - name: Run compatibility and runtime-bypass tests
-        working-directory: tests
+        working-directory: /tmp/dora-loader-tests
         env:
+          DORA_REPO_ROOT: ${{ github.workspace }}
           COMFYUI_PATH: ${{ github.workspace }}/ComfyUI
           PYTHONPATH: ${{ github.workspace }}/ComfyUI
         run: python -m pytest -q --import-mode=importlib .

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,49 @@ permissions:
   contents: read
 
 jobs:
+  package-and-frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out custom node
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "22"
+
+      - name: Compile Python sources
+        run: python -m py_compile __init__.py nodes.py runtime_bypass.py
+
+      - name: Check frontend JavaScript syntax
+        shell: bash
+        run: |
+          while IFS= read -r -d '' file; do
+            echo "Checking ${file}"
+            node --check "${file}"
+          done < <(find web -type f -name '*.js' -print0)
+
+      - name: Build package wheel
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip wheel --no-deps --wheel-dir /tmp/dora-loader-wheel .
+
+      - name: Verify wheel was produced
+        shell: bash
+        run: |
+          shopt -s nullglob
+          wheels=(/tmp/dora-loader-wheel/*.whl)
+          test "${#wheels[@]}" -eq 1
+          echo "Built ${wheels[0]}"
+
   compatibility-and-runtime-bypass:
     strategy:
       fail-fast: false
@@ -38,30 +81,11 @@ jobs:
           python-version: "3.12"
           cache: pip
 
-      - name: Set up Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
-        with:
-          node-version: "22"
-
       - name: Install test dependencies
         run: |
           python -m pip install --upgrade pip
           python -m pip install torch --index-url https://download.pytorch.org/whl/cpu
           python -m pip install pytest numpy psutil safetensors einops tqdm pyyaml pillow packaging aiohttp comfy-kitchen==0.2.26 comfy-aimdo==0.4.13
-
-      - name: Compile Python sources
-        run: python -m py_compile __init__.py nodes.py runtime_bypass.py
-
-      - name: Check frontend JavaScript syntax
-        shell: bash
-        run: |
-          while IFS= read -r -d '' file; do
-            echo "Checking ${file}"
-            node --check "${file}"
-          done < <(find web -type f -name '*.js' -print0)
-
-      - name: Build package wheel
-        run: python -m pip wheel --no-deps --wheel-dir /tmp/dora-loader-wheel .
 
       - name: Run compatibility and runtime-bypass tests
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -81,11 +81,17 @@ jobs:
           python-version: "3.12"
           cache: pip
 
-      - name: Install test dependencies
+      - name: Install pinned ComfyUI runtime and test dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install torch --index-url https://download.pytorch.org/whl/cpu
-          python -m pip install pytest numpy psutil safetensors einops tqdm pyyaml pillow packaging aiohttp comfy-kitchen==0.2.26 comfy-aimdo==0.4.13
+          # Install the CPU builds first so the hosted runner never pulls CUDA
+          # PyTorch packages just to exercise pure loader/adapter behavior.
+          python -m pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
+          # Each matrix entry owns its runtime dependency set. Installing the
+          # checked-out requirements keeps this compatibility test faithful to
+          # that exact ComfyUI release instead of maintaining a partial duplicate.
+          python -m pip install -r ComfyUI/requirements.txt
+          python -m pip install pytest
 
       - name: Stage compatibility tests outside package tree
         shell: bash

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,7 +88,8 @@ jobs:
           python -m pip install pytest numpy psutil safetensors einops tqdm pyyaml pillow packaging aiohttp comfy-kitchen==0.2.26 comfy-aimdo==0.4.13
 
       - name: Run compatibility and runtime-bypass tests
+        working-directory: tests
         env:
           COMFYUI_PATH: ${{ github.workspace }}/ComfyUI
           PYTHONPATH: ${{ github.workspace }}/ComfyUI
-        run: python -m pytest -q --rootdir=tests --import-mode=importlib tests
+        run: python -m pytest -q --import-mode=importlib .

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,4 +91,4 @@ jobs:
         env:
           COMFYUI_PATH: ${{ github.workspace }}/ComfyUI
           PYTHONPATH: ${{ github.workspace }}/ComfyUI
-        run: python -m pytest -q tests
+        run: python -m pytest -q --rootdir=tests --import-mode=importlib tests

--- a/README.md
+++ b/README.md
@@ -19,6 +19,45 @@ This implementation was reworked for the unified DoRA + standard LoRA path in th
 
 ---
 
+## Runtime bypass LoRA (low VRAM)
+
+The loader includes an optional **Runtime bypass LoRA (low VRAM)** mode for supported standard LoRAs.
+
+The word **bypass** refers to bypassing **weight materialization**, not bypassing or weakening the LoRA effect. For a normal additive LoRA, the regular merged path evaluates a layer with `W + ΔW`, while the runtime path keeps `W` untouched and evaluates the equivalent low-rank contribution during the forward pass:
+
+```text
+regular: (W + ΔW)x
+runtime: Wx + ΔWx
+```
+
+For supported standard LoRAs these are mathematically equivalent. Small floating-point differences can still occur because the operations are executed in a different order/dtype path, and runtime bypass adds the low-rank operations on every forward instead of paying the full merge/materialization cost up front.
+
+This follows ComfyUI's own bypass adapter design: ComfyUI describes it as loading LoRA **without modifying base model weights** and injecting the LoRA computation into the forward pass (`base_forward(x) + lora_path(x)`).
+
+### Why it saves so much VRAM
+
+Normal materialized patching may need to retain the original model weights while also holding the fully patched replacement weights. On very large HIGH_VRAM models this can mean tens of GiB of additional live VRAM even when the LoRA file itself is only a few hundred MiB.
+
+Runtime bypass keeps the base model weights unchanged and stores/evaluates the low-rank adapter tensors directly, avoiding that full patched-model copy for supported adapters.
+
+### Important limitation: DoRA is not runtime-bypassed
+
+Current ComfyUI bypass LoRA math implements the additive LoRA path, but not DoRA magnitude normalization/rescaling. Treating a DoRA as ordinary bypass LoRA would therefore change its mathematics.
+
+This loader deliberately **fails closed** when runtime bypass encounters DoRA or another unsupported adapter form. It does not silently approximate it. Disable Runtime bypass LoRA for those files and use the normal materialized path instead.
+
+Runtime bypass currently refuses:
+
+- DoRA / magnitude-vector LoRAs (`dora_scale`, Diffusers/PEFT `lora_magnitude_vector`, `w_norm`, `b_norm`)
+- non-LoRA weight-adapter types
+- LoRA reshape metadata
+- sliced / offset / transformed adapter targets
+- non-default `strength_model` patch semantics
+
+The option is **OFF by default**, so existing workflows retain the previous materialized LoRA/DoRA behavior unless you explicitly enable it.
+
+---
+
 ## Auto-strength
 
 This node includes optional **auto-strength** redistribution for loaded LoRAs / DoRAs.
@@ -343,6 +382,7 @@ Each row has:
 ### Global options
 
 - Stack Enabled
+- Runtime bypass LoRA (low VRAM)
 - Verbose
 - Log Unloaded Keys
 - Auto-strength enabled
@@ -381,8 +421,9 @@ For each enabled row:
 9. if enabled, compute per-base auto-strength redistribution ratios  
    on the selected analysis device and bake only those ratios into the LoRA tensors
 10. call `comfy.lora.load_lora(...)`
-11. apply patches via `model.add_patches(...)` / `clip.add_patches(...)`  
-    using the normal outer Model / CLIP strengths
+11. apply supported standard LoRA adapters either:
+    - through the normal `model.add_patches(...)` / `clip.add_patches(...)` materialized path when Runtime bypass LoRA is OFF, or
+    - through runtime forward-pass adapter injection when Runtime bypass LoRA is ON
 
 ---
 
@@ -399,6 +440,12 @@ These patches affect DoRA / LoRA application in the running ComfyUI process, not
 ---
 
 ## Troubleshooting
+
+### Runtime bypass rejects a LoRA
+
+Runtime bypass only takes adapters for which the supported forward-pass path preserves the normal patch semantics. In particular, current ComfyUI bypass LoRA does **not** implement DoRA magnitude normalization.
+
+If the loader reports DoRA/magnitude-vector, reshape, offset/transform, or another unsupported adapter form, disable **Runtime bypass LoRA (low VRAM)** for that file rather than trying to force it through the runtime path.
 
 ### Flux2 DoRA instability
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,19 +1,20 @@
 # DoRA Dynamic LoRA Loader v1.0.39
 
-Adds an opt-in runtime LoRA path for reducing the large persistent VRAM cost of materializing standard LoRA patches on very large HIGH_VRAM models, together with proper CI and automated release infrastructure.
+This release adds an opt-in runtime LoRA path that avoids the large persistent VRAM cost of materializing standard LoRA patches on very large HIGH_VRAM models. It also adds reproducible CI, Comfy Registry packaging exclusions, and automated GitHub release infrastructure.
 
 ## Runtime bypass LoRA
 
 - Adds `Runtime bypass LoRA (low VRAM)` to the DoRA Power LoRA Loader.
-- Keeps the option disabled by default so existing workflows retain the current materialized-weight behavior.
-- For supported standard LoRAs, this is intended to preserve the same LoRA effect while changing how it is executed: instead of materializing `W + ΔW`, the loader keeps the base weight `W` untouched and evaluates the low-rank `ΔW` path during the forward pass.
-- Applies supported standard LoRA adapters in the module forward pass rather than permanently materializing LoRA-patched base weights.
-- Supports multiple stacked LoRAs targeting the same module and removes nested forward wrappers in reverse order during ejection.
-- Keeps LoRA strength as a runtime adapter multiplier, avoiding a full base-weight rematerialization solely because the strength changes.
+- Keeps the option **OFF by default**, so existing workflows retain the previous materialized-weight behavior.
+- For supported standard LoRAs, runtime bypass preserves the intended LoRA transformation while changing how it is executed: the normal path evaluates `(W + ΔW)x`, while runtime bypass keeps `W` untouched and evaluates `Wx + ΔWx` during the forward pass.
+- Avoids retaining a full materialized LoRA-patched copy of all targeted base weights.
+- Supports multiple stacked LoRAs on the same module with state-aware, reverse-order hook removal.
+- Strength changes update the runtime adapter multiplier instead of requiring the full base-weight set to be rematerialized.
+- Non-adapter patches retain normal ComfyUI materialized patch semantics and are reported in the log.
 
 ## Correctness safeguards
 
-Runtime bypass intentionally fails closed whenever ComfyUI's bypass path cannot reproduce the original patch semantics exactly.
+Runtime bypass deliberately fails closed whenever the supported forward-pass path cannot reproduce the normal patch semantics.
 
 It refuses:
 
@@ -25,18 +26,31 @@ It refuses:
 
 DoRA is checked from raw file keys before application and again from the constructed adapter object. Unsupported files produce an explicit error instead of silently changing their mathematical meaning.
 
+The injection lifecycle is also state-aware: partial injection rollback, repeated ejection, and stacked wrappers cannot restore a stale module `forward`. Runtime mode also fails closed if adapters were captured but the parent loader returns an output shape that cannot accept the resulting injections.
+
+## MiniMax-H3 VRAM validation
+
+The original HIGH_VRAM trace showed 208 LoRA-targeted MiniMax-H3 weights retaining exactly one additional BF16-sized live allocation each, totaling about **38,220 MiB** of extra live VRAM before inference.
+
+With runtime bypass enabled in the tested MiniMax-H3 workflow:
+
+- that model-sized materialized LoRA duplication disappeared;
+- repeated LoRA strength changes peaked in the low-70-GiB range and returned to the same settled live-allocation baseline afterward instead of accumulating on each change;
+- a Turbo LoRA remained visibly effective in runtime mode.
+
+Small floating-point differences from the merged path are still possible because the operations are executed separately and may follow a different dtype/order path.
+
 ## Testing and release automation
 
-- Adds a GitHub Actions test matrix against pinned ComfyUI v0.29.2, v0.30.2, and v0.31.1 commits.
-- Compiles the Python sources on every tested ComfyUI version.
-- Checks every frontend JavaScript file with `node --check`.
-- Builds the package wheel in CI.
-- Adds runtime-bypass tests covering default-off behavior, cache invalidation, DoRA/reshape/offset rejection, non-adapter fallback behavior, standard adapter capture without materialization, stacked-LoRA additive equivalence, and clean forward restoration.
+- Adds package/wheel validation, Python compilation, and frontend JavaScript syntax checks.
+- Adds compatibility/runtime-bypass tests against pinned ComfyUI v0.29.2, v0.30.2, and v0.31.1 revisions with explicit CPU PyTorch-family pins and version reporting.
+- Tests cover default-off behavior, cache invalidation, bounded multi-LoRA preflight caching, DoRA/reshape/offset rejection, non-adapter fallback behavior, standard adapter capture without materialization, stacked-LoRA additive equivalence, repeated hook injection/ejection, cloned-patcher interception end to end, and fail-closed unsupported loader output.
+- Adds `.comfyignore` so development-only `.github/` and `tests/` content is not shipped in Comfy Registry archives.
 - Adds an automated GitHub release workflow gated on a successful `tests` run from `main`.
 - GitHub releases contain a versioned repository ZIP and `SHA256SUMS` manifest and use this file as the release notes.
+- Existing release tags are accepted only for an exact same-commit rerun; a conflicting existing tag fails the release rather than silently reporting success.
 - Aligns Comfy Registry publishing with the pinned action revisions used by Spectrum MiniMax H3.
-- Manual MiniMax-H3 VRAM validation confirmed that repeated LoRA strength changes return to the same settled live-allocation baseline rather than accumulating another materialized model-sized copy each time.
 
 ## Compatibility
 
-The runtime bypass option is opt-in. With it disabled, the loader continues through the existing LoRA/DoRA path. State Manager behavior, existing loader globals, Flux/Flux2 compatibility handling, ZiT/Lumina2 normalization, DoRA fixes, and auto-strength remain on their existing path.
+Runtime bypass is opt-in. With it disabled, the loader continues through the existing LoRA/DoRA path. State Manager behavior, existing loader globals, Flux/Flux2 compatibility handling, ZiT/Lumina2 normalization, DoRA fixes, and auto-strength remain on their existing path.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,40 @@
+# DoRA Dynamic LoRA Loader v1.0.39
+
+Adds an opt-in runtime LoRA path for reducing the large persistent VRAM cost of materializing standard LoRA patches on very large HIGH_VRAM models, together with proper CI and automated release infrastructure.
+
+## Runtime bypass LoRA
+
+- Adds `Runtime bypass LoRA (low VRAM; standard LoRA only)` to the DoRA Power LoRA Loader.
+- Keeps the option disabled by default so existing workflows retain the current materialized-weight behavior.
+- Applies supported standard LoRA adapters in the module forward pass rather than permanently materializing LoRA-patched base weights.
+- Supports multiple stacked LoRAs targeting the same module and removes nested forward wrappers in reverse order during ejection.
+- Keeps LoRA strength as a runtime adapter multiplier, avoiding a full base-weight rematerialization solely because the strength changes.
+
+## Correctness safeguards
+
+Runtime bypass intentionally fails closed whenever ComfyUI's bypass path cannot reproduce the original patch semantics exactly.
+
+It refuses:
+
+- DoRA magnitude scaling (`dora_scale`, PEFT/Diffusers `lora_magnitude_vector`, `w_norm`, `b_norm`)
+- non-LoRA weight-adapter types
+- reshape metadata
+- sliced, offset, or transformed adapter targets
+- non-default `strength_model` patch semantics
+
+DoRA is checked from raw file keys before application and again from the constructed adapter object. Unsupported files produce an explicit error instead of silently changing their mathematical meaning.
+
+## Testing and release automation
+
+- Adds a GitHub Actions test matrix against pinned ComfyUI v0.29.2, v0.30.2, and v0.31.1 commits.
+- Compiles the Python sources on every tested ComfyUI version.
+- Checks every frontend JavaScript file with `node --check`.
+- Builds the package wheel in CI.
+- Adds runtime-bypass tests covering default-off behavior, cache invalidation, DoRA/reshape/offset rejection, non-adapter fallback behavior, standard adapter capture without materialization, stacked-LoRA additive equivalence, and clean forward restoration.
+- Adds an automated GitHub release workflow gated on a successful `tests` run from `main`.
+- GitHub releases contain a versioned repository ZIP and `SHA256SUMS` manifest and use this file as the release notes.
+- Aligns Comfy Registry publishing with the pinned action revisions used by Spectrum MiniMax H3.
+
+## Compatibility
+
+The runtime bypass option is opt-in. With it disabled, the loader continues through the existing LoRA/DoRA path. State Manager behavior, existing loader globals, Flux/Flux2 compatibility handling, ZiT/Lumina2 normalization, DoRA fixes, and auto-strength remain on their existing path.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,8 +4,9 @@ Adds an opt-in runtime LoRA path for reducing the large persistent VRAM cost of 
 
 ## Runtime bypass LoRA
 
-- Adds `Runtime bypass LoRA (low VRAM; standard LoRA only)` to the DoRA Power LoRA Loader.
+- Adds `Runtime bypass LoRA (low VRAM)` to the DoRA Power LoRA Loader.
 - Keeps the option disabled by default so existing workflows retain the current materialized-weight behavior.
+- For supported standard LoRAs, this is intended to preserve the same LoRA effect while changing how it is executed: instead of materializing `W + ΔW`, the loader keeps the base weight `W` untouched and evaluates the low-rank `ΔW` path during the forward pass.
 - Applies supported standard LoRA adapters in the module forward pass rather than permanently materializing LoRA-patched base weights.
 - Supports multiple stacked LoRAs targeting the same module and removes nested forward wrappers in reverse order during ejection.
 - Keeps LoRA strength as a runtime adapter multiplier, avoiding a full base-weight rematerialization solely because the strength changes.
@@ -34,6 +35,7 @@ DoRA is checked from raw file keys before application and again from the constru
 - Adds an automated GitHub release workflow gated on a successful `tests` run from `main`.
 - GitHub releases contain a versioned repository ZIP and `SHA256SUMS` manifest and use this file as the release notes.
 - Aligns Comfy Registry publishing with the pinned action revisions used by Spectrum MiniMax H3.
+- Manual MiniMax-H3 VRAM validation confirmed that repeated LoRA strength changes return to the same settled live-allocation baseline rather than accumulating another materialized model-sized copy each time.
 
 ## Compatibility
 

--- a/__init__.py
+++ b/__init__.py
@@ -1,4 +1,5 @@
-from .nodes import DoraPowerLoraLoader, DoraStateManager, StateManager, StateManagerSeed, StateManagerTextBox
+from .nodes import DoraStateManager, StateManager, StateManagerSeed, StateManagerTextBox
+from .runtime_bypass import RuntimeBypassDoraPowerLoraLoader
 
 # Backend API for frontend LoRA dropdown (avoids relying on /object_info variants).
 import folder_paths
@@ -16,7 +17,7 @@ async def dora_dynamic_lora_list_loras(request):
 WEB_DIRECTORY = "./web"
 
 NODE_CLASS_MAPPINGS = {
-    "DoRA Power LoRA Loader": DoraPowerLoraLoader,
+    "DoRA Power LoRA Loader": RuntimeBypassDoraPowerLoraLoader,
     "State Manager": StateManager,
     "State Manager Text Box": StateManagerTextBox,
     "State Manager Seed": StateManagerSeed,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "dora-dynamic-lora-loader"
 description = "A ComfyUI custom node that loads and stacks regular LoRAs and DoRA LoRAs with Flux/Flux2 and OneTrainer compatibility fixes."
-version = "1.0.38"
+version = "1.0.39"
 license = { file = "LICENSE" }
 
 [project.urls]
@@ -13,4 +13,4 @@ Documentation = "https://github.com/xmarre/ComfyUI-DoRA-Dynamic-LoRA-Loader#read
 PublisherId = "xmarre"
 DisplayName = "ComfyUI-DoRA-Dynamic-LoRA-Loader"
 Icon = ""
-includes = ["__init__.py", "nodes.py", "web"]
+includes = ["__init__.py", "nodes.py", "runtime_bypass.py", "web"]

--- a/runtime_bypass.py
+++ b/runtime_bypass.py
@@ -193,25 +193,44 @@ def _make_stacked_injection(
             )
             hooks.append(hook)
 
+    active_hooks: List[Any] = []
+
     def inject_all(_model_patcher):
-        injected: List[Any] = []
+        # ModelPatcher normally prevents duplicate injection, but keep this
+        # injection idempotent when exercised directly as well.
+        if active_hooks:
+            return
         try:
             for hook in hooks:
                 hook.inject()
-                injected.append(hook)
+                active_hooks.append(hook)
         except Exception:
-            for hook in reversed(injected):
+            while active_hooks:
+                hook = active_hooks.pop()
                 try:
                     hook.eject()
                 except Exception:
-                    pass
+                    _LOG.exception(
+                        "[DoRA Power LoRA Loader] runtime bypass: rollback eject failed."
+                    )
             raise
 
     def eject_all(_model_patcher):
         # Multiple LoRAs on one module form nested forward wrappers. They MUST be
         # removed in reverse order or an older wrapper can be restored accidentally.
-        for hook in reversed(hooks):
-            hook.eject()
+        first_error = None
+        while active_hooks:
+            hook = active_hooks.pop()
+            try:
+                hook.eject()
+            except Exception as exc:
+                _LOG.exception(
+                    "[DoRA Power LoRA Loader] runtime bypass: hook eject failed."
+                )
+                if first_error is None:
+                    first_error = exc
+        if first_error is not None:
+            raise first_error
 
     injection = comfy.patcher_extension.PatcherInjection(
         inject=inject_all,
@@ -291,7 +310,8 @@ class RuntimeBypassDoraPowerLoraLoader(_base.DoraPowerLoraLoader):
             signature = (str(path), None, None)
 
         if signature not in cache:
-            cache.clear()
+            if len(cache) >= 32:
+                cache.pop(next(iter(cache)))
             cache[signature] = _raw_dora_keys(lora_name)
 
         dora_keys = cache[signature]
@@ -433,10 +453,27 @@ class RuntimeBypassDoraPowerLoraLoader(_base.DoraPowerLoraLoader):
 
         try:
             output = super().load_loras(model, clip, **kwargs)
+            captured = bool(
+                self._runtime_bypass_capture["model"]
+                or self._runtime_bypass_capture["clip"]
+            )
             if not isinstance(output, dict) or "result" not in output:
+                if captured:
+                    raise RuntimeBypassUnsupportedError(
+                        "Runtime bypass captured LoRA adapters, but the loader output shape is unsupported, "
+                        "so the adapters cannot be injected. Disable Runtime bypass LoRA."
+                    )
                 return output
 
-            result = list(output["result"])
+            result = output["result"]
+            if not isinstance(result, (tuple, list)):
+                if captured:
+                    raise RuntimeBypassUnsupportedError(
+                        "Runtime bypass captured LoRA adapters, but the loader result is not a sequence, "
+                        "so the adapters cannot be injected. Disable Runtime bypass LoRA."
+                    )
+                return output
+
             new_model = result[0] if len(result) > 0 else None
             new_clip = result[1] if len(result) > 1 else None
 
@@ -461,7 +498,6 @@ class RuntimeBypassDoraPowerLoraLoader(_base.DoraPowerLoraLoader):
                 clip_count,
             )
 
-            output["result"] = tuple(result)
             return output
         finally:
             self._runtime_bypass_active = False

--- a/runtime_bypass.py
+++ b/runtime_bypass.py
@@ -1,0 +1,469 @@
+"""Opt-in runtime/bypass LoRA mode for the DoRA Power LoRA Loader.
+
+The normal ComfyUI LoRA path materializes patched model weights. On very large
+HIGH_VRAM models that can retain a second full copy of every LoRA-targeted base
+weight. Runtime bypass mode keeps the base weights untouched and evaluates
+standard LoRA adapters in the module forward pass instead.
+
+Safety is deliberate: ComfyUI's bypass LoRA implementation does not implement
+DoRA magnitude normalization, so this mode refuses DoRA and other adapter forms
+that cannot be represented exactly by the supported runtime path.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from collections import defaultdict
+from typing import Any, Dict, Iterable, List, Tuple
+
+import comfy.patcher_extension
+import comfy.weight_adapter
+import comfy.utils
+import folder_paths
+
+from . import nodes as _base
+
+
+_LOG = logging.getLogger(__name__)
+_RUNTIME_INPUT = "runtime_bypass_lora"
+_RUNTIME_INJECTION_PREFIX = "dora_runtime_bypass_lora"
+
+
+class RuntimeBypassUnsupportedError(RuntimeError):
+    """Raised when runtime mode would change the mathematical meaning of a LoRA."""
+
+
+def _as_bool(value: Any, default: bool = False) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return default
+    if isinstance(value, str):
+        text = value.strip().lower()
+        if text in {"1", "true", "yes", "on"}:
+            return True
+        if text in {"0", "false", "no", "off", ""}:
+            return False
+        return default
+    return bool(value)
+
+
+def _is_dora_key(key: Any) -> bool:
+    text = str(key).lower()
+    return (
+        "dora_scale" in text
+        or "lora_magnitude_vector" in text
+        or ".w_norm" in text
+        or ".b_norm" in text
+    )
+
+
+def _read_lora_key_names(path: str) -> List[str]:
+    """Read only key names where possible; avoid materializing safetensor payloads."""
+    if str(path).lower().endswith(".safetensors"):
+        try:
+            from safetensors import safe_open
+
+            with safe_open(path, framework="pt", device="cpu") as f:
+                return [str(k) for k in f.keys()]
+        except Exception as exc:
+            _LOG.debug(
+                "[DoRA Power LoRA Loader] runtime bypass: safetensors key-only scan failed for %s (%r); falling back to Comfy loader.",
+                path,
+                exc,
+            )
+
+    try:
+        data = comfy.utils.load_torch_file(path, safe_load=True)
+    except TypeError:
+        data = comfy.utils.load_torch_file(path)
+    try:
+        return [str(k) for k in data.keys()]
+    finally:
+        del data
+
+
+def _raw_dora_keys(lora_name: str) -> List[str]:
+    path = folder_paths.get_full_path("loras", lora_name)
+    if not path:
+        raise FileNotFoundError(f"LoRA not found: {lora_name}")
+    return [key for key in _read_lora_key_names(path) if _is_dora_key(key)]
+
+
+def _patch_target(raw_key: Any) -> Tuple[str, Any, Any]:
+    if isinstance(raw_key, str):
+        return raw_key, None, None
+    if isinstance(raw_key, tuple) and raw_key:
+        key = raw_key[0]
+        offset = raw_key[1] if len(raw_key) > 1 else None
+        function = raw_key[2] if len(raw_key) > 2 else None
+        return str(key), offset, function
+    return str(raw_key), None, None
+
+
+def _resolve_module(root: Any, weight_key: str) -> Any:
+    if not weight_key.endswith(".weight"):
+        raise RuntimeBypassUnsupportedError(
+            f"Runtime bypass only supports adapter weight targets; got {weight_key!r}."
+        )
+
+    module_key = weight_key[: -len(".weight")]
+    module = root
+    for part in module_key.split("."):
+        try:
+            module = getattr(module, part)
+            continue
+        except (AttributeError, TypeError):
+            pass
+
+        try:
+            module = module[part]
+            continue
+        except (KeyError, IndexError, TypeError, AttributeError):
+            pass
+
+        if part.isdigit():
+            try:
+                module = module[int(part)]
+                continue
+            except (KeyError, IndexError, TypeError, AttributeError):
+                pass
+
+        raise RuntimeBypassUnsupportedError(
+            f"Runtime bypass could not resolve module {module_key!r} for weight {weight_key!r}."
+        )
+    return module
+
+
+def _validate_lora_adapter(adapter: Any, lora_name: str, raw_key: Any) -> None:
+    if not isinstance(adapter, comfy.weight_adapter.LoRAAdapter):
+        raise RuntimeBypassUnsupportedError(
+            "Runtime bypass currently supports standard LoRA adapters only. "
+            f"{lora_name!r} produced {type(adapter).__name__} for {raw_key!r}. "
+            "Disable Runtime bypass LoRA for this file."
+        )
+
+    weights = getattr(adapter, "weights", None)
+    if not isinstance(weights, (tuple, list)):
+        raise RuntimeBypassUnsupportedError(
+            f"Runtime bypass could not inspect the LoRA adapter for {lora_name!r} at {raw_key!r}."
+        )
+
+    # ComfyUI LoRAAdapter weights are:
+    # (up, down, alpha, mid, dora_scale, reshape)
+    dora_scale = weights[4] if len(weights) > 4 else None
+    reshape = weights[5] if len(weights) > 5 else None
+    if dora_scale is not None:
+        raise RuntimeBypassUnsupportedError(
+            "Runtime bypass LoRA is enabled, but "
+            f"{lora_name!r} contains DoRA magnitude scaling at {raw_key!r}. "
+            "ComfyUI's runtime bypass path does not apply DoRA magnitude normalization, "
+            "so running it would silently change the result. Disable Runtime bypass LoRA for this DoRA."
+        )
+    if reshape is not None:
+        raise RuntimeBypassUnsupportedError(
+            "Runtime bypass does not currently support LoRA reshape metadata. "
+            f"{lora_name!r} uses it at {raw_key!r}. Disable Runtime bypass LoRA for this file."
+        )
+
+
+def _make_stacked_injection(
+    root: Any,
+    adapters: Iterable[Dict[str, Any]],
+) -> Tuple[List[Any], int]:
+    """Build one injection whose same-module hooks unwind in strict reverse order."""
+    grouped: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
+    for item in adapters:
+        grouped[str(item["key"])].append(item)
+
+    hooks: List[Any] = []
+    for weight_key, items in grouped.items():
+        module = _resolve_module(root, weight_key)
+        if not hasattr(module, "weight"):
+            raise RuntimeBypassUnsupportedError(
+                f"Runtime bypass target {weight_key!r} resolved to {type(module).__name__}, which has no weight attribute."
+            )
+        for item in items:
+            hook = comfy.weight_adapter.BypassForwardHook(
+                module,
+                item["adapter"],
+                multiplier=float(item["strength"]),
+            )
+            hooks.append(hook)
+
+    def inject_all(_model_patcher):
+        injected: List[Any] = []
+        try:
+            for hook in hooks:
+                hook.inject()
+                injected.append(hook)
+        except Exception:
+            for hook in reversed(injected):
+                try:
+                    hook.eject()
+                except Exception:
+                    pass
+            raise
+
+    def eject_all(_model_patcher):
+        # Multiple LoRAs on one module form nested forward wrappers. They MUST be
+        # removed in reverse order or an older wrapper can be restored accidentally.
+        for hook in reversed(hooks):
+            hook.eject()
+
+    injection = comfy.patcher_extension.PatcherInjection(
+        inject=inject_all,
+        eject=eject_all,
+    )
+    return [injection], len(hooks)
+
+
+def _instance_override(obj: Any, name: str, replacement: Any):
+    """Install an instance-only method override and return a restoration callback."""
+    d = getattr(obj, "__dict__", None)
+    had_instance_value = isinstance(d, dict) and name in d
+    previous_instance_value = d.get(name) if had_instance_value else None
+    setattr(obj, name, replacement)
+
+    def restore():
+        if had_instance_value:
+            setattr(obj, name, previous_instance_value)
+        else:
+            try:
+                delattr(obj, name)
+            except AttributeError:
+                pass
+
+    return restore
+
+
+class RuntimeBypassDoraPowerLoraLoader(_base.DoraPowerLoraLoader):
+    """DoRA Power LoRA Loader with an opt-in low-VRAM standard-LoRA runtime path."""
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        inputs = super().INPUT_TYPES()
+        optional = inputs.get("optional")
+        if optional is not None:
+            optional[_RUNTIME_INPUT] = (
+                "BOOLEAN",
+                {
+                    "default": False,
+                    "tooltip": (
+                        "Apply standard LoRAs in the forward pass instead of materializing patched model weights. "
+                        "Greatly reduces persistent VRAM on very large HIGH_VRAM models. DoRA and unsupported "
+                        "adapter/offset forms are refused rather than approximated."
+                    ),
+                },
+            )
+        return inputs
+
+    @classmethod
+    def IS_CHANGED(cls, model: Any = None, clip: Any = None, **kwargs):
+        # The base loader's cache key intentionally only includes its known globals.
+        # Add this mode explicitly so toggling it always invalidates the node output.
+        base_key = super().IS_CHANGED(model=model, clip=clip, **kwargs)
+        return json.dumps(
+            {
+                "base": base_key,
+                _RUNTIME_INPUT: _as_bool(kwargs.get(_RUNTIME_INPUT, False)),
+            },
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+
+    def _runtime_preflight(self, lora_name: str) -> None:
+        cache = getattr(self, "_runtime_dora_scan_cache", None)
+        if cache is None:
+            cache = {}
+            self._runtime_dora_scan_cache = cache
+
+        path = folder_paths.get_full_path("loras", lora_name)
+        if not path:
+            raise FileNotFoundError(f"LoRA not found: {lora_name}")
+        try:
+            st = os.stat(path)
+            signature = (str(path), int(st.st_size), int(getattr(st, "st_mtime_ns", 0)))
+        except OSError:
+            signature = (str(path), None, None)
+
+        if signature not in cache:
+            cache.clear()
+            cache[signature] = _raw_dora_keys(lora_name)
+
+        dora_keys = cache[signature]
+        if dora_keys:
+            examples = ", ".join(dora_keys[:3])
+            suffix = "" if len(dora_keys) <= 3 else f" (+{len(dora_keys) - 3} more)"
+            raise RuntimeBypassUnsupportedError(
+                "Runtime bypass LoRA is enabled, but "
+                f"{lora_name!r} is a DoRA/magnitude LoRA ({examples}{suffix}). "
+                "ComfyUI's bypass adapter math does not implement DoRA magnitude normalization. "
+                "Disable Runtime bypass LoRA for this file; it will not be silently approximated."
+            )
+
+    def _capture_add_patches(
+        self,
+        target: str,
+        state_dict_keys: set[str],
+        original_add_patches: Any,
+        lora_name: str,
+    ):
+        capture = self._runtime_bypass_capture[target]
+
+        def add_patches_runtime(patches, *args, **kwargs):
+            strength_patch = kwargs.get("strength_patch", args[0] if args else 1.0)
+            strength_model = kwargs.get("strength_model", args[1] if len(args) > 1 else 1.0)
+            try:
+                strength_patch_f = float(strength_patch)
+                strength_model_f = float(strength_model)
+            except Exception as exc:
+                raise RuntimeBypassUnsupportedError(
+                    f"Runtime bypass received non-scalar patch strengths for {lora_name!r}."
+                ) from exc
+
+            if abs(strength_model_f - 1.0) > 1e-12:
+                raise RuntimeBypassUnsupportedError(
+                    "Runtime bypass cannot reproduce ModelPatcher strength_model scaling. "
+                    f"{lora_name!r} requested strength_model={strength_model_f}."
+                )
+
+            regular: Dict[Any, Any] = {}
+            applied: List[Any] = []
+
+            for raw_key, patch_data in patches.items():
+                key, offset, function = _patch_target(raw_key)
+                if key not in state_dict_keys:
+                    continue
+
+                if isinstance(patch_data, comfy.weight_adapter.WeightAdapterBase):
+                    _validate_lora_adapter(patch_data, lora_name, raw_key)
+                    if offset is not None or function is not None:
+                        raise RuntimeBypassUnsupportedError(
+                            "Runtime bypass does not currently support sliced/offset or transformed LoRA targets. "
+                            f"{lora_name!r} uses one at {raw_key!r}. Disable Runtime bypass LoRA for this file."
+                        )
+                    capture.append(
+                        {
+                            "key": key,
+                            "adapter": patch_data,
+                            "strength": strength_patch_f,
+                            "lora_name": lora_name,
+                        }
+                    )
+                    applied.append(raw_key)
+                else:
+                    # Match ComfyUI's own bypass loader: non-adapter patches retain
+                    # their normal materialized semantics. Standard LoRA files should
+                    # overwhelmingly/entirely take the adapter path above.
+                    regular[raw_key] = patch_data
+
+            if regular:
+                result = original_add_patches(regular, *args, **kwargs)
+                if result:
+                    applied.extend(result)
+                _LOG.warning(
+                    "[DoRA Power LoRA Loader] runtime bypass: %s contains %d non-adapter patch(es) for %s; "
+                    "those patches still use normal materialized weight patching.",
+                    lora_name,
+                    len(regular),
+                    target,
+                )
+
+            return applied
+
+        return add_patches_runtime
+
+    def _load_one(self, model, clip, *args, **kwargs):
+        if not getattr(self, "_runtime_bypass_active", False):
+            return super()._load_one(model, clip, *args, **kwargs)
+
+        lora_name = str(kwargs.get("lora_name") or "")
+        if not lora_name:
+            raise RuntimeBypassUnsupportedError("Runtime bypass could not determine the active LoRA name.")
+
+        self._runtime_preflight(lora_name)
+
+        restores = []
+        try:
+            if model is not None:
+                model_keys = set(model.model.state_dict().keys())
+                original = model.add_patches
+                restores.append(
+                    _instance_override(
+                        model,
+                        "add_patches",
+                        self._capture_add_patches("model", model_keys, original, lora_name),
+                    )
+                )
+
+            if clip is not None:
+                clip_keys = set(clip.cond_stage_model.state_dict().keys())
+                original = clip.add_patches
+                restores.append(
+                    _instance_override(
+                        clip,
+                        "add_patches",
+                        self._capture_add_patches("clip", clip_keys, original, lora_name),
+                    )
+                )
+
+            return super()._load_one(model, clip, *args, **kwargs)
+        finally:
+            for restore in reversed(restores):
+                restore()
+
+    def load_loras(self, model, clip, **kwargs):
+        runtime_enabled = _as_bool(kwargs.get(_RUNTIME_INPUT, False))
+        if not runtime_enabled:
+            return super().load_loras(model, clip, **kwargs)
+
+        if not hasattr(comfy.weight_adapter, "BypassForwardHook"):
+            raise RuntimeError(
+                "Runtime bypass LoRA requires a ComfyUI build with weight_adapter.BypassForwardHook support. "
+                "Disable Runtime bypass LoRA or update ComfyUI."
+            )
+
+        self._runtime_bypass_active = True
+        self._runtime_bypass_capture = {"model": [], "clip": []}
+        self._runtime_dora_scan_cache = {}
+
+        try:
+            output = super().load_loras(model, clip, **kwargs)
+            if not isinstance(output, dict) or "result" not in output:
+                return output
+
+            result = list(output["result"])
+            new_model = result[0] if len(result) > 0 else None
+            new_clip = result[1] if len(result) > 1 else None
+
+            model_count = 0
+            clip_count = 0
+            injection_key = f"{_RUNTIME_INJECTION_PREFIX}_{id(self)}"
+
+            model_adapters = self._runtime_bypass_capture["model"]
+            if new_model is not None and model_adapters:
+                injections, model_count = _make_stacked_injection(new_model.model, model_adapters)
+                new_model.set_injections(injection_key, injections)
+
+            clip_adapters = self._runtime_bypass_capture["clip"]
+            if new_clip is not None and clip_adapters:
+                injections, clip_count = _make_stacked_injection(new_clip.cond_stage_model, clip_adapters)
+                new_clip.patcher.set_injections(injection_key, injections)
+
+            _LOG.info(
+                "[DoRA Power LoRA Loader] Runtime bypass LoRA enabled: model_hooks=%d clip_hooks=%d. "
+                "Base weights remain unmaterialized for these standard-LoRA adapters.",
+                model_count,
+                clip_count,
+            )
+
+            output["result"] = tuple(result)
+            return output
+        finally:
+            self._runtime_bypass_active = False
+            self._runtime_bypass_capture = {"model": [], "clip": []}
+            self._runtime_dora_scan_cache = {}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,13 @@ ROOT = pathlib.Path(
 ).resolve()
 COMFYUI_PATH = pathlib.Path(os.environ.get("COMFYUI_PATH", ROOT / "ComfyUI")).resolve()
 
+comfy_cli_args_path = COMFYUI_PATH / "comfy" / "cli_args.py"
+if not comfy_cli_args_path.is_file():
+    pytest.skip(
+        f"ComfyUI checkout not found at {COMFYUI_PATH}; set COMFYUI_PATH to a valid checkout.",
+        allow_module_level=True,
+    )
+
 if str(COMFYUI_PATH) not in sys.path:
     sys.path.insert(0, str(COMFYUI_PATH))
 
@@ -24,8 +31,10 @@ if str(COMFYUI_PATH) not in sys.path:
 # comfy.model_management. Force CPU mode for these pure adapter tests; this is
 # the same supported ComfyUI --cpu execution mode, without letting ComfyUI parse
 # pytest's own command-line arguments.
-import comfy.cli_args as comfy_cli_args
-
+comfy_cli_args = pytest.importorskip(
+    "comfy.cli_args",
+    reason=f"Could not import comfy.cli_args from ComfyUI checkout at {COMFYUI_PATH}.",
+)
 comfy_cli_args.args.cpu = True
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,12 @@ import types
 import pytest
 
 
-ROOT = pathlib.Path(__file__).resolve().parents[1]
+# CI copies this test directory outside the custom-node package tree so pytest
+# cannot auto-import the node's root __init__.py. DORA_REPO_ROOT points back to
+# the actual checkout; local runs still fall back to the parent directory.
+ROOT = pathlib.Path(
+    os.environ.get("DORA_REPO_ROOT", pathlib.Path(__file__).resolve().parents[1])
+).resolve()
 COMFYUI_PATH = pathlib.Path(os.environ.get("COMFYUI_PATH", ROOT / "ComfyUI")).resolve()
 
 if str(COMFYUI_PATH) not in sys.path:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,16 @@ COMFYUI_PATH = pathlib.Path(os.environ.get("COMFYUI_PATH", ROOT / "ComfyUI")).re
 if str(COMFYUI_PATH) not in sys.path:
     sys.path.insert(0, str(COMFYUI_PATH))
 
+# GitHub's hosted runners use the CPU-only PyTorch wheel. ComfyUI's CLI parser
+# intentionally parses an empty argv when imported as a library, so its default
+# device remains CUDA unless a caller changes the parsed args before importing
+# comfy.model_management. Force CPU mode for these pure adapter tests; this is
+# the same supported ComfyUI --cpu execution mode, without letting ComfyUI parse
+# pytest's own command-line arguments.
+import comfy.cli_args as comfy_cli_args
+
+comfy_cli_args.args.cpu = True
+
 
 @pytest.fixture(scope="session")
 def dora_modules():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,43 @@
+import importlib.util
+import os
+import pathlib
+import sys
+import types
+
+import pytest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+COMFYUI_PATH = pathlib.Path(os.environ.get("COMFYUI_PATH", ROOT / "ComfyUI")).resolve()
+
+if str(COMFYUI_PATH) not in sys.path:
+    sys.path.insert(0, str(COMFYUI_PATH))
+
+
+@pytest.fixture(scope="session")
+def dora_modules():
+    """Load nodes.py/runtime_bypass.py as a package without executing __init__.py.
+
+    The custom-node __init__ registers HTTP routes against a live PromptServer,
+    which is correct inside ComfyUI but unnecessary for these pure loader tests.
+    """
+    package_name = "dora_loader_testpkg"
+    package = types.ModuleType(package_name)
+    package.__path__ = [str(ROOT)]
+    package.__package__ = package_name
+    sys.modules[package_name] = package
+
+    def load_module(short_name: str, filename: str):
+        full_name = f"{package_name}.{short_name}"
+        spec = importlib.util.spec_from_file_location(full_name, ROOT / filename)
+        if spec is None or spec.loader is None:
+            raise RuntimeError(f"Could not build import spec for {filename}")
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[full_name] = module
+        setattr(package, short_name, module)
+        spec.loader.exec_module(module)
+        return module
+
+    nodes = load_module("nodes", "nodes.py")
+    runtime = load_module("runtime_bypass", "runtime_bypass.py")
+    return nodes, runtime

--- a/tests/test_runtime_bypass.py
+++ b/tests/test_runtime_bypass.py
@@ -68,6 +68,38 @@ def test_reshape_adapter_is_refused(dora_modules):
         runtime._validate_lora_adapter(adapter, "reshape.safetensors", "layer.weight")
 
 
+def test_preflight_cache_keeps_multiple_stacked_loras(dora_modules, monkeypatch, tmp_path):
+    _, runtime = dora_modules
+    loader = runtime.RuntimeBypassDoraPowerLoraLoader()
+    loader._runtime_dora_scan_cache = {}
+
+    paths = {}
+    for name in ("a.safetensors", "b.safetensors"):
+        path = tmp_path / name
+        path.write_bytes(b"test")
+        paths[name] = str(path)
+
+    scans = []
+    monkeypatch.setattr(
+        runtime.folder_paths,
+        "get_full_path",
+        lambda category, name: paths.get(name),
+    )
+
+    def fake_raw_dora_keys(name):
+        scans.append(name)
+        return []
+
+    monkeypatch.setattr(runtime, "_raw_dora_keys", fake_raw_dora_keys)
+
+    loader._runtime_preflight("a.safetensors")
+    loader._runtime_preflight("b.safetensors")
+    loader._runtime_preflight("a.safetensors")
+
+    assert scans == ["a.safetensors", "b.safetensors"]
+    assert len(loader._runtime_dora_scan_cache) == 2
+
+
 def test_standard_adapter_is_captured_without_materializing_patch(dora_modules):
     _, runtime = dora_modules
     comfy_weight_adapter = runtime.comfy.weight_adapter
@@ -207,13 +239,129 @@ def test_stacked_runtime_loras_match_additive_lora_math_and_restore_forward(dora
     assert hook_count == 2
     assert len(injections) == 1
 
+    # Direct repeated injection/ejection should be harmless as well as the normal
+    # ModelPatcher-managed single inject/eject lifecycle.
     injections[0].inject(None)
-    try:
-        torch.testing.assert_close(model.layer(x), expected)
-    finally:
-        injections[0].eject(None)
+    injections[0].inject(None)
+    torch.testing.assert_close(model.layer(x), expected)
+    injections[0].eject(None)
+    injections[0].eject(None)
 
     torch.testing.assert_close(model.layer(x), base)
+
+
+def test_load_loras_intercepts_cloned_patcher_end_to_end(dora_modules, monkeypatch):
+    _, runtime = dora_modules
+    comfy_weight_adapter = runtime.comfy.weight_adapter
+    adapter = make_adapter(
+        comfy_weight_adapter,
+        [[0.8], [-0.3]],
+        [[0.4, -0.2, 0.6]],
+        alpha=1.0,
+    )
+
+    class TinyModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.layer = torch.nn.Linear(3, 2, bias=False)
+
+    class FakePatcher:
+        def __init__(self, model):
+            self.model = model
+            self.materialized_calls = []
+            self.injections = {}
+            self.clone_source = None
+
+        def clone(self):
+            clone = FakePatcher(self.model)
+            clone.clone_source = self
+            return clone
+
+        def add_patches(self, patches, strength_patch=1.0, strength_model=1.0):
+            self.materialized_calls.append((patches, strength_patch, strength_model))
+            return list(patches)
+
+        def set_injections(self, key, injections):
+            self.injections[key] = injections
+
+    base_cls = runtime._base.DoraPowerLoraLoader
+
+    def fake_base_load_one(self, model, clip, *args, **kwargs):
+        model.add_patches(
+            {"layer.weight": adapter},
+            kwargs.get("strength_model", 1.0),
+        )
+        return model, clip, {}
+
+    def fake_base_load_loras(self, model, clip, **kwargs):
+        cloned = model.clone()
+        new_model, new_clip, _ = self._load_one(
+            cloned,
+            clip,
+            lora_name="standard.safetensors",
+            strength_model=0.75,
+            strength_clip=0.0,
+        )
+        return {"result": (new_model, new_clip, "{}", "", {})}
+
+    monkeypatch.setattr(base_cls, "_load_one", fake_base_load_one)
+    monkeypatch.setattr(base_cls, "load_loras", fake_base_load_loras)
+    monkeypatch.setattr(
+        runtime.RuntimeBypassDoraPowerLoraLoader,
+        "_runtime_preflight",
+        lambda self, lora_name: None,
+    )
+
+    model = TinyModel()
+    original = FakePatcher(model)
+    loader = runtime.RuntimeBypassDoraPowerLoraLoader()
+    output = loader.load_loras(original, None, runtime_bypass_lora=True)
+    result_model = output["result"][0]
+
+    assert result_model is not original
+    assert result_model.clone_source is original
+    assert original.materialized_calls == []
+    assert result_model.materialized_calls == []
+    assert len(result_model.injections) == 1
+
+    x = torch.tensor([[0.2, -0.7, 1.1]], dtype=torch.float32)
+    base = model.layer(x).detach().clone()
+    expected_delta = F.linear(F.linear(x, adapter.weights[1]), adapter.weights[0]) * 0.75
+    injection = next(iter(result_model.injections.values()))[0]
+    injection.inject(result_model)
+    try:
+        torch.testing.assert_close(model.layer(x), base + expected_delta)
+    finally:
+        injection.eject(result_model)
+    torch.testing.assert_close(model.layer(x), base)
+
+
+def test_load_loras_fails_closed_if_captured_adapters_cannot_be_injected(dora_modules, monkeypatch):
+    _, runtime = dora_modules
+    comfy_weight_adapter = runtime.comfy.weight_adapter
+    adapter = make_adapter(
+        comfy_weight_adapter,
+        [[1.0], [0.5]],
+        [[0.25, -0.5, 1.0]],
+    )
+    base_cls = runtime._base.DoraPowerLoraLoader
+
+    def fake_base_load_loras(self, model, clip, **kwargs):
+        self._runtime_bypass_capture["model"].append(
+            {
+                "key": "layer.weight",
+                "adapter": adapter,
+                "strength": 1.0,
+                "lora_name": "standard.safetensors",
+            }
+        )
+        return (model, clip)
+
+    monkeypatch.setattr(base_cls, "load_loras", fake_base_load_loras)
+    loader = runtime.RuntimeBypassDoraPowerLoraLoader()
+
+    with pytest.raises(runtime.RuntimeBypassUnsupportedError, match="output shape is unsupported"):
+        loader.load_loras(None, None, runtime_bypass_lora=True)
 
 
 def test_runtime_module_uses_comfy_bypass_primitive(dora_modules):

--- a/tests/test_runtime_bypass.py
+++ b/tests/test_runtime_bypass.py
@@ -1,0 +1,221 @@
+import json
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+
+def make_adapter(comfy_weight_adapter, up, down, *, alpha=1.0, dora_scale=None, reshape=None):
+    up_t = torch.tensor(up, dtype=torch.float32)
+    down_t = torch.tensor(down, dtype=torch.float32)
+    return comfy_weight_adapter.LoRAAdapter(
+        set(),
+        (up_t, down_t, alpha, None, dora_scale, reshape),
+    )
+
+
+def test_switch_defaults_off_and_invalidates_cache(dora_modules):
+    _, runtime = dora_modules
+    cls = runtime.RuntimeBypassDoraPowerLoraLoader
+
+    spec = cls.INPUT_TYPES()["optional"]["runtime_bypass_lora"]
+    assert spec[0] == "BOOLEAN"
+    assert spec[1]["default"] is False
+
+    off_key = json.loads(cls.IS_CHANGED(model=None, clip=None, runtime_bypass_lora=False))
+    on_key = json.loads(cls.IS_CHANGED(model=None, clip=None, runtime_bypass_lora=True))
+    assert off_key["runtime_bypass_lora"] is False
+    assert on_key["runtime_bypass_lora"] is True
+    assert off_key != on_key
+
+
+def test_dora_key_detection_is_fail_closed(dora_modules):
+    _, runtime = dora_modules
+
+    assert runtime._is_dora_key("foo.dora_scale")
+    assert runtime._is_dora_key("foo.lora_magnitude_vector.default.weight")
+    assert runtime._is_dora_key("foo.w_norm")
+    assert runtime._is_dora_key("foo.b_norm")
+    assert not runtime._is_dora_key("foo.lora_up.weight")
+    assert not runtime._is_dora_key("foo.lora_down.weight")
+
+
+def test_dora_adapter_is_refused(dora_modules):
+    _, runtime = dora_modules
+    comfy_weight_adapter = runtime.comfy.weight_adapter
+    adapter = make_adapter(
+        comfy_weight_adapter,
+        [[1.0], [0.5]],
+        [[0.25, -0.5, 1.0]],
+        dora_scale=torch.ones(2, dtype=torch.float32),
+    )
+
+    with pytest.raises(runtime.RuntimeBypassUnsupportedError, match="DoRA magnitude scaling"):
+        runtime._validate_lora_adapter(adapter, "character.safetensors", "layer.weight")
+
+
+def test_reshape_adapter_is_refused(dora_modules):
+    _, runtime = dora_modules
+    comfy_weight_adapter = runtime.comfy.weight_adapter
+    adapter = make_adapter(
+        comfy_weight_adapter,
+        [[1.0], [0.5]],
+        [[0.25, -0.5, 1.0]],
+        reshape=[2, 3],
+    )
+
+    with pytest.raises(runtime.RuntimeBypassUnsupportedError, match="reshape metadata"):
+        runtime._validate_lora_adapter(adapter, "reshape.safetensors", "layer.weight")
+
+
+def test_standard_adapter_is_captured_without_materializing_patch(dora_modules):
+    _, runtime = dora_modules
+    comfy_weight_adapter = runtime.comfy.weight_adapter
+    loader = runtime.RuntimeBypassDoraPowerLoraLoader()
+    loader._runtime_bypass_capture = {"model": [], "clip": []}
+
+    adapter = make_adapter(
+        comfy_weight_adapter,
+        [[1.0], [0.5]],
+        [[0.25, -0.5, 1.0]],
+    )
+    materialized_calls = []
+
+    def original_add_patches(patches, *args, **kwargs):
+        materialized_calls.append((patches, args, kwargs))
+        return list(patches)
+
+    capture_add = loader._capture_add_patches(
+        "model",
+        {"layer.weight"},
+        original_add_patches,
+        "standard.safetensors",
+    )
+    applied = capture_add({"layer.weight": adapter}, 0.65)
+
+    assert applied == ["layer.weight"]
+    assert materialized_calls == []
+    assert len(loader._runtime_bypass_capture["model"]) == 1
+    captured = loader._runtime_bypass_capture["model"][0]
+    assert captured["key"] == "layer.weight"
+    assert captured["adapter"] is adapter
+    assert captured["strength"] == pytest.approx(0.65)
+
+
+def test_non_adapter_patch_preserves_native_materialized_semantics(dora_modules):
+    _, runtime = dora_modules
+    loader = runtime.RuntimeBypassDoraPowerLoraLoader()
+    loader._runtime_bypass_capture = {"model": [], "clip": []}
+    materialized_calls = []
+
+    def original_add_patches(patches, *args, **kwargs):
+        materialized_calls.append((patches, args, kwargs))
+        return list(patches)
+
+    capture_add = loader._capture_add_patches(
+        "model",
+        {"layer.weight"},
+        original_add_patches,
+        "mixed.safetensors",
+    )
+    patch = ("diff", torch.ones(2, 3))
+    applied = capture_add({"layer.weight": patch}, 0.4)
+
+    assert applied == ["layer.weight"]
+    assert len(materialized_calls) == 1
+    assert materialized_calls[0][0] == {"layer.weight": patch}
+    assert loader._runtime_bypass_capture["model"] == []
+
+
+def test_offset_adapter_is_refused_instead_of_approximated(dora_modules):
+    _, runtime = dora_modules
+    comfy_weight_adapter = runtime.comfy.weight_adapter
+    loader = runtime.RuntimeBypassDoraPowerLoraLoader()
+    loader._runtime_bypass_capture = {"model": [], "clip": []}
+    adapter = make_adapter(
+        comfy_weight_adapter,
+        [[1.0], [0.5]],
+        [[0.25, -0.5, 1.0]],
+    )
+
+    capture_add = loader._capture_add_patches(
+        "model",
+        {"layer.weight"},
+        lambda patches, *args, **kwargs: list(patches),
+        "offset.safetensors",
+    )
+
+    with pytest.raises(runtime.RuntimeBypassUnsupportedError, match="sliced/offset"):
+        capture_add({("layer.weight", (0, 2), None): adapter}, 1.0)
+
+
+def test_stacked_runtime_loras_match_additive_lora_math_and_restore_forward(dora_modules):
+    _, runtime = dora_modules
+    comfy_weight_adapter = runtime.comfy.weight_adapter
+
+    class TinyModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.layer = torch.nn.Linear(3, 2, bias=False)
+
+    model = TinyModel()
+    with torch.no_grad():
+        model.layer.weight.copy_(
+            torch.tensor(
+                [
+                    [0.20, -0.40, 0.10],
+                    [0.50, 0.30, -0.20],
+                ],
+                dtype=torch.float32,
+            )
+        )
+
+    adapter_a = make_adapter(
+        comfy_weight_adapter,
+        [[0.8], [-0.3]],
+        [[0.4, -0.2, 0.6]],
+        alpha=1.0,
+    )
+    adapter_b = make_adapter(
+        comfy_weight_adapter,
+        [[-0.5], [0.7]],
+        [[0.1, 0.5, -0.4]],
+        alpha=1.0,
+    )
+    strength_a = 0.65
+    strength_b = -0.30
+    x = torch.tensor(
+        [
+            [0.2, -0.7, 1.1],
+            [1.3, 0.4, -0.2],
+        ],
+        dtype=torch.float32,
+    )
+
+    base = model.layer(x).detach().clone()
+    expected_a = F.linear(F.linear(x, adapter_a.weights[1]), adapter_a.weights[0]) * strength_a
+    expected_b = F.linear(F.linear(x, adapter_b.weights[1]), adapter_b.weights[0]) * strength_b
+    expected = base + expected_a + expected_b
+
+    injections, hook_count = runtime._make_stacked_injection(
+        model,
+        [
+            {"key": "layer.weight", "adapter": adapter_a, "strength": strength_a, "lora_name": "a"},
+            {"key": "layer.weight", "adapter": adapter_b, "strength": strength_b, "lora_name": "b"},
+        ],
+    )
+    assert hook_count == 2
+    assert len(injections) == 1
+
+    injections[0].inject(None)
+    try:
+        torch.testing.assert_close(model.layer(x), expected)
+    finally:
+        injections[0].eject(None)
+
+    torch.testing.assert_close(model.layer(x), base)
+
+
+def test_runtime_module_uses_comfy_bypass_primitive(dora_modules):
+    _, runtime = dora_modules
+    assert hasattr(runtime.comfy.weight_adapter, "BypassForwardHook")

--- a/web/runtime_bypass_lora.js
+++ b/web/runtime_bypass_lora.js
@@ -1,0 +1,103 @@
+import { app } from "../../scripts/app.js";
+
+const NODE_CLASS = "DoRA Power LoRA Loader";
+const EXT_NAME = "comfyui_dora_dynamic_lora.runtime_bypass";
+const WIDGET_NAME = "runtime_bypass_lora";
+const PROPERTY_NAME = "dora_runtime_bypass_lora";
+
+function isTarget(nodeData, nodeType) {
+  const name = nodeData?.name ?? "";
+  const displayName = nodeData?.display_name ?? "";
+  const comfyClass = nodeType?.comfyClass ?? "";
+  return name === NODE_CLASS || displayName === NODE_CLASS || comfyClass === NODE_CLASS;
+}
+
+function runtimeValue(node) {
+  node.properties = node.properties || {};
+  if (node.properties[PROPERTY_NAME] === undefined) {
+    node.properties[PROPERTY_NAME] = false;
+  }
+  return !!node.properties[PROPERTY_NAME];
+}
+
+function ensureRuntimeWidget(node) {
+  if (!node || !Array.isArray(node.widgets)) return null;
+
+  const existing = node.widgets.find((widget) => widget?.name === WIDGET_NAME);
+  if (existing) return existing;
+
+  const widget = node.addWidget(
+    "toggle",
+    WIDGET_NAME,
+    runtimeValue(node),
+    (value) => {
+      node.properties = node.properties || {};
+      node.properties[PROPERTY_NAME] = !!value;
+      widget.value = !!value;
+      node.setDirtyCanvas?.(true, true);
+      node.graph?.change?.();
+    }
+  );
+
+  widget.label = "Runtime bypass LoRA (low VRAM; standard LoRA only)";
+  widget.tooltip =
+    "Keeps base model weights untouched and evaluates standard LoRA adapters during forward passes. " +
+    "Avoids the full materialized patched-weight copy on very large models. DoRA and unsupported " +
+    "adapter/offset forms fail explicitly instead of being approximated.";
+  widget.options = widget.options || {};
+  widget.options.tooltip = widget.tooltip;
+
+  // The main extension rebuilds the entire custom UI and adds the analysis widget last.
+  // Put this global mode directly below Stack Enabled rather than burying it at the bottom.
+  const currentIndex = node.widgets.indexOf(widget);
+  const stackIndex = node.widgets.findIndex((item) => item?.name === "stack_enabled");
+  if (currentIndex >= 0 && stackIndex >= 0 && currentIndex !== stackIndex + 1) {
+    node.widgets.splice(currentIndex, 1);
+    node.widgets.splice(stackIndex + 1, 0, widget);
+  }
+
+  return widget;
+}
+
+app.registerExtension({
+  name: EXT_NAME,
+  async beforeRegisterNodeDef(nodeType, nodeData) {
+    if (!isTarget(nodeData, nodeType)) return;
+
+    // dora_power_lora_loader.js removes and recreates every widget whenever its UI
+    // rebuilds. Its auto-strength custom widget is the final build step, so use that
+    // as a stable point to reinsert this standard serializable boolean widget.
+    const inheritedAddCustomWidget = nodeType.prototype.addCustomWidget;
+    if (typeof inheritedAddCustomWidget === "function" && !nodeType.prototype.__doraRuntimeBypassWrapped) {
+      nodeType.prototype.addCustomWidget = function (widget) {
+        const result = inheritedAddCustomWidget.apply(this, arguments);
+        if (widget?.name === "auto_strength_visualization") {
+          ensureRuntimeWidget(this);
+        }
+        return result;
+      };
+      nodeType.prototype.__doraRuntimeBypassWrapped = true;
+    }
+
+    const originalOnNodeCreated = nodeType.prototype.onNodeCreated;
+    nodeType.prototype.onNodeCreated = function () {
+      const result = originalOnNodeCreated?.apply(this, arguments);
+      // Fallback for frontend variants where the report widget is not installed.
+      ensureRuntimeWidget(this);
+      return result;
+    };
+
+    const originalConfigure = nodeType.prototype.configure;
+    nodeType.prototype.configure = function (info) {
+      if (info?.properties && Object.prototype.hasOwnProperty.call(info.properties, PROPERTY_NAME)) {
+        this.properties = this.properties || {};
+        this.properties[PROPERTY_NAME] = !!info.properties[PROPERTY_NAME];
+      }
+      const result = originalConfigure?.apply(this, arguments);
+      ensureRuntimeWidget(this);
+      const widget = this.widgets?.find((item) => item?.name === WIDGET_NAME);
+      if (widget) widget.value = runtimeValue(this);
+      return result;
+    };
+  },
+});

--- a/web/runtime_bypass_lora.js
+++ b/web/runtime_bypass_lora.js
@@ -39,7 +39,7 @@ function ensureRuntimeWidget(node) {
     }
   );
 
-  widget.label = "Runtime bypass LoRA (low VRAM; standard LoRA only)";
+  widget.label = "Runtime bypass LoRA (low VRAM)";
   widget.tooltip =
     "Keeps base model weights untouched and evaluates standard LoRA adapters during forward passes. " +
     "Avoids the full materialized patched-weight copy on very large models. DoRA and unsupported " +


### PR DESCRIPTION
## Summary

Adds an opt-in **`Runtime bypass LoRA (low VRAM)`** mode to `DoRA Power LoRA Loader`.

The option is **OFF by default**, so existing workflows keep the current materialized LoRA/DoRA behavior unless runtime bypass is explicitly enabled.

For supported standard LoRAs, `bypass` means bypassing **weight materialization**, not bypassing or weakening the LoRA effect. The normal merged path evaluates `(W + ΔW)x`; runtime bypass keeps `W` unchanged and evaluates `Wx + ΔWx` during the forward pass. Those are mathematically equivalent for the supported additive LoRA path, apart from normal floating-point differences caused by operation ordering/dtype.

## Root cause

VRAM tracing on MiniMax-H3 showed why a small LoRA could consume tens of GiB in HIGH_VRAM mode.

The traced materialization pass patched 208 model weights. For every targeted weight, ComfyUI retained the original BF16 tensor in the patch backup while replacing the module parameter with a new patched BF16 tensor. Across the traced H3 weights this retained **38,220 MiB** of additional live VRAM before inference.

That is distinct from `ModelPatcher.clone()` itself: cloning shares the underlying model. The model-sized duplication appears when the LoRA is materialized and the original weight must remain available for unpatch/repatch.

With very little remaining headroom, later LoRA/strength changes could then push the workflow to the GPU limit.

## Runtime path

ComfyUI already provides bypass-adapter primitives that keep base weights untouched and inject the low-rank contribution into module forwards. This PR integrates that model into the existing dynamic loader rather than replacing the loader's existing mapping/conversion logic.

When runtime bypass is enabled:

- the existing LoRA loading, key conversion/mapping, Flux/Flux2/OneTrainer compatibility, ZiT/Lumina2 handling, and auto-strength path still run through the parent loader;
- supported standard `LoRAAdapter` patches are intercepted at the final `add_patches` boundary instead of being materialized into base weights;
- captured adapters are installed as forward-pass injections on the cloned ModelPatcher/CLIP patcher;
- multiple LoRAs targeting the same module are supported with nested hooks and state-aware reverse-order ejection;
- partial injection failures roll back only hooks that were actually installed;
- repeated/direct ejection cannot restore a stale `forward` wrapper;
- strength changes update the runtime adapter multiplier instead of rematerializing the full targeted weight set;
- non-adapter patches keep normal ComfyUI materialized patch semantics and emit a warning.

## Correctness / fail-closed behavior

Runtime bypass is only used where the supported forward-pass path preserves the intended patch semantics. Unsupported forms are rejected explicitly rather than silently approximated.

Runtime mode currently refuses:

- DoRA / magnitude-vector LoRAs (`dora_scale`, PEFT/Diffusers `lora_magnitude_vector`, `w_norm`, `b_norm`)
- non-LoRA weight-adapter types
- LoRA reshape metadata
- sliced/offset/transformed adapter targets
- non-default `strength_model` patch semantics

DoRA is checked both from raw file keys and from the constructed adapter object. Current ComfyUI bypass LoRA math evaluates the additive low-rank path but does not apply DoRA magnitude normalization, so treating DoRA as ordinary runtime LoRA would change its mathematics.

The loader also fails closed if adapters were captured but the parent loader returns an output shape that cannot accept the resulting injections.

## Validation

Automated validation includes:

- package/wheel build
- Python compilation
- frontend JavaScript syntax checks
- compatibility/runtime tests against pinned ComfyUI v0.29.2, v0.30.2, and v0.31.1 revisions
- explicit pinned CPU PyTorch-family versions with version reporting for reproducible matrix runs
- default-OFF and cache invalidation behavior
- bounded multi-LoRA DoRA-preflight caching
- standard adapter capture without materialization
- non-adapter fallback behavior
- DoRA/reshape/offset rejection
- stacked-LoRA additive equivalence
- repeated injection/ejection and clean forward restoration
- end-to-end interception through a cloned fake ModelPatcher
- fail-closed behavior when captured adapters cannot be injected

Manual MiniMax-H3 testing on the 96 GB RTX PRO 6000 Blackwell also confirms the intended VRAM behavior. The previous model-sized LoRA duplication disappears. After the one-time HIGH_VRAM residency change in the test workflow, repeated LoRA strength changes peaked around **72.65 GiB** and returned to the same **59.55 GiB** settled live-allocation baseline instead of accumulating on each change. A Turbo LoRA also remained visibly effective in runtime mode.

## Release / packaging

This PR prepares **v1.0.39** and adds the same class of CI/release infrastructure used by Spectrum MiniMax H3:

- `.comfyignore` excludes development-only `.github/` and `tests/` content from Comfy Registry archives;
- `tests.yml` runs package/frontend validation plus the pinned ComfyUI compatibility matrix;
- a successful `tests` push run on `main` gates the GitHub release workflow;
- the GitHub release contains `ComfyUI-DoRA-Dynamic-LoRA-Loader-v1.0.39.zip` plus `SHA256SUMS` and uses `RELEASE_NOTES.md`;
- release reruns are idempotent only when an existing `v1.0.39` release targets the exact tested commit; a conflicting tag/release fails instead of silently succeeding;
- Comfy Registry publishing remains handled by the pinned `publish-node-action` workflow.
