### PR TITLE
Diagnose missing Power LoRA frontend UI in-node

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,23 @@ jobs:
           node-version: "22"
 
       - name: Compile Python sources
-        run: python -m py_compile __init__.py nodes.py runtime_bypass.py
+        run: python -m py_compile __init__.py nodes.py runtime_bypass.py frontend_guard.py
+
+      - name: Verify required frontend assets and registry includes
+        shell: bash
+        run: |
+          test -s web/dora_power_lora_loader.js
+          test -s web/index.js
+          python - <<'PY'
+          import pathlib
+          import tomllib
+
+          config = tomllib.loads(pathlib.Path("pyproject.toml").read_text(encoding="utf-8"))
+          includes = set(config.get("tool", {}).get("comfy", {}).get("includes", []))
+          missing = {"frontend_guard.py", "web"} - includes
+          if missing:
+              raise SystemExit(f"Missing required Comfy Registry include(s): {sorted(missing)}")
+          PY
 
       - name: Check frontend JavaScript syntax
         shell: bash

--- a/__init__.py
+++ b/__init__.py
@@ -1,5 +1,5 @@
+from .frontend_guard import FrontendGuardDoraPowerLoraLoader
 from .nodes import DoraStateManager, StateManager, StateManagerSeed, StateManagerTextBox
-from .runtime_bypass import RuntimeBypassDoraPowerLoraLoader
 
 # Backend API for frontend LoRA dropdown (avoids relying on /object_info variants).
 import folder_paths
@@ -17,7 +17,7 @@ async def dora_dynamic_lora_list_loras(request):
 WEB_DIRECTORY = "./web"
 
 NODE_CLASS_MAPPINGS = {
-    "DoRA Power LoRA Loader": RuntimeBypassDoraPowerLoraLoader,
+    "DoRA Power LoRA Loader": FrontendGuardDoraPowerLoraLoader,
     "State Manager": StateManager,
     "State Manager Text Box": StateManagerTextBox,
     "State Manager Seed": StateManagerSeed,
@@ -32,3 +32,5 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "State Manager Seed": "State Seed",
     "DoRA State Manager": "State Manager (legacy)",
 }
+
+__all__ = ["NODE_CLASS_MAPPINGS", "NODE_DISPLAY_NAME_MAPPINGS", "WEB_DIRECTORY"]

--- a/frontend_guard.py
+++ b/frontend_guard.py
@@ -1,0 +1,53 @@
+"""Backend-visible diagnostic for a missing/disabled custom frontend extension.
+
+The DoRA Power LoRA Loader's LoRA rows and Add LoRA control are constructed by
+``web/dora_power_lora_loader.js``. If that frontend extension is disabled,
+missing from the installation, or otherwise not executed, ComfyUI falls back to
+rendering the raw backend inputs. That state is functional enough to expose the
+node, but it has no way to create LoRA rows.
+
+This wrapper prepends one ordinary optional STRING widget explaining the failure
+mode. The normal frontend rebuild removes all backend widgets before drawing the
+real loader UI, so the diagnostic is visible only when the frontend enhancement
+has not taken over.
+"""
+
+from __future__ import annotations
+
+from .runtime_bypass import RuntimeBypassDoraPowerLoraLoader
+
+
+FRONTEND_STATUS_INPUT = "frontend_ui_status"
+FRONTEND_STATUS_MESSAGE = (
+    "LoRA UI frontend is not active. Enable "
+    "'comfyui_dora_dynamic_lora.power_lora_loader' in Settings > Extensions, "
+    "then reload ComfyUI. If that extension is not listed, reinstall/update this "
+    "custom node and verify that its web/ folder is present."
+)
+
+
+class FrontendGuardDoraPowerLoraLoader(RuntimeBypassDoraPowerLoraLoader):
+    """Expose a self-diagnostic widget when the JavaScript UI is unavailable."""
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        inputs = super().INPUT_TYPES()
+        optional = dict(inputs.get("optional") or {})
+
+        guarded = dict(inputs)
+        guarded["optional"] = {
+            FRONTEND_STATUS_INPUT: (
+                "STRING",
+                {
+                    "default": FRONTEND_STATUS_MESSAGE,
+                    "multiline": True,
+                    "tooltip": (
+                        "This message should disappear when the DoRA Power LoRA Loader "
+                        "frontend extension is running. If it is visible, the dynamic "
+                        "LoRA rows and Add LoRA control cannot be created by the browser UI."
+                    ),
+                },
+            ),
+            **optional,
+        }
+        return guarded

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,4 +13,4 @@ Documentation = "https://github.com/xmarre/ComfyUI-DoRA-Dynamic-LoRA-Loader#read
 PublisherId = "xmarre"
 DisplayName = "ComfyUI-DoRA-Dynamic-LoRA-Loader"
 Icon = ""
-includes = ["__init__.py", "nodes.py", "runtime_bypass.py", "web"]
+includes = ["__init__.py", "nodes.py", "runtime_bypass.py", "frontend_guard.py", "web"]

--- a/tests/test_frontend_guard.py
+++ b/tests/test_frontend_guard.py
@@ -1,0 +1,44 @@
+import importlib.util
+import os
+import pathlib
+import sys
+
+
+def _load_frontend_guard_module(dora_modules):
+    # dora_modules creates the synthetic package and loads nodes/runtime_bypass
+    # without executing the custom-node __init__.py (which needs PromptServer).
+    dora_modules
+    root = pathlib.Path(
+        os.environ.get("DORA_REPO_ROOT", pathlib.Path(__file__).resolve().parents[1])
+    ).resolve()
+    package_name = "dora_loader_testpkg"
+    full_name = f"{package_name}.frontend_guard"
+
+    existing = sys.modules.get(full_name)
+    if existing is not None:
+        return existing
+
+    spec = importlib.util.spec_from_file_location(full_name, root / "frontend_guard.py")
+    if spec is None or spec.loader is None:
+        raise RuntimeError("Could not build import spec for frontend_guard.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[full_name] = module
+    setattr(sys.modules[package_name], "frontend_guard", module)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_frontend_guard_explains_missing_dynamic_lora_ui(dora_modules):
+    guard = _load_frontend_guard_module(dora_modules)
+    inputs = guard.FrontendGuardDoraPowerLoraLoader.INPUT_TYPES()
+    optional = inputs["optional"]
+
+    assert next(iter(optional)) == guard.FRONTEND_STATUS_INPUT
+    assert "runtime_bypass_lora" in optional
+
+    kind, options = optional[guard.FRONTEND_STATUS_INPUT]
+    assert kind == "STRING"
+    assert options["multiline"] is True
+    assert "Settings > Extensions" in options["default"]
+    assert "comfyui_dora_dynamic_lora.power_lora_loader" in options["default"]
+    assert "web/" in options["default"]


### PR DESCRIPTION
## Summary

The screenshot is the loader's **raw backend form**: Python loaded successfully, but `web/dora_power_lora_loader.js` did not take over the node. The `None` LoRA row and `add_lora` control are created by that frontend extension, so they cannot exist in this state.

This is not a Nodes 2.0 requirement and there is no rgthree/Power LoRA prerequisite. The frontend extension itself must be active.

## Root cause / failure mode

The loader currently has an asymmetric failure mode:

- backend custom node loads -> ComfyUI can create `DoRA Power LoRA Loader` and shows all raw optional inputs;
- frontend extension is disabled, absent from the install, or not executed -> the dynamic LoRA UI never replaces those raw widgets;
- the resulting node looks valid but has no `None` row or `add_lora`, which makes the missing frontend easy to misdiagnose as a feature/prerequisite issue.

The most direct thing for the affected user to check is **Settings -> Extensions** and make sure `comfyui_dora_dynamic_lora.power_lora_loader` is enabled, then reload. If that extension is not listed, the installed package is missing/not serving the `web/` frontend files and should be reinstalled/updated. A frontend dev-server session is another known case where custom-node JS extensions are not loaded.

## Changes

- add `FrontendGuardDoraPowerLoraLoader`, a thin wrapper around the existing runtime-bypass loader;
- prepend a backend-visible `frontend_ui_status` diagnostic explaining exactly what to enable/reinstall;
- keep normal behavior unchanged: `dora_power_lora_loader.js` already removes all backend widgets before rebuilding the real UI, so the diagnostic disappears whenever the frontend is healthy;
- explicitly export `WEB_DIRECTORY` through `__all__`;
- include the new guard module in Registry packaging metadata;
- make CI fail if the required Power LoRA frontend assets are missing or the Registry include set stops carrying the guard/web directory;
- add a compatibility test that verifies the guard remains first, preserves `runtime_bypass_lora`, and contains the actionable extension/path information.

## Regression considerations

- execution behavior is unchanged; the guard is an optional string consumed only as an ignored `**kwargs` entry when the frontend is unavailable;
- existing LoRA/state serialization remains on the existing `dora_power_lora` properties path;
- normal frontend rebuild still removes the complete backend widget list before constructing LoRA rows and globals;
- existing workflows keep the same public node mapping name (`DoRA Power LoRA Loader`).

## Validation

CI is expected to run the existing package/frontend checks and the pinned ComfyUI v0.29.2 / v0.30.2 / v0.31.1 compatibility matrix. This PR does not claim runtime validation until those checks complete.