### PR TITLE
Fix loader state resets across workflow reconfiguration

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,6 +39,9 @@ jobs:
             node --check "${file}"
           done < <(find web -type f -name '*.js' -print0)
 
+      - name: Run frontend persistence regression tests
+        run: node --test tests/test_frontend_state_persistence.mjs
+
       - name: Build package wheel
         run: |
           python -m pip install --upgrade pip

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,56 +1,54 @@
-# DoRA Dynamic LoRA Loader v1.0.39
+# DoRA Dynamic LoRA Loader v1.0.40
 
-This release adds an opt-in runtime LoRA path that avoids the large persistent VRAM cost of materializing standard LoRA patches on very large HIGH_VRAM models. It also adds reproducible CI, Comfy Registry packaging exclusions, and automated GitHub release infrastructure.
+This release fixes DoRA Power LoRA Loader settings appearing to reset when switching away from a ComfyUI workflow tab and returning to it on newer store-backed ComfyUI frontends.
 
-## Runtime bypass LoRA
+## Workflow-tab state restoration fix
 
-- Adds `Runtime bypass LoRA (low VRAM)` to the DoRA Power LoRA Loader.
-- Keeps the option **OFF by default**, so existing workflows retain the previous materialized-weight behavior.
-- For supported standard LoRAs, runtime bypass preserves the intended LoRA transformation while changing how it is executed: the normal path evaluates `(W + ΔW)x`, while runtime bypass keeps `W` untouched and evaluates `Wx + ΔWx` during the forward pass.
-- Avoids retaining a full materialized LoRA-patched copy of all targeted base weights.
-- Supports multiple stacked LoRAs on the same module with state-aware, reverse-order hook removal.
-- Strength changes update the runtime adapter multiplier instead of requiring the full base-weight set to be rematerialized.
-- Non-adapter patches retain normal ComfyUI materialized patch semantics and are reported in the log.
+The affected loader could restore its saved workflow state correctly while still displaying bootstrap/default widget values after graph reconstruction. This was most visible with settings such as:
 
-## Correctness safeguards
+- `auto_strength_enabled`
+- `auto_strength_device`
+- `auto_strength_ratio_floor`
+- `auto_strength_ratio_ceiling`
+- other loader-global controls and the loader state slot
 
-Runtime bypass deliberately fails closed whenever the supported forward-pass path cannot reproduce the normal patch semantics.
+A browser lifecycle trace confirmed that edited values were present in the outgoing workflow serialization and arrived intact in the returning node's `configure()` call. The canonical `properties.dora_power_lora` state and live `_doraGlobals` were also correct after restore. Only the visible standard widget facade remained at its defaults.
 
-It refuses:
+## Root cause
 
-- DoRA magnitude scaling (`dora_scale`, PEFT/Diffusers `lora_magnitude_vector`, `w_norm`, `b_norm`)
-- non-LoRA weight-adapter types
-- reshape metadata
-- sliced, offset, or transformed adapter targets
-- non-default `strength_model` patch semantics
+Current ComfyUI frontends back standard widget values with `WidgetValueStore`. Widgets are registered by graph ID, node ID, widget name, and type.
 
-DoRA is checked from raw file keys before application and again from the constructed adapter object. Unsupported files produce an explicit error instead of silently changing their mathematical meaning.
+The DoRA Power LoRA Loader dynamically rebuilds its widgets. A freshly created node first builds bootstrap widgets, then workflow `configure()` restores the real loader state and rebuilds the same widget names. On the newer frontend, recreating a same-name/same-type widget can reconnect it to the already-registered bootstrap store entry instead of adopting the restored `addWidget(..., initialValue)` value.
 
-The injection lifecycle is also state-aware: partial injection rollback, repeated ejection, and stacked wrappers cannot restore a stale module `forward`. Runtime mode also fails closed if adapters were captured but the parent loader returns an output shape that cannot accept the resulting injections.
+That produced the misleading state where the loader internally held the correct workflow values but the UI continued to show defaults.
 
-## MiniMax-H3 VRAM validation
+## Fix
 
-The original HIGH_VRAM trace showed 208 LoRA-targeted MiniMax-H3 weights retaining exactly one additional BF16-sized live allocation each, totaling about **38,220 MiB** of extra live VRAM before inference.
+- Keeps `properties.dora_power_lora` as the authoritative workflow representation for the loader.
+- Keeps `_doraRows` / `_doraGlobals` as the loader-owned live state.
+- Disables generic LiteGraph widget workflow serialization for this dynamic loader so `widgets_values` / `widgets_values_named` cannot become competing persistent state stores.
+- Synchronizes dynamically recreated known loader widgets back to the canonical property-backed value after frontend widget registration.
+- Performs one deterministic post-`configure()` reconciliation of attached known widgets.
+- Does not use timeout-based repair loops.
+- Keeps `widgets_values_named` and positional `widgets_values` only as migration inputs when canonical state is absent.
+- Preserves legacy workflow compatibility, partial reconfiguration, null-state recovery, LoRA rows, and state-slot persistence.
 
-With runtime bypass enabled in the tested MiniMax-H3 workflow:
+## Validation
 
-- that model-sized materialized LoRA duplication disappeared;
-- repeated LoRA strength changes peaked in the low-70-GiB range and returned to the same settled live-allocation baseline afterward instead of accumulating on each change;
-- a Turbo LoRA remained visibly effective in runtime mode.
+The final fix was verified in the real browser reproduction that previously failed repeatedly: after changing non-default auto-strength values, switching to another workflow, and switching back, the settings now remain correct.
 
-Small floating-point differences from the merged path are still possible because the operations are executed separately and may follow a different dtype/order path.
+Regression coverage includes:
 
-## Testing and release automation
+- canonical loader state surviving a workflow-tab round trip;
+- bootstrap defaults never overriding incoming canonical state;
+- canonical state beating conflicting stale named-widget data;
+- store-backed same-name widget reconstruction being forced back to canonical floor, ceiling, device, and state-slot values;
+- stale widget facades not overwriting loader-owned state during serialization;
+- legacy named/positional migration;
+- partial configure and `dora_power_lora: null` recovery.
 
-- Adds package/wheel validation, Python compilation, and frontend JavaScript syntax checks.
-- Adds compatibility/runtime-bypass tests against pinned ComfyUI v0.29.2, v0.30.2, and v0.31.1 revisions with explicit CPU PyTorch-family pins and version reporting.
-- Tests cover default-off behavior, cache invalidation, bounded multi-LoRA preflight caching, DoRA/reshape/offset rejection, non-adapter fallback behavior, standard adapter capture without materialization, stacked-LoRA additive equivalence, repeated hook injection/ejection, cloned-patcher interception end to end, and fail-closed unsupported loader output.
-- Adds `.comfyignore` so development-only `.github/` and `tests/` content is not shipped in Comfy Registry archives.
-- Adds an automated GitHub release workflow gated on a successful `tests` run from `main`.
-- GitHub releases contain a versioned repository ZIP and `SHA256SUMS` manifest and use this file as the release notes.
-- Existing release tags are accepted only for an exact same-commit rerun; a conflicting existing tag fails the release rather than silently reporting success.
-- Aligns Comfy Registry publishing with the pinned action revisions used by Spectrum MiniMax H3.
+The existing compatibility/runtime test matrix remains green against pinned ComfyUI v0.29.2, v0.30.2, and v0.31.1 revisions.
 
 ## Compatibility
 
-Runtime bypass is opt-in. With it disabled, the loader continues through the existing LoRA/DoRA path. State Manager behavior, existing loader globals, Flux/Flux2 compatibility handling, ZiT/Lumina2 normalization, DoRA fixes, and auto-strength remain on their existing path.
+No workflow migration is required. Existing workflows continue to use the same node and state format. The widget-store synchronization is narrowly scoped to the DoRA Power LoRA Loader; on older LiteGraph/frontends without the newer store behavior it reduces to assigning the widget the canonical value it was already intended to have.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "dora-dynamic-lora-loader"
 description = "A ComfyUI custom node that loads and stacks regular LoRAs and DoRA LoRAs with Flux/Flux2 and OneTrainer compatibility fixes."
-version = "1.0.39"
+version = "1.0.40"
 license = { file = "LICENSE" }
 
 [project.urls]

--- a/tests/test_frontend_state_persistence.mjs
+++ b/tests/test_frontend_state_persistence.mjs
@@ -102,15 +102,6 @@ function makeNodeType() {
   class FakeNode {}
   FakeNode.comfyClass = NODE_CLASS;
 
-  FakeNode.prototype.addWidget = function (type, name, value, callback, options = {}) {
-    const widget = { type, name, value: clone(value), callback, options };
-    this.widgets ??= [];
-    this.widgets.push(widget);
-    return widget;
-  };
-
-  // Model the loader bootstrap: a fresh graph node owns default controls and
-  // default live state before configure() receives workflow data.
   FakeNode.prototype.onNodeCreated = function () {
     this.serialize_widgets = true;
     this.properties = {
@@ -154,8 +145,6 @@ function makeNodeType() {
     output.widgets_values = [];
   };
 
-  // Relevant LiteGraph ordering: generic widget values are captured before the
-  // onSerialize hook, but only when serialize_widgets remains enabled.
   FakeNode.prototype.serialize = function () {
     const output = { properties: clone(this.properties || {}) };
     if (this.serialize_widgets && Array.isArray(this.widgets)) {
@@ -184,13 +173,17 @@ async function patchedNodeType() {
 
 function makeFreshNode(NodeType) {
   const node = new NodeType();
+  node.addWidget = function (_type, name, value) {
+    const widget = { name, value: clone(value) };
+    this.widgets ||= [];
+    this.widgets.push(widget);
+    return widget;
+  };
   node.onNodeCreated();
   return node;
 }
 
 function applyUserState(node, state, slot = "loader_42", { staleWidgetFacade = false } = {}) {
-  // Model the actual loader callbacks: _doraRows/_doraGlobals are updated and
-  // persistNodeState mirrors them into dora_power_lora immediately.
   node._doraRows = clone(state.rows);
   node._doraGlobals = clone(state.globals);
   node.properties.dora_power_lora = clone(state);
@@ -256,8 +249,6 @@ test("#14897-style one-shot tab round trip preserves loader state", async () => 
   const outgoing = makeFreshNode(NodeType);
   applyUserState(outgoing, edited, "roundtrip_slot");
 
-  // PR #14897 relies on this synchronous graph serialization before replacing
-  // the canvas rather than a later debounced draft flush.
   const frozenWorkflowNode = outgoing.serialize();
   assert.deepEqual(frozenWorkflowNode.properties.dora_power_lora, edited);
   assert.equal(frozenWorkflowNode.properties.dora_state_slot, "roundtrip_slot");
@@ -273,31 +264,6 @@ test("#14897-style one-shot tab round trip preserves loader state", async () => 
   assert.equal(restored.properties.dora_state_slot, "roundtrip_slot");
 });
 
-test("recreated same-name widgets are forced to canonical values after frontend registration", async () => {
-  const NodeType = await patchedNodeType();
-  const saved = customState("widget-store.safetensors");
-  saved.globals.auto_strength_device = "auto";
-  saved.globals.auto_strength_ratio_floor = 0.95;
-  saved.globals.auto_strength_ratio_ceiling = 2.0;
-  const node = makeFreshNode(NodeType);
-  node.configure({ properties: { dora_power_lora: clone(saved), dora_state_slot: "store_slot" } });
-
-  // Model the #14897-era WidgetValueStore behavior observed in the browser:
-  // addWidget receives a stale/default initial value for a same-name widget.
-  // The persistence shim must overwrite the returned widget with the canonical
-  // property-backed value after frontend registration.
-  node.widgets = [];
-  const floor = node.addWidget("number", "auto_strength_ratio_floor", 0.30, () => {});
-  const ceiling = node.addWidget("number", "auto_strength_ratio_ceiling", 1.50, () => {});
-  const device = node.addWidget("combo", "auto_strength_device", "gpu", () => {});
-  const slot = node.addWidget("text", "state_slot", "loader_default", () => {});
-
-  assert.equal(floor.value, 0.95);
-  assert.equal(ceiling.value, 2.0);
-  assert.equal(device.value, "auto");
-  assert.equal(slot.value, "store_slot");
-});
-
 test("stale frontend widget facade cannot overwrite callback-owned live state", async () => {
   const NodeType = await patchedNodeType();
   const edited = customState("live-wins.safetensors");
@@ -306,15 +272,86 @@ test("stale frontend widget facade cannot overwrite callback-owned live state", 
   edited.globals.auto_strength_ratio_ceiling = 2.11;
   const node = makeFreshNode(NodeType);
 
-  // This models an alternate/new frontend renderer where the visual/widget
-  // facade still exposes bootstrap defaults even though the loader callbacks
-  // already updated _doraGlobals and dora_power_lora.
   applyUserState(node, edited, "live_slot", { staleWidgetFacade: true });
   const output = node.serialize();
 
   assert.deepEqual(output.properties.dora_power_lora, edited);
   assert.deepEqual(node.properties.dora_power_lora, edited);
   assert.equal(output.properties.dora_state_slot, "live_slot");
+});
+
+test("store-backed recreated widgets are synchronized to canonical state", async () => {
+  const extension = await loadPersistenceExtension();
+
+  class StoreBackedNode {}
+  StoreBackedNode.comfyClass = NODE_CLASS;
+
+  StoreBackedNode.prototype.onNodeCreated = function () {
+    this.serialize_widgets = true;
+    this.properties = {
+      dora_power_lora: clone(DEFAULT_STATE),
+      dora_state_slot: "loader_default",
+    };
+    this._doraRows = clone(DEFAULT_STATE.rows);
+    this._doraGlobals = clone(DEFAULT_STATE.globals);
+    this.widgets = [];
+    this.addWidget("number", "auto_strength_ratio_floor", 0.30);
+    this.addWidget("number", "auto_strength_ratio_ceiling", 1.50);
+    this.addWidget("combo", "auto_strength_device", "gpu");
+    this.addWidget("text", "state_slot", "loader_default");
+    return this;
+  };
+
+  StoreBackedNode.prototype.configure = function (info) {
+    const state = clone(info.properties.dora_power_lora);
+    this.properties = { ...(this.properties || {}), ...(info.properties || {}) };
+    this._doraRows = clone(state.rows);
+    this._doraGlobals = clone(state.globals);
+    this.widgets = [];
+    this.addWidget("number", "auto_strength_ratio_floor", 0.30);
+    this.addWidget("number", "auto_strength_ratio_ceiling", 1.50);
+    this.addWidget("combo", "auto_strength_device", "gpu");
+    this.addWidget("text", "state_slot", "loader_default");
+    return this;
+  };
+
+  await extension.beforeRegisterNodeDef(StoreBackedNode, { name: NODE_CLASS, display_name: NODE_CLASS });
+
+  const node = new StoreBackedNode();
+  node.widgets = [];
+  node.addWidget = function (_type, name, value) {
+    const staleDefaults = {
+      auto_strength_ratio_floor: 0.30,
+      auto_strength_ratio_ceiling: 1.50,
+      auto_strength_device: "gpu",
+      state_slot: "loader_default",
+    };
+    const widget = {
+      name,
+      value: Object.prototype.hasOwnProperty.call(staleDefaults, name) ? staleDefaults[name] : value,
+    };
+    this.widgets.push(widget);
+    return widget;
+  };
+
+  node.onNodeCreated();
+
+  const saved = customState("store-backed.safetensors");
+  saved.globals.auto_strength_device = "auto";
+  saved.globals.auto_strength_ratio_floor = 0.95;
+  saved.globals.auto_strength_ratio_ceiling = 2.0;
+  node.configure({
+    properties: {
+      dora_power_lora: clone(saved),
+      dora_state_slot: "store_slot",
+    },
+  });
+
+  const byName = Object.fromEntries(node.widgets.map((widget) => [widget.name, widget.value]));
+  assert.equal(byName.auto_strength_ratio_floor, 0.95);
+  assert.equal(byName.auto_strength_ratio_ceiling, 2.0);
+  assert.equal(byName.auto_strength_device, "auto");
+  assert.equal(byName.state_slot, "store_slot");
 });
 
 test("named widget workflow data is accepted only when canonical state is absent", async () => {

--- a/tests/test_frontend_state_persistence.mjs
+++ b/tests/test_frontend_state_persistence.mjs
@@ -157,6 +157,28 @@ test("named widget-only workflow data migrates into authoritative loader state",
   assert.equal(node.lastConfigureInfo.widgets_values_named, undefined);
 });
 
+test("named global recovery preserves live LoRA rows when custom row values are absent", async () => {
+  const NodeType = await patchedNodeType();
+  const live = customState("keep-this-row.safetensors");
+  const node = makeNode(NodeType, live);
+
+  node.configure({
+    widgets_values_named: {
+      auto_strength_enabled: true,
+      auto_strength_device: "auto",
+      auto_strength_ratio_floor: 0.52,
+      auto_strength_ratio_ceiling: 1.74,
+    },
+  });
+
+  const state = node.properties.dora_power_lora;
+  assert.deepEqual(state.rows, live.rows);
+  assert.equal(state.globals.auto_strength_device, "auto");
+  assert.equal(state.globals.auto_strength_ratio_floor, 0.52);
+  assert.equal(state.globals.auto_strength_ratio_ceiling, 1.74);
+  assert.equal(state.globals.broadcast_scale, live.globals.broadcast_scale);
+});
+
 test("explicit serialized state remains authoritative over named widget shadows", async () => {
   const NodeType = await patchedNodeType();
   const node = makeNode(NodeType, customState("live.safetensors"));

--- a/tests/test_frontend_state_persistence.mjs
+++ b/tests/test_frontend_state_persistence.mjs
@@ -18,71 +18,6 @@ function clone(value) {
   return JSON.parse(JSON.stringify(value));
 }
 
-async function loadPersistenceExtension() {
-  const sourceUrl = new URL("../web/dora_power_lora_persistence.js", import.meta.url);
-  let source = await readFile(sourceUrl, "utf8");
-  let extension = null;
-  globalThis.__doraPersistenceTestApp = {
-    registerExtension(value) {
-      extension = value;
-    },
-  };
-  source = source.replace(
-    'import { app } from "../../scripts/app.js";',
-    "const app = globalThis.__doraPersistenceTestApp;"
-  );
-  const encoded = Buffer.from(source, "utf8").toString("base64");
-  await import(`data:text/javascript;base64,${encoded}#${Date.now()}-${Math.random()}`);
-  delete globalThis.__doraPersistenceTestApp;
-  assert.ok(extension, "persistence extension should register");
-  return extension;
-}
-
-function makeNodeType() {
-  class FakeNode {}
-  FakeNode.comfyClass = NODE_CLASS;
-
-  // Model the loader's existing configure contract: a configure call without
-  // dora_power_lora or legacy positional values falls back to defaults.
-  FakeNode.prototype.configure = function (info) {
-    this.lastConfigureInfo = info;
-    let state;
-    if (info?.properties?.dora_power_lora) {
-      state = clone(info.properties.dora_power_lora);
-    } else if (Array.isArray(info?.widgets_values) && info.widgets_values.length) {
-      state = {
-        rows: [{ enabled: true, name: "legacy.safetensors", strengthModel: 0.7, strengthClip: 0.7 }],
-        globals: { stack_enabled: true, migrated_from_legacy_widgets: true },
-      };
-    } else {
-      state = clone(DEFAULT_STATE);
-    }
-
-    this.properties = { ...(this.properties || {}), ...(info?.properties || {}) };
-    this.properties.dora_power_lora = clone(state);
-    this._doraRows = clone(state.rows);
-    this._doraGlobals = clone(state.globals);
-    return this;
-  };
-
-  // Model the loader's existing serializer. Current LiteGraph has already
-  // populated widgets_values_named before this hook executes.
-  FakeNode.prototype.onSerialize = function (output) {
-    output.properties = { ...(output.properties || {}) };
-    output.properties.dora_power_lora = clone(this.properties.dora_power_lora);
-    output.widgets_values = [];
-  };
-
-  return FakeNode;
-}
-
-async function patchedNodeType() {
-  const extension = await loadPersistenceExtension();
-  const NodeType = makeNodeType();
-  await extension.beforeRegisterNodeDef(NodeType, { name: NODE_CLASS, display_name: NODE_CLASS });
-  return NodeType;
-}
-
 function customState(name = "custom.safetensors") {
   return {
     rows: [{ enabled: true, name, strengthModel: 0.85, strengthClip: 0.65 }],
@@ -106,6 +41,7 @@ function makeVisibleWidgets(state, slot = "loader_42") {
     {
       name: "LORA_1",
       row: clone(state.rows[0]),
+      value: null,
       serializeValue() {
         const row = this.row;
         return {
@@ -135,8 +71,6 @@ function makeNamedWidgetSnapshot(state, slot = "loader_42", { includeRow = false
       strengthTwo: row.strengthClip,
     };
   } else {
-    // Current LiteGraph stores widget.value in named workflow state. The custom
-    // LoRA row has no value property, so it commonly serializes as null here.
     named.LORA_1 = null;
   }
   Object.assign(named, clone(state.globals));
@@ -144,165 +78,265 @@ function makeNamedWidgetSnapshot(state, slot = "loader_42", { includeRow = false
   return named;
 }
 
-function makeNode(NodeType, state = customState(), { widgets = true } = {}) {
-  const node = new NodeType();
-  node.properties = {
-    dora_power_lora: clone(state),
-    dora_state_slot: "loader_42",
+async function loadPersistenceExtension() {
+  const sourceUrl = new URL("../web/dora_power_lora_persistence.js", import.meta.url);
+  let source = await readFile(sourceUrl, "utf8");
+  let extension = null;
+  globalThis.__doraPersistenceTestApp = {
+    registerExtension(value) {
+      extension = value;
+    },
   };
-  node._doraRows = clone(state.rows);
-  node._doraGlobals = clone(state.globals);
-  node.widgets = widgets ? makeVisibleWidgets(state) : [];
+  source = source.replace(
+    'import { app } from "../../scripts/app.js";',
+    "const app = globalThis.__doraPersistenceTestApp;"
+  );
+  const encoded = Buffer.from(source, "utf8").toString("base64");
+  await import(`data:text/javascript;base64,${encoded}#${Date.now()}-${Math.random()}`);
+  delete globalThis.__doraPersistenceTestApp;
+  assert.ok(extension, "persistence extension should register");
+  return extension;
+}
+
+function makeNodeType() {
+  class FakeNode {}
+  FakeNode.comfyClass = NODE_CLASS;
+
+  // Model the loader's onNodeCreated bootstrap: dynamic controls exist with
+  // defaults before workflow configure() restores a serialized node.
+  FakeNode.prototype.onNodeCreated = function () {
+    this.serialize_widgets = true;
+    this.properties = {
+      dora_power_lora: clone(DEFAULT_STATE),
+      dora_state_slot: "loader_default",
+    };
+    this._doraRows = clone(DEFAULT_STATE.rows);
+    this._doraGlobals = clone(DEFAULT_STATE.globals);
+    this.widgets = makeVisibleWidgets(DEFAULT_STATE, "loader_default");
+    return this;
+  };
+
+  // Model the existing loader configure contract.
+  FakeNode.prototype.configure = function (info) {
+    this.lastConfigureInfo = clone(info ?? {});
+    let state;
+    if (info?.properties?.dora_power_lora) {
+      state = clone(info.properties.dora_power_lora);
+    } else if (Array.isArray(info?.widgets_values) && info.widgets_values.length) {
+      state = {
+        rows: [{ enabled: true, name: "legacy.safetensors", strengthModel: 0.7, strengthClip: 0.7 }],
+        globals: { stack_enabled: true, migrated_from_legacy_widgets: true },
+      };
+    } else {
+      state = clone(DEFAULT_STATE);
+    }
+
+    this.properties = { ...(this.properties || {}), ...(info?.properties || {}) };
+    this.properties.dora_power_lora = clone(state);
+    this._doraRows = clone(state.rows);
+    this._doraGlobals = clone(state.globals);
+    this.widgets = makeVisibleWidgets(
+      state,
+      this.properties.dora_state_slot || "loader_default"
+    );
+    return this;
+  };
+
+  // Model the loader's existing onSerialize hook.
+  FakeNode.prototype.onSerialize = function (output) {
+    output.properties = { ...(output.properties || {}) };
+    output.properties.dora_power_lora = clone(this.properties.dora_power_lora);
+    output.widgets_values = [];
+  };
+
+  // Model the relevant current LiteGraph serialize ordering: generic widget
+  // serialization happens before onSerialize(), and is skipped when
+  // serialize_widgets is false.
+  FakeNode.prototype.serialize = function () {
+    const output = { properties: clone(this.properties || {}) };
+    if (this.serialize_widgets && Array.isArray(this.widgets)) {
+      output.widgets_values = [];
+      output.widgets_values_named = {};
+      this.widgets.forEach((widget, index) => {
+        if (widget.serialize === false) return;
+        const value = widget.value ?? null;
+        output.widgets_values[index] = clone(value);
+        output.widgets_values_named[widget.name] = clone(value);
+      });
+    }
+    this.onSerialize(output);
+    return output;
+  };
+
+  return FakeNode;
+}
+
+async function patchedNodeType() {
+  const extension = await loadPersistenceExtension();
+  const NodeType = makeNodeType();
+  await extension.beforeRegisterNodeDef(NodeType, { name: NODE_CLASS, display_name: NODE_CLASS });
+  return NodeType;
+}
+
+function makeFreshNode(NodeType) {
+  const node = new NodeType();
+  node.onNodeCreated();
   return node;
 }
 
-test("partial configure preserves current visible loader state", async () => {
+function applyVisibleUserState(node, state, slot = "loader_42") {
+  node._doraRows = clone(state.rows);
+  node._doraGlobals = clone(state.globals);
+  node.widgets = makeVisibleWidgets(state, slot);
+}
+
+test("loader disables generic LiteGraph widget workflow serialization", async () => {
   const NodeType = await patchedNodeType();
-  const expected = customState();
-  const node = makeNode(NodeType, expected);
+  const node = makeFreshNode(NodeType);
+  assert.equal(node.serialize_widgets, false);
+
+  node.configure({ properties: { dora_power_lora: customState(), dora_state_slot: "saved_slot" } });
+  assert.equal(node.serialize_widgets, false);
+
+  const output = node.serialize();
+  assert.equal(Object.prototype.hasOwnProperty.call(output, "widgets_values_named"), false);
+  assert.deepEqual(output.widgets_values, []);
+});
+
+test("fresh bootstrap defaults never override incoming serialized loader state", async () => {
+  const NodeType = await patchedNodeType();
+  const saved = customState("saved.safetensors");
+  saved.globals.auto_strength_device = "auto";
+  saved.globals.auto_strength_ratio_floor = 0.61;
+  saved.globals.auto_strength_ratio_ceiling = 1.94;
+  const node = makeFreshNode(NodeType);
+
+  node.configure({ properties: { dora_power_lora: clone(saved), dora_state_slot: "saved_slot" } });
+
+  assert.deepEqual(node.properties.dora_power_lora, saved);
+  assert.deepEqual(node._doraGlobals, saved.globals);
+  assert.equal(node.properties.dora_state_slot, "saved_slot");
+});
+
+test("workflow-tab round trip preserves visible auto-strength and LoRA state", async () => {
+  const NodeType = await patchedNodeType();
+  const edited = customState("roundtrip.safetensors");
+  edited.globals.auto_strength_enabled = true;
+  edited.globals.auto_strength_device = "auto";
+  edited.globals.auto_strength_ratio_floor = 0.63;
+  edited.globals.auto_strength_ratio_ceiling = 1.92;
+
+  // Active workflow: loader was created, user changed controls, then #14897's
+  // tab transition freezes the graph with one synchronous serialize().
+  const outgoing = makeFreshNode(NodeType);
+  applyVisibleUserState(outgoing, edited, "roundtrip_slot");
+  const frozenWorkflowNode = outgoing.serialize();
+
+  assert.deepEqual(frozenWorkflowNode.properties.dora_power_lora, edited);
+  assert.equal(frozenWorkflowNode.properties.dora_state_slot, "roundtrip_slot");
+  assert.equal(Object.prototype.hasOwnProperty.call(frozenWorkflowNode, "widgets_values_named"), false);
+
+  // Returning to the tab constructs a brand-new loader with defaults first,
+  // then configures it from the workflow's frozen activeState.
+  const restored = makeFreshNode(NodeType);
+  assert.deepEqual(restored._doraGlobals, DEFAULT_STATE.globals);
+  restored.configure(frozenWorkflowNode);
+
+  assert.deepEqual(restored.properties.dora_power_lora, edited);
+  assert.deepEqual(restored._doraGlobals, edited.globals);
+  assert.deepEqual(restored._doraRows, edited.rows);
+  assert.equal(restored.properties.dora_state_slot, "roundtrip_slot");
+});
+
+test("serialization reconciles visible widgets before canonical property output", async () => {
+  const NodeType = await patchedNodeType();
+  const visible = customState("visible-at-save.safetensors");
+  visible.globals.auto_strength_ratio_floor = 0.72;
+  visible.globals.auto_strength_ratio_ceiling = 2.11;
+  const node = makeFreshNode(NodeType);
+
+  // Deliberately leave properties/live globals stale to reproduce a visual
+  // control that is newer than canonical state at the serialization boundary.
+  node.widgets = makeVisibleWidgets(visible, "visible_slot");
+  const output = node.serialize();
+
+  assert.deepEqual(output.properties.dora_power_lora, visible);
+  assert.deepEqual(node.properties.dora_power_lora, visible);
+  assert.equal(output.properties.dora_state_slot, "visible_slot");
+});
+
+test("named widget workflow data is accepted only as migration input", async () => {
+  const NodeType = await patchedNodeType();
+  const migrated = customState("named-migration.safetensors");
+  migrated.globals.auto_strength_device = "auto";
+  migrated.globals.auto_strength_ratio_floor = 0.52;
+  migrated.globals.auto_strength_ratio_ceiling = 1.74;
+  const node = makeFreshNode(NodeType);
+
+  node.configure({
+    widgets_values_named: makeNamedWidgetSnapshot(migrated, "named_slot", { includeRow: true }),
+  });
+
+  assert.deepEqual(node.properties.dora_power_lora, migrated);
+  assert.equal(node.properties.dora_state_slot, "named_slot");
+  assert.equal(node.lastConfigureInfo.widgets_values_named, undefined);
+});
+
+test("named globals can repair stale serialized globals without deleting serialized rows", async () => {
+  const NodeType = await patchedNodeType();
+  const serialized = customState("keep-row.safetensors");
+  serialized.globals = clone(DEFAULT_STATE.globals);
+  const newer = customState("ignored-row.safetensors");
+  newer.globals.auto_strength_ratio_floor = 0.55;
+  newer.globals.auto_strength_ratio_ceiling = 1.88;
+  const node = makeFreshNode(NodeType);
+
+  node.configure({
+    properties: { dora_power_lora: clone(serialized), dora_state_slot: "serialized_slot" },
+    widgets_values_named: makeNamedWidgetSnapshot(newer, "named_slot", { includeRow: false }),
+  });
+
+  assert.deepEqual(node.properties.dora_power_lora.rows, serialized.rows);
+  assert.equal(node.properties.dora_power_lora.globals.auto_strength_enabled, true);
+  assert.equal(node.properties.dora_power_lora.globals.auto_strength_ratio_floor, 0.55);
+  assert.equal(node.properties.dora_power_lora.globals.auto_strength_ratio_ceiling, 1.88);
+  assert.equal(node.properties.dora_state_slot, "named_slot");
+});
+
+test("partial configure preserves existing live state", async () => {
+  const NodeType = await patchedNodeType();
+  const live = customState("partial.safetensors");
+  const node = makeFreshNode(NodeType);
+  node.properties.dora_power_lora = clone(live);
+  node.properties.dora_state_slot = "partial_slot";
+  node._doraRows = clone(live.rows);
+  node._doraGlobals = clone(live.globals);
 
   node.configure({ size: [420, 640] });
 
-  assert.deepEqual(node.properties.dora_power_lora, expected);
-  assert.equal(node.lastConfigureInfo.properties.dora_state_slot, "loader_42");
-  assert.equal(node.lastConfigureInfo.widgets_values_named, undefined);
-});
-
-test("named widget-only workflow data migrates into canonical loader state", async () => {
-  const NodeType = await patchedNodeType();
-  const node = makeNode(NodeType, DEFAULT_STATE);
-  const named = customState("named.safetensors");
-  named.globals.broadcast_scale = 2.25;
-  named.globals.auto_strength_device = "auto";
-  named.globals.auto_strength_ratio_floor = 0.41;
-  named.globals.auto_strength_ratio_ceiling = 1.91;
-
-  node.configure({
-    widgets_values_named: makeNamedWidgetSnapshot(named, "named_slot", { includeRow: true }),
-  });
-
-  const state = node.properties.dora_power_lora;
-  assert.deepEqual(state.rows, named.rows);
-  assert.equal(state.globals.stack_enabled, false);
-  assert.equal(state.globals.broadcast_scale, 2.25);
-  assert.equal(state.globals.auto_strength_enabled, true);
-  assert.equal(state.globals.auto_strength_device, "auto");
-  assert.equal(state.globals.auto_strength_ratio_floor, 0.41);
-  assert.equal(state.globals.auto_strength_ratio_ceiling, 1.91);
-  assert.equal(node.lastConfigureInfo.properties.dora_state_slot, "named_slot");
-  assert.equal(node.lastConfigureInfo.widgets_values_named, undefined);
-});
-
-test("named globals override stale serialized defaults while preserving serialized LoRA rows", async () => {
-  const NodeType = await patchedNodeType();
-  const serialized = customState("keep-serialized-row.safetensors");
-  serialized.globals = clone(DEFAULT_STATE.globals);
-  const node = makeNode(NodeType, DEFAULT_STATE);
-  const visible = customState("ignored-named-row.safetensors");
-  visible.globals.auto_strength_device = "auto";
-  visible.globals.auto_strength_ratio_floor = 0.52;
-  visible.globals.auto_strength_ratio_ceiling = 1.74;
-
-  node.configure({
-    properties: { dora_power_lora: clone(serialized), dora_state_slot: "serialized_slot" },
-    widgets_values_named: makeNamedWidgetSnapshot(visible, "visible_slot", { includeRow: false }),
-  });
-
-  const state = node.properties.dora_power_lora;
-  assert.deepEqual(state.rows, serialized.rows);
-  assert.equal(state.globals.auto_strength_enabled, true);
-  assert.equal(state.globals.auto_strength_device, "auto");
-  assert.equal(state.globals.auto_strength_ratio_floor, 0.52);
-  assert.equal(state.globals.auto_strength_ratio_ceiling, 1.74);
-  assert.equal(node.lastConfigureInfo.properties.dora_state_slot, "visible_slot");
-});
-
-test("named LoRA rows override stale serialized rows when a row snapshot is available", async () => {
-  const NodeType = await patchedNodeType();
-  const serialized = customState("stale-row.safetensors");
-  const visible = customState("visible-row.safetensors");
-  const node = makeNode(NodeType, DEFAULT_STATE);
-
-  node.configure({
-    properties: { dora_power_lora: clone(serialized) },
-    widgets_values_named: makeNamedWidgetSnapshot(visible, "loader_42", { includeRow: true }),
-  });
-
-  assert.deepEqual(node.properties.dora_power_lora.rows, visible.rows);
-  assert.equal(node.properties.dora_power_lora.globals.auto_strength_ratio_floor, visible.globals.auto_strength_ratio_floor);
-});
-
-test("serialized state stays authoritative when no named widget snapshot exists", async () => {
-  const NodeType = await patchedNodeType();
-  const node = makeNode(NodeType, customState("live.safetensors"));
-  const serialized = customState("serialized.safetensors");
-  serialized.globals.auto_strength_ratio_floor = 0.58;
-  serialized.globals.auto_strength_ratio_ceiling = 1.66;
-
-  node.configure({
-    properties: { dora_power_lora: clone(serialized), dora_state_slot: "serialized_slot" },
-  });
-
-  assert.deepEqual(node.properties.dora_power_lora, serialized);
-  assert.equal(node.lastConfigureInfo.properties.dora_state_slot, "serialized_slot");
+  assert.deepEqual(node.properties.dora_power_lora, live);
+  assert.equal(node.properties.dora_state_slot, "partial_slot");
 });
 
 test("null serialized state is treated as missing and recovered", async () => {
   const NodeType = await patchedNodeType();
   const live = customState("recover-null.safetensors");
-  const node = makeNode(NodeType, live);
+  const node = makeFreshNode(NodeType);
+  node.properties.dora_power_lora = clone(live);
+  node._doraRows = clone(live.rows);
+  node._doraGlobals = clone(live.globals);
 
   node.configure({ properties: { dora_power_lora: null } });
 
   assert.deepEqual(node.properties.dora_power_lora, live);
 });
 
-test("legacy positional widget migration is not shadowed by the preservation guard", async () => {
+test("legacy positional widget migration remains available", async () => {
   const NodeType = await patchedNodeType();
-  const node = makeNode(NodeType, customState());
+  const node = makeFreshNode(NodeType);
 
   node.configure({ widgets_values: [true, "legacy.safetensors", 0.7, 0.7, true, false, false] });
 
   assert.equal(node.properties.dora_power_lora.globals.migrated_from_legacy_widgets, true);
   assert.equal(node.properties.dora_power_lora.rows[0].name, "legacy.safetensors");
-});
-
-test("serialization uses visible widget values over stale live globals and properties", async () => {
-  const NodeType = await patchedNodeType();
-  const stale = clone(DEFAULT_STATE);
-  const visible = customState("visible-at-save.safetensors");
-  visible.globals.auto_strength_device = "auto";
-  visible.globals.auto_strength_ratio_floor = 0.63;
-  visible.globals.auto_strength_ratio_ceiling = 1.92;
-  const node = makeNode(NodeType, stale, { widgets: false });
-  node.widgets = makeVisibleWidgets(visible, "visible_slot");
-
-  const output = {
-    properties: { unrelated: "keep" },
-    widgets_values_named: makeNamedWidgetSnapshot(visible, "visible_slot", { includeRow: false }),
-  };
-  node.onSerialize(output);
-
-  assert.deepEqual(output.properties.dora_power_lora, visible);
-  assert.deepEqual(node.properties.dora_power_lora, visible);
-  assert.equal(output.properties.unrelated, "keep");
-  assert.equal(output.properties.dora_state_slot, "visible_slot");
-  assert.equal(node.properties.dora_state_slot, "visible_slot");
-  assert.deepEqual(output.widgets_values, []);
-  assert.equal(Object.prototype.hasOwnProperty.call(output, "widgets_values_named"), false);
-});
-
-test("serialization preserves live LoRA rows when named row value is null", async () => {
-  const NodeType = await patchedNodeType();
-  const live = customState("keep-live-row.safetensors");
-  const node = makeNode(NodeType, live);
-
-  const output = {
-    properties: {},
-    widgets_values_named: makeNamedWidgetSnapshot(live, "loader_42", { includeRow: false }),
-  };
-  node.onSerialize(output);
-
-  assert.deepEqual(output.properties.dora_power_lora.rows, live.rows);
-  assert.equal(output.properties.dora_power_lora.globals.auto_strength_ratio_floor, live.globals.auto_strength_ratio_floor);
 });

--- a/tests/test_frontend_state_persistence.mjs
+++ b/tests/test_frontend_state_persistence.mjs
@@ -102,8 +102,8 @@ function makeNodeType() {
   class FakeNode {}
   FakeNode.comfyClass = NODE_CLASS;
 
-  // Model the loader's onNodeCreated bootstrap: dynamic controls exist with
-  // defaults before workflow configure() restores a serialized node.
+  // Model the loader bootstrap: a fresh graph node owns default controls and
+  // default live state before configure() receives workflow data.
   FakeNode.prototype.onNodeCreated = function () {
     this.serialize_widgets = true;
     this.properties = {
@@ -116,7 +116,6 @@ function makeNodeType() {
     return this;
   };
 
-  // Model the existing loader configure contract.
   FakeNode.prototype.configure = function (info) {
     this.lastConfigureInfo = clone(info ?? {});
     let state;
@@ -142,16 +141,14 @@ function makeNodeType() {
     return this;
   };
 
-  // Model the loader's existing onSerialize hook.
   FakeNode.prototype.onSerialize = function (output) {
     output.properties = { ...(output.properties || {}) };
     output.properties.dora_power_lora = clone(this.properties.dora_power_lora);
     output.widgets_values = [];
   };
 
-  // Model the relevant current LiteGraph serialize ordering: generic widget
-  // serialization happens before onSerialize(), and is skipped when
-  // serialize_widgets is false.
+  // Relevant LiteGraph ordering: generic widget values are captured before the
+  // onSerialize hook, but only when serialize_widgets remains enabled.
   FakeNode.prototype.serialize = function () {
     const output = { properties: clone(this.properties || {}) };
     if (this.serialize_widgets && Array.isArray(this.widgets)) {
@@ -184,10 +181,14 @@ function makeFreshNode(NodeType) {
   return node;
 }
 
-function applyVisibleUserState(node, state, slot = "loader_42") {
+function applyUserState(node, state, slot = "loader_42", { staleWidgetFacade = false } = {}) {
+  // Model the actual loader callbacks: _doraRows/_doraGlobals are updated and
+  // persistNodeState mirrors them into dora_power_lora immediately.
   node._doraRows = clone(state.rows);
   node._doraGlobals = clone(state.globals);
-  node.widgets = makeVisibleWidgets(state, slot);
+  node.properties.dora_power_lora = clone(state);
+  node.properties.dora_state_slot = slot;
+  node.widgets = makeVisibleWidgets(staleWidgetFacade ? DEFAULT_STATE : state, staleWidgetFacade ? "loader_default" : slot);
 }
 
 test("loader disables generic LiteGraph widget workflow serialization", async () => {
@@ -218,7 +219,26 @@ test("fresh bootstrap defaults never override incoming serialized loader state",
   assert.equal(node.properties.dora_state_slot, "saved_slot");
 });
 
-test("workflow-tab round trip preserves visible auto-strength and LoRA state", async () => {
+test("canonical serialized state beats conflicting legacy named defaults", async () => {
+  const NodeType = await patchedNodeType();
+  const saved = customState("canonical.safetensors");
+  saved.globals.auto_strength_device = "auto";
+  saved.globals.auto_strength_ratio_floor = 0.64;
+  saved.globals.auto_strength_ratio_ceiling = 1.97;
+  const node = makeFreshNode(NodeType);
+
+  node.configure({
+    properties: { dora_power_lora: clone(saved), dora_state_slot: "canonical_slot" },
+    widgets_values_named: makeNamedWidgetSnapshot(DEFAULT_STATE, "stale_named_slot", { includeRow: true }),
+  });
+
+  assert.deepEqual(node.properties.dora_power_lora, saved);
+  assert.deepEqual(node._doraGlobals, saved.globals);
+  assert.equal(node.properties.dora_state_slot, "canonical_slot");
+  assert.equal(node.lastConfigureInfo.widgets_values_named, undefined);
+});
+
+test("#14897-style one-shot tab round trip preserves loader state", async () => {
   const NodeType = await patchedNodeType();
   const edited = customState("roundtrip.safetensors");
   edited.globals.auto_strength_enabled = true;
@@ -226,18 +246,16 @@ test("workflow-tab round trip preserves visible auto-strength and LoRA state", a
   edited.globals.auto_strength_ratio_floor = 0.63;
   edited.globals.auto_strength_ratio_ceiling = 1.92;
 
-  // Active workflow: loader was created, user changed controls, then #14897's
-  // tab transition freezes the graph with one synchronous serialize().
   const outgoing = makeFreshNode(NodeType);
-  applyVisibleUserState(outgoing, edited, "roundtrip_slot");
-  const frozenWorkflowNode = outgoing.serialize();
+  applyUserState(outgoing, edited, "roundtrip_slot");
 
+  // PR #14897 relies on this synchronous graph serialization before replacing
+  // the canvas rather than a later debounced draft flush.
+  const frozenWorkflowNode = outgoing.serialize();
   assert.deepEqual(frozenWorkflowNode.properties.dora_power_lora, edited);
   assert.equal(frozenWorkflowNode.properties.dora_state_slot, "roundtrip_slot");
   assert.equal(Object.prototype.hasOwnProperty.call(frozenWorkflowNode, "widgets_values_named"), false);
 
-  // Returning to the tab constructs a brand-new loader with defaults first,
-  // then configures it from the workflow's frozen activeState.
   const restored = makeFreshNode(NodeType);
   assert.deepEqual(restored._doraGlobals, DEFAULT_STATE.globals);
   restored.configure(frozenWorkflowNode);
@@ -248,24 +266,26 @@ test("workflow-tab round trip preserves visible auto-strength and LoRA state", a
   assert.equal(restored.properties.dora_state_slot, "roundtrip_slot");
 });
 
-test("serialization reconciles visible widgets before canonical property output", async () => {
+test("stale frontend widget facade cannot overwrite callback-owned live state", async () => {
   const NodeType = await patchedNodeType();
-  const visible = customState("visible-at-save.safetensors");
-  visible.globals.auto_strength_ratio_floor = 0.72;
-  visible.globals.auto_strength_ratio_ceiling = 2.11;
+  const edited = customState("live-wins.safetensors");
+  edited.globals.auto_strength_device = "auto";
+  edited.globals.auto_strength_ratio_floor = 0.72;
+  edited.globals.auto_strength_ratio_ceiling = 2.11;
   const node = makeFreshNode(NodeType);
 
-  // Deliberately leave properties/live globals stale to reproduce a visual
-  // control that is newer than canonical state at the serialization boundary.
-  node.widgets = makeVisibleWidgets(visible, "visible_slot");
+  // This models an alternate/new frontend renderer where the visual/widget
+  // facade still exposes bootstrap defaults even though the loader callbacks
+  // already updated _doraGlobals and dora_power_lora.
+  applyUserState(node, edited, "live_slot", { staleWidgetFacade: true });
   const output = node.serialize();
 
-  assert.deepEqual(output.properties.dora_power_lora, visible);
-  assert.deepEqual(node.properties.dora_power_lora, visible);
-  assert.equal(output.properties.dora_state_slot, "visible_slot");
+  assert.deepEqual(output.properties.dora_power_lora, edited);
+  assert.deepEqual(node.properties.dora_power_lora, edited);
+  assert.equal(output.properties.dora_state_slot, "live_slot");
 });
 
-test("named widget workflow data is accepted only as migration input", async () => {
+test("named widget workflow data is accepted only when canonical state is absent", async () => {
   const NodeType = await patchedNodeType();
   const migrated = customState("named-migration.safetensors");
   migrated.globals.auto_strength_device = "auto";
@@ -274,6 +294,7 @@ test("named widget workflow data is accepted only as migration input", async () 
   const node = makeFreshNode(NodeType);
 
   node.configure({
+    properties: { unrelated: true },
     widgets_values_named: makeNamedWidgetSnapshot(migrated, "named_slot", { includeRow: true }),
   });
 
@@ -282,35 +303,11 @@ test("named widget workflow data is accepted only as migration input", async () 
   assert.equal(node.lastConfigureInfo.widgets_values_named, undefined);
 });
 
-test("named globals can repair stale serialized globals without deleting serialized rows", async () => {
-  const NodeType = await patchedNodeType();
-  const serialized = customState("keep-row.safetensors");
-  serialized.globals = clone(DEFAULT_STATE.globals);
-  const newer = customState("ignored-row.safetensors");
-  newer.globals.auto_strength_ratio_floor = 0.55;
-  newer.globals.auto_strength_ratio_ceiling = 1.88;
-  const node = makeFreshNode(NodeType);
-
-  node.configure({
-    properties: { dora_power_lora: clone(serialized), dora_state_slot: "serialized_slot" },
-    widgets_values_named: makeNamedWidgetSnapshot(newer, "named_slot", { includeRow: false }),
-  });
-
-  assert.deepEqual(node.properties.dora_power_lora.rows, serialized.rows);
-  assert.equal(node.properties.dora_power_lora.globals.auto_strength_enabled, true);
-  assert.equal(node.properties.dora_power_lora.globals.auto_strength_ratio_floor, 0.55);
-  assert.equal(node.properties.dora_power_lora.globals.auto_strength_ratio_ceiling, 1.88);
-  assert.equal(node.properties.dora_state_slot, "named_slot");
-});
-
 test("partial configure preserves existing live state", async () => {
   const NodeType = await patchedNodeType();
   const live = customState("partial.safetensors");
   const node = makeFreshNode(NodeType);
-  node.properties.dora_power_lora = clone(live);
-  node.properties.dora_state_slot = "partial_slot";
-  node._doraRows = clone(live.rows);
-  node._doraGlobals = clone(live.globals);
+  applyUserState(node, live, "partial_slot");
 
   node.configure({ size: [420, 640] });
 
@@ -322,9 +319,7 @@ test("null serialized state is treated as missing and recovered", async () => {
   const NodeType = await patchedNodeType();
   const live = customState("recover-null.safetensors");
   const node = makeFreshNode(NodeType);
-  node.properties.dora_power_lora = clone(live);
-  node._doraRows = clone(live.rows);
-  node._doraGlobals = clone(live.globals);
+  applyUserState(node, live, "recover_slot");
 
   node.configure({ properties: { dora_power_lora: null } });
 

--- a/tests/test_frontend_state_persistence.mjs
+++ b/tests/test_frontend_state_persistence.mjs
@@ -65,8 +65,8 @@ function makeNodeType() {
     return this;
   };
 
-  // Model the loader's existing serializer, which reads properties rather than
-  // the live row/global objects and leaves named values from current LiteGraph.
+  // Model the loader's existing serializer. Current LiteGraph has already
+  // populated widgets_values_named before this hook executes.
   FakeNode.prototype.onSerialize = function (output) {
     output.properties = { ...(output.properties || {}) };
     output.properties.dora_power_lora = clone(this.properties.dora_power_lora);
@@ -101,7 +101,50 @@ function customState(name = "custom.safetensors") {
   };
 }
 
-function makeNode(NodeType, state = customState()) {
+function makeVisibleWidgets(state, slot = "loader_42") {
+  const widgets = [
+    {
+      name: "LORA_1",
+      row: clone(state.rows[0]),
+      serializeValue() {
+        const row = this.row;
+        return {
+          on: row.enabled,
+          lora: row.name,
+          strength: row.strengthModel,
+          strengthTwo: row.strengthClip,
+        };
+      },
+    },
+  ];
+  for (const [name, value] of Object.entries(state.globals)) {
+    widgets.push({ name, value: clone(value) });
+  }
+  widgets.push({ name: "state_slot", value: slot });
+  return widgets;
+}
+
+function makeNamedWidgetSnapshot(state, slot = "loader_42", { includeRow = false } = {}) {
+  const named = {};
+  if (includeRow) {
+    const row = state.rows[0];
+    named.LORA_1 = {
+      on: row.enabled,
+      lora: row.name,
+      strength: row.strengthModel,
+      strengthTwo: row.strengthClip,
+    };
+  } else {
+    // Current LiteGraph stores widget.value in named workflow state. The custom
+    // LoRA row has no value property, so it commonly serializes as null here.
+    named.LORA_1 = null;
+  }
+  Object.assign(named, clone(state.globals));
+  named.state_slot = slot;
+  return named;
+}
+
+function makeNode(NodeType, state = customState(), { widgets = true } = {}) {
   const node = new NodeType();
   node.properties = {
     dora_power_lora: clone(state),
@@ -109,10 +152,11 @@ function makeNode(NodeType, state = customState()) {
   };
   node._doraRows = clone(state.rows);
   node._doraGlobals = clone(state.globals);
+  node.widgets = widgets ? makeVisibleWidgets(state) : [];
   return node;
 }
 
-test("partial configure preserves the live loader state", async () => {
+test("partial configure preserves current visible loader state", async () => {
   const NodeType = await patchedNodeType();
   const expected = customState();
   const node = makeNode(NodeType, expected);
@@ -124,29 +168,21 @@ test("partial configure preserves the live loader state", async () => {
   assert.equal(node.lastConfigureInfo.widgets_values_named, undefined);
 });
 
-test("named widget-only workflow data migrates into authoritative loader state", async () => {
+test("named widget-only workflow data migrates into canonical loader state", async () => {
   const NodeType = await patchedNodeType();
   const node = makeNode(NodeType, DEFAULT_STATE);
+  const named = customState("named.safetensors");
+  named.globals.broadcast_scale = 2.25;
+  named.globals.auto_strength_device = "auto";
+  named.globals.auto_strength_ratio_floor = 0.41;
+  named.globals.auto_strength_ratio_ceiling = 1.91;
 
   node.configure({
-    widgets_values_named: {
-      LORA_1: { on: true, lora: "named.safetensors", strength: 0.72, strengthTwo: 0.51 },
-      stack_enabled: false,
-      broadcast_modulations: false,
-      broadcast_scale: 2.25,
-      auto_strength_enabled: true,
-      auto_strength_device: "auto",
-      auto_strength_ratio_floor: 0.41,
-      auto_strength_ratio_ceiling: 1.91,
-      dora_slice_fix: false,
-      state_slot: "named_slot",
-    },
+    widgets_values_named: makeNamedWidgetSnapshot(named, "named_slot", { includeRow: true }),
   });
 
   const state = node.properties.dora_power_lora;
-  assert.deepEqual(state.rows, [
-    { enabled: true, name: "named.safetensors", strengthModel: 0.72, strengthClip: 0.51 },
-  ]);
+  assert.deepEqual(state.rows, named.rows);
   assert.equal(state.globals.stack_enabled, false);
   assert.equal(state.globals.broadcast_scale, 2.25);
   assert.equal(state.globals.auto_strength_enabled, true);
@@ -157,29 +193,46 @@ test("named widget-only workflow data migrates into authoritative loader state",
   assert.equal(node.lastConfigureInfo.widgets_values_named, undefined);
 });
 
-test("named global recovery preserves live LoRA rows when custom row values are absent", async () => {
+test("named globals override stale serialized defaults while preserving serialized LoRA rows", async () => {
   const NodeType = await patchedNodeType();
-  const live = customState("keep-this-row.safetensors");
-  const node = makeNode(NodeType, live);
+  const serialized = customState("keep-serialized-row.safetensors");
+  serialized.globals = clone(DEFAULT_STATE.globals);
+  const node = makeNode(NodeType, DEFAULT_STATE);
+  const visible = customState("ignored-named-row.safetensors");
+  visible.globals.auto_strength_device = "auto";
+  visible.globals.auto_strength_ratio_floor = 0.52;
+  visible.globals.auto_strength_ratio_ceiling = 1.74;
 
   node.configure({
-    widgets_values_named: {
-      auto_strength_enabled: true,
-      auto_strength_device: "auto",
-      auto_strength_ratio_floor: 0.52,
-      auto_strength_ratio_ceiling: 1.74,
-    },
+    properties: { dora_power_lora: clone(serialized), dora_state_slot: "serialized_slot" },
+    widgets_values_named: makeNamedWidgetSnapshot(visible, "visible_slot", { includeRow: false }),
   });
 
   const state = node.properties.dora_power_lora;
-  assert.deepEqual(state.rows, live.rows);
+  assert.deepEqual(state.rows, serialized.rows);
+  assert.equal(state.globals.auto_strength_enabled, true);
   assert.equal(state.globals.auto_strength_device, "auto");
   assert.equal(state.globals.auto_strength_ratio_floor, 0.52);
   assert.equal(state.globals.auto_strength_ratio_ceiling, 1.74);
-  assert.equal(state.globals.broadcast_scale, live.globals.broadcast_scale);
+  assert.equal(node.lastConfigureInfo.properties.dora_state_slot, "visible_slot");
 });
 
-test("explicit serialized state remains authoritative over named widget shadows", async () => {
+test("named LoRA rows override stale serialized rows when a row snapshot is available", async () => {
+  const NodeType = await patchedNodeType();
+  const serialized = customState("stale-row.safetensors");
+  const visible = customState("visible-row.safetensors");
+  const node = makeNode(NodeType, DEFAULT_STATE);
+
+  node.configure({
+    properties: { dora_power_lora: clone(serialized) },
+    widgets_values_named: makeNamedWidgetSnapshot(visible, "loader_42", { includeRow: true }),
+  });
+
+  assert.deepEqual(node.properties.dora_power_lora.rows, visible.rows);
+  assert.equal(node.properties.dora_power_lora.globals.auto_strength_ratio_floor, visible.globals.auto_strength_ratio_floor);
+});
+
+test("serialized state stays authoritative when no named widget snapshot exists", async () => {
   const NodeType = await patchedNodeType();
   const node = makeNode(NodeType, customState("live.safetensors"));
   const serialized = customState("serialized.safetensors");
@@ -188,15 +241,20 @@ test("explicit serialized state remains authoritative over named widget shadows"
 
   node.configure({
     properties: { dora_power_lora: clone(serialized), dora_state_slot: "serialized_slot" },
-    widgets_values_named: {
-      auto_strength_ratio_floor: 0.30,
-      auto_strength_ratio_ceiling: 1.50,
-      auto_strength_enabled: false,
-    },
   });
 
   assert.deepEqual(node.properties.dora_power_lora, serialized);
-  assert.equal(node.lastConfigureInfo.widgets_values_named, undefined);
+  assert.equal(node.lastConfigureInfo.properties.dora_state_slot, "serialized_slot");
+});
+
+test("null serialized state is treated as missing and recovered", async () => {
+  const NodeType = await patchedNodeType();
+  const live = customState("recover-null.safetensors");
+  const node = makeNode(NodeType, live);
+
+  node.configure({ properties: { dora_power_lora: null } });
+
+  assert.deepEqual(node.properties.dora_power_lora, live);
 });
 
 test("legacy positional widget migration is not shadowed by the preservation guard", async () => {
@@ -209,25 +267,42 @@ test("legacy positional widget migration is not shadowed by the preservation gua
   assert.equal(node.properties.dora_power_lora.rows[0].name, "legacy.safetensors");
 });
 
-test("serialization snapshots live row/global state and drops named widget shadows", async () => {
+test("serialization uses visible widget values over stale live globals and properties", async () => {
   const NodeType = await patchedNodeType();
-  const node = makeNode(NodeType, DEFAULT_STATE);
-  const live = customState("live-at-save.safetensors");
-  node._doraRows = clone(live.rows);
-  node._doraGlobals = clone(live.globals);
+  const stale = clone(DEFAULT_STATE);
+  const visible = customState("visible-at-save.safetensors");
+  visible.globals.auto_strength_device = "auto";
+  visible.globals.auto_strength_ratio_floor = 0.63;
+  visible.globals.auto_strength_ratio_ceiling = 1.92;
+  const node = makeNode(NodeType, stale, { widgets: false });
+  node.widgets = makeVisibleWidgets(visible, "visible_slot");
 
   const output = {
     properties: { unrelated: "keep" },
-    widgets_values_named: {
-      auto_strength_ratio_floor: 0.30,
-      auto_strength_ratio_ceiling: 1.50,
-    },
+    widgets_values_named: makeNamedWidgetSnapshot(visible, "visible_slot", { includeRow: false }),
   };
   node.onSerialize(output);
 
-  assert.deepEqual(output.properties.dora_power_lora, live);
+  assert.deepEqual(output.properties.dora_power_lora, visible);
+  assert.deepEqual(node.properties.dora_power_lora, visible);
   assert.equal(output.properties.unrelated, "keep");
-  assert.equal(output.properties.dora_state_slot, "loader_42");
+  assert.equal(output.properties.dora_state_slot, "visible_slot");
+  assert.equal(node.properties.dora_state_slot, "visible_slot");
   assert.deepEqual(output.widgets_values, []);
   assert.equal(Object.prototype.hasOwnProperty.call(output, "widgets_values_named"), false);
+});
+
+test("serialization preserves live LoRA rows when named row value is null", async () => {
+  const NodeType = await patchedNodeType();
+  const live = customState("keep-live-row.safetensors");
+  const node = makeNode(NodeType, live);
+
+  const output = {
+    properties: {},
+    widgets_values_named: makeNamedWidgetSnapshot(live, "loader_42", { includeRow: false }),
+  };
+  node.onSerialize(output);
+
+  assert.deepEqual(output.properties.dora_power_lora.rows, live.rows);
+  assert.equal(output.properties.dora_power_lora.globals.auto_strength_ratio_floor, live.globals.auto_strength_ratio_floor);
 });

--- a/tests/test_frontend_state_persistence.mjs
+++ b/tests/test_frontend_state_persistence.mjs
@@ -102,6 +102,13 @@ function makeNodeType() {
   class FakeNode {}
   FakeNode.comfyClass = NODE_CLASS;
 
+  FakeNode.prototype.addWidget = function (type, name, value, callback, options = {}) {
+    const widget = { type, name, value: clone(value), callback, options };
+    this.widgets ??= [];
+    this.widgets.push(widget);
+    return widget;
+  };
+
   // Model the loader bootstrap: a fresh graph node owns default controls and
   // default live state before configure() receives workflow data.
   FakeNode.prototype.onNodeCreated = function () {
@@ -264,6 +271,31 @@ test("#14897-style one-shot tab round trip preserves loader state", async () => 
   assert.deepEqual(restored._doraGlobals, edited.globals);
   assert.deepEqual(restored._doraRows, edited.rows);
   assert.equal(restored.properties.dora_state_slot, "roundtrip_slot");
+});
+
+test("recreated same-name widgets are forced to canonical values after frontend registration", async () => {
+  const NodeType = await patchedNodeType();
+  const saved = customState("widget-store.safetensors");
+  saved.globals.auto_strength_device = "auto";
+  saved.globals.auto_strength_ratio_floor = 0.95;
+  saved.globals.auto_strength_ratio_ceiling = 2.0;
+  const node = makeFreshNode(NodeType);
+  node.configure({ properties: { dora_power_lora: clone(saved), dora_state_slot: "store_slot" } });
+
+  // Model the #14897-era WidgetValueStore behavior observed in the browser:
+  // addWidget receives a stale/default initial value for a same-name widget.
+  // The persistence shim must overwrite the returned widget with the canonical
+  // property-backed value after frontend registration.
+  node.widgets = [];
+  const floor = node.addWidget("number", "auto_strength_ratio_floor", 0.30, () => {});
+  const ceiling = node.addWidget("number", "auto_strength_ratio_ceiling", 1.50, () => {});
+  const device = node.addWidget("combo", "auto_strength_device", "gpu", () => {});
+  const slot = node.addWidget("text", "state_slot", "loader_default", () => {});
+
+  assert.equal(floor.value, 0.95);
+  assert.equal(ceiling.value, 2.0);
+  assert.equal(device.value, "auto");
+  assert.equal(slot.value, "store_slot");
 });
 
 test("stale frontend widget facade cannot overwrite callback-owned live state", async () => {

--- a/tests/test_frontend_state_persistence.mjs
+++ b/tests/test_frontend_state_persistence.mjs
@@ -1,0 +1,211 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const NODE_CLASS = "DoRA Power LoRA Loader";
+const DEFAULT_STATE = {
+  rows: [{ enabled: true, name: "None", strengthModel: 1.0, strengthClip: 1.0 }],
+  globals: {
+    stack_enabled: true,
+    auto_strength_enabled: false,
+    auto_strength_device: "gpu",
+    auto_strength_ratio_floor: 0.30,
+    auto_strength_ratio_ceiling: 1.50,
+  },
+};
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+async function loadPersistenceExtension() {
+  const sourceUrl = new URL("../web/dora_power_lora_persistence.js", import.meta.url);
+  let source = await readFile(sourceUrl, "utf8");
+  let extension = null;
+  globalThis.__doraPersistenceTestApp = {
+    registerExtension(value) {
+      extension = value;
+    },
+  };
+  source = source.replace(
+    'import { app } from "../../scripts/app.js";',
+    "const app = globalThis.__doraPersistenceTestApp;"
+  );
+  const encoded = Buffer.from(source, "utf8").toString("base64");
+  await import(`data:text/javascript;base64,${encoded}#${Date.now()}-${Math.random()}`);
+  delete globalThis.__doraPersistenceTestApp;
+  assert.ok(extension, "persistence extension should register");
+  return extension;
+}
+
+function makeNodeType() {
+  class FakeNode {}
+  FakeNode.comfyClass = NODE_CLASS;
+
+  // Model the loader's existing configure contract: a configure call without
+  // dora_power_lora or legacy positional values falls back to defaults.
+  FakeNode.prototype.configure = function (info) {
+    this.lastConfigureInfo = info;
+    let state;
+    if (info?.properties?.dora_power_lora) {
+      state = clone(info.properties.dora_power_lora);
+    } else if (Array.isArray(info?.widgets_values) && info.widgets_values.length) {
+      state = {
+        rows: [{ enabled: true, name: "legacy.safetensors", strengthModel: 0.7, strengthClip: 0.7 }],
+        globals: { stack_enabled: true, migrated_from_legacy_widgets: true },
+      };
+    } else {
+      state = clone(DEFAULT_STATE);
+    }
+
+    this.properties = { ...(this.properties || {}), ...(info?.properties || {}) };
+    this.properties.dora_power_lora = clone(state);
+    this._doraRows = clone(state.rows);
+    this._doraGlobals = clone(state.globals);
+    return this;
+  };
+
+  // Model the loader's existing serializer, which reads properties rather than
+  // the live row/global objects and leaves named values from current LiteGraph.
+  FakeNode.prototype.onSerialize = function (output) {
+    output.properties = { ...(output.properties || {}) };
+    output.properties.dora_power_lora = clone(this.properties.dora_power_lora);
+    output.widgets_values = [];
+  };
+
+  return FakeNode;
+}
+
+async function patchedNodeType() {
+  const extension = await loadPersistenceExtension();
+  const NodeType = makeNodeType();
+  await extension.beforeRegisterNodeDef(NodeType, { name: NODE_CLASS, display_name: NODE_CLASS });
+  return NodeType;
+}
+
+function customState(name = "custom.safetensors") {
+  return {
+    rows: [{ enabled: true, name, strengthModel: 0.85, strengthClip: 0.65 }],
+    globals: {
+      stack_enabled: false,
+      verbose: true,
+      broadcast_modulations: false,
+      broadcast_scale: 1.75,
+      auto_strength_enabled: true,
+      auto_strength_device: "cpu",
+      auto_strength_ratio_floor: 0.47,
+      auto_strength_ratio_ceiling: 1.83,
+      dora_slice_fix: false,
+      zimage_lumina2_compat: false,
+    },
+  };
+}
+
+function makeNode(NodeType, state = customState()) {
+  const node = new NodeType();
+  node.properties = {
+    dora_power_lora: clone(state),
+    dora_state_slot: "loader_42",
+  };
+  node._doraRows = clone(state.rows);
+  node._doraGlobals = clone(state.globals);
+  return node;
+}
+
+test("partial configure preserves the live loader state", async () => {
+  const NodeType = await patchedNodeType();
+  const expected = customState();
+  const node = makeNode(NodeType, expected);
+
+  node.configure({ size: [420, 640] });
+
+  assert.deepEqual(node.properties.dora_power_lora, expected);
+  assert.equal(node.lastConfigureInfo.properties.dora_state_slot, "loader_42");
+  assert.equal(node.lastConfigureInfo.widgets_values_named, undefined);
+});
+
+test("named widget-only workflow data migrates into authoritative loader state", async () => {
+  const NodeType = await patchedNodeType();
+  const node = makeNode(NodeType, DEFAULT_STATE);
+
+  node.configure({
+    widgets_values_named: {
+      LORA_1: { on: true, lora: "named.safetensors", strength: 0.72, strengthTwo: 0.51 },
+      stack_enabled: false,
+      broadcast_modulations: false,
+      broadcast_scale: 2.25,
+      auto_strength_enabled: true,
+      auto_strength_device: "auto",
+      auto_strength_ratio_floor: 0.41,
+      auto_strength_ratio_ceiling: 1.91,
+      dora_slice_fix: false,
+      state_slot: "named_slot",
+    },
+  });
+
+  const state = node.properties.dora_power_lora;
+  assert.deepEqual(state.rows, [
+    { enabled: true, name: "named.safetensors", strengthModel: 0.72, strengthClip: 0.51 },
+  ]);
+  assert.equal(state.globals.stack_enabled, false);
+  assert.equal(state.globals.broadcast_scale, 2.25);
+  assert.equal(state.globals.auto_strength_enabled, true);
+  assert.equal(state.globals.auto_strength_device, "auto");
+  assert.equal(state.globals.auto_strength_ratio_floor, 0.41);
+  assert.equal(state.globals.auto_strength_ratio_ceiling, 1.91);
+  assert.equal(node.lastConfigureInfo.properties.dora_state_slot, "named_slot");
+  assert.equal(node.lastConfigureInfo.widgets_values_named, undefined);
+});
+
+test("explicit serialized state remains authoritative over named widget shadows", async () => {
+  const NodeType = await patchedNodeType();
+  const node = makeNode(NodeType, customState("live.safetensors"));
+  const serialized = customState("serialized.safetensors");
+  serialized.globals.auto_strength_ratio_floor = 0.58;
+  serialized.globals.auto_strength_ratio_ceiling = 1.66;
+
+  node.configure({
+    properties: { dora_power_lora: clone(serialized), dora_state_slot: "serialized_slot" },
+    widgets_values_named: {
+      auto_strength_ratio_floor: 0.30,
+      auto_strength_ratio_ceiling: 1.50,
+      auto_strength_enabled: false,
+    },
+  });
+
+  assert.deepEqual(node.properties.dora_power_lora, serialized);
+  assert.equal(node.lastConfigureInfo.widgets_values_named, undefined);
+});
+
+test("legacy positional widget migration is not shadowed by the preservation guard", async () => {
+  const NodeType = await patchedNodeType();
+  const node = makeNode(NodeType, customState());
+
+  node.configure({ widgets_values: [true, "legacy.safetensors", 0.7, 0.7, true, false, false] });
+
+  assert.equal(node.properties.dora_power_lora.globals.migrated_from_legacy_widgets, true);
+  assert.equal(node.properties.dora_power_lora.rows[0].name, "legacy.safetensors");
+});
+
+test("serialization snapshots live row/global state and drops named widget shadows", async () => {
+  const NodeType = await patchedNodeType();
+  const node = makeNode(NodeType, DEFAULT_STATE);
+  const live = customState("live-at-save.safetensors");
+  node._doraRows = clone(live.rows);
+  node._doraGlobals = clone(live.globals);
+
+  const output = {
+    properties: { unrelated: "keep" },
+    widgets_values_named: {
+      auto_strength_ratio_floor: 0.30,
+      auto_strength_ratio_ceiling: 1.50,
+    },
+  };
+  node.onSerialize(output);
+
+  assert.deepEqual(output.properties.dora_power_lora, live);
+  assert.equal(output.properties.unrelated, "keep");
+  assert.equal(output.properties.dora_state_slot, "loader_42");
+  assert.deepEqual(output.widgets_values, []);
+  assert.equal(Object.prototype.hasOwnProperty.call(output, "widgets_values_named"), false);
+});

--- a/web/dora_power_lora_persistence.js
+++ b/web/dora_power_lora_persistence.js
@@ -53,7 +53,7 @@ function snapshotLiveState(node) {
   });
 }
 
-function stateFromNamedWidgetValues(named) {
+function stateFromNamedWidgetValues(named, liveGlobals = null) {
   if (!isObject(named)) return null;
 
   const rows = Object.entries(named)
@@ -80,7 +80,11 @@ function stateFromNamedWidgetValues(named) {
 
   const globals = {};
   let hasGlobals = false;
-  for (const key of GLOBAL_WIDGET_KEYS) {
+  const globalKeys = new Set(GLOBAL_WIDGET_KEYS);
+  if (isObject(liveGlobals)) {
+    for (const key of Object.keys(liveGlobals)) globalKeys.add(key);
+  }
+  for (const key of globalKeys) {
     if (!Object.prototype.hasOwnProperty.call(named, key)) continue;
     globals[key] = cloneJson(named[key]);
     hasGlobals = true;
@@ -88,6 +92,18 @@ function stateFromNamedWidgetValues(named) {
 
   if (!rows.length && !hasGlobals) return null;
   return { rows, globals };
+}
+
+function mergeNamedStateWithLive(namedState, liveState) {
+  if (!namedState) return liveState ? cloneJson(liveState) : null;
+  if (!liveState) return cloneJson(namedState);
+  return cloneJson({
+    rows: namedState.rows.length ? namedState.rows : (Array.isArray(liveState.rows) ? liveState.rows : []),
+    globals: {
+      ...(isObject(liveState.globals) ? liveState.globals : {}),
+      ...(isObject(namedState.globals) ? namedState.globals : {}),
+    },
+  });
 }
 
 function prepareConfigureInfo(node, info) {
@@ -98,10 +114,11 @@ function prepareConfigureInfo(node, info) {
   const properties = originalProperties ? { ...originalProperties } : {};
   const hasSerializedState = Object.prototype.hasOwnProperty.call(properties, "dora_power_lora");
   const hasLegacyWidgetValues = Array.isArray(info.widgets_values) && info.widgets_values.length > 0;
-  const namedState = stateFromNamedWidgetValues(info.widgets_values_named);
+  const liveState = snapshotLiveState(node);
+  const namedState = stateFromNamedWidgetValues(info.widgets_values_named, liveState?.globals);
 
   if (!hasSerializedState && !hasLegacyWidgetValues) {
-    const fallbackState = namedState ?? snapshotLiveState(node);
+    const fallbackState = mergeNamedStateWithLive(namedState, liveState);
     if (fallbackState) properties.dora_power_lora = fallbackState;
   }
 

--- a/web/dora_power_lora_persistence.js
+++ b/web/dora_power_lora_persistence.js
@@ -359,7 +359,6 @@ app.registerExtension({
       // Workflow persistence is property-backed. Generic LiteGraph widget
       // serialization creates a competing representation and is unnecessary.
       this.serialize_widgets = false;
-      syncKnownWidgetFacade(this);
       traceLifecycle("onNodeCreated:after", this);
       return result;
     };
@@ -384,14 +383,8 @@ app.registerExtension({
       this.serialize_widgets = false;
       syncKnownWidgetFacade(this);
       traceLifecycle("configure:after", this);
-      queueMicrotask(() => {
-        syncKnownWidgetFacade(this);
-        traceLifecycle("configure:microtask", this);
-      });
-      setTimeout(() => {
-        syncKnownWidgetFacade(this);
-        traceLifecycle("configure:timeout-250ms", this);
-      }, 250);
+      queueMicrotask(() => traceLifecycle("configure:microtask", this));
+      setTimeout(() => traceLifecycle("configure:timeout-250ms", this), 250);
       return result;
     };
 
@@ -414,11 +407,7 @@ app.registerExtension({
     };
   },
   loadedGraphNode(node) {
-    syncKnownWidgetFacade(node);
     traceLifecycle("loadedGraphNode", node);
-    setTimeout(() => {
-      syncKnownWidgetFacade(node);
-      traceLifecycle("loadedGraphNode:timeout-500ms", node);
-    }, 500);
+    setTimeout(() => traceLifecycle("loadedGraphNode:timeout-500ms", node), 500);
   },
 });

--- a/web/dora_power_lora_persistence.js
+++ b/web/dora_power_lora_persistence.js
@@ -36,7 +36,49 @@ function isObject(value) {
   return !!value && typeof value === "object" && !Array.isArray(value);
 }
 
-function snapshotLiveState(node) {
+function normalizeWidgetRow(value) {
+  if (!isObject(value)) return null;
+  const strengthModel = Number(value.strengthModel ?? value.strength_model ?? value.strength);
+  const strengthClip = Number(
+    value.strengthClip ??
+      value.strength_clip ??
+      value.strengthTwo ??
+      value.strengthModel ??
+      value.strength_model ??
+      value.strength
+  );
+  return {
+    enabled: value.enabled !== undefined ? !!value.enabled : (value.on !== undefined ? !!value.on : true),
+    name: String(value.name ?? value.lora ?? "None"),
+    strengthModel: Number.isFinite(strengthModel) ? strengthModel : 1.0,
+    strengthClip: Number.isFinite(strengthClip)
+      ? strengthClip
+      : (Number.isFinite(strengthModel) ? strengthModel : 1.0),
+  };
+}
+
+function rowsFromNodeWidgets(node) {
+  const rows = [];
+  for (const widget of Array.isArray(node?.widgets) ? node.widgets : []) {
+    const match = /^LORA_(\d+)$/.exec(String(widget?.name ?? ""));
+    if (!match) continue;
+
+    let raw = isObject(widget?.row) ? widget.row : null;
+    if (!raw && typeof widget?.serializeValue === "function") {
+      try {
+        const serialized = widget.serializeValue();
+        if (isObject(serialized)) raw = serialized;
+      } catch (_) {}
+    }
+
+    const row = normalizeWidgetRow(raw);
+    if (row) rows.push({ index: Number(match[1]), row });
+  }
+  rows.sort((a, b) => a.index - b.index);
+  return rows.map((entry) => entry.row);
+}
+
+function snapshotStoredLiveState(node) {
   const stored = isObject(node?.properties?.dora_power_lora)
     ? node.properties.dora_power_lora
     : null;
@@ -53,26 +95,36 @@ function snapshotLiveState(node) {
   });
 }
 
-function stateFromNamedWidgetValues(named, liveGlobals = null) {
+function snapshotAuthoritativeState(node) {
+  const base = snapshotStoredLiveState(node) || { rows: [], globals: {} };
+  const widgets = Array.isArray(node?.widgets) ? node.widgets : [];
+  const widgetRows = rowsFromNodeWidgets(node);
+  const globals = isObject(base.globals) ? { ...base.globals } : {};
+  const globalKeys = new Set([...GLOBAL_WIDGET_KEYS, ...Object.keys(globals)]);
+  let capturedGlobal = false;
+
+  for (const widget of widgets) {
+    const name = String(widget?.name ?? "");
+    if (!globalKeys.has(name) || widget?.value === undefined) continue;
+    globals[name] = cloneJson(widget.value);
+    capturedGlobal = true;
+  }
+
+  const rows = widgetRows.length
+    ? widgetRows
+    : (Array.isArray(base.rows) ? base.rows : []);
+  if (!rows.length && !Object.keys(globals).length && !capturedGlobal) return null;
+  return cloneJson({ rows, globals });
+}
+
+function stateFromNamedWidgetValues(named, baseGlobals = null) {
   if (!isObject(named)) return null;
 
   const rows = Object.entries(named)
     .map(([key, value]) => {
       const match = /^LORA_(\d+)$/.exec(key);
-      if (!match || !isObject(value)) return null;
-      const strengthModel = Number(value.strength ?? value.strengthModel);
-      const strengthClip = Number(value.strengthTwo ?? value.strengthClip ?? value.strength ?? value.strengthModel);
-      return {
-        index: Number(match[1]),
-        row: {
-          enabled: value.on !== undefined ? !!value.on : (value.enabled !== undefined ? !!value.enabled : true),
-          name: String(value.lora ?? value.name ?? "None"),
-          strengthModel: Number.isFinite(strengthModel) ? strengthModel : 1.0,
-          strengthClip: Number.isFinite(strengthClip)
-            ? strengthClip
-            : (Number.isFinite(strengthModel) ? strengthModel : 1.0),
-        },
-      };
+      const row = match ? normalizeWidgetRow(value) : null;
+      return match && row ? { index: Number(match[1]), row } : null;
     })
     .filter(Boolean)
     .sort((a, b) => a.index - b.index)
@@ -81,8 +133,8 @@ function stateFromNamedWidgetValues(named, liveGlobals = null) {
   const globals = {};
   let hasGlobals = false;
   const globalKeys = new Set(GLOBAL_WIDGET_KEYS);
-  if (isObject(liveGlobals)) {
-    for (const key of Object.keys(liveGlobals)) globalKeys.add(key);
+  if (isObject(baseGlobals)) {
+    for (const key of Object.keys(baseGlobals)) globalKeys.add(key);
   }
   for (const key of globalKeys) {
     if (!Object.prototype.hasOwnProperty.call(named, key)) continue;
@@ -94,16 +146,33 @@ function stateFromNamedWidgetValues(named, liveGlobals = null) {
   return { rows, globals };
 }
 
-function mergeNamedStateWithLive(namedState, liveState) {
-  if (!namedState) return liveState ? cloneJson(liveState) : null;
-  if (!liveState) return cloneJson(namedState);
+function mergeState(baseState, overlayState) {
+  if (!baseState && !overlayState) return null;
+  const base = isObject(baseState) ? baseState : {};
+  const overlay = isObject(overlayState) ? overlayState : {};
+  const baseRows = Array.isArray(base.rows) ? base.rows : [];
+  const overlayRows = Array.isArray(overlay.rows) ? overlay.rows : [];
   return cloneJson({
-    rows: namedState.rows.length ? namedState.rows : (Array.isArray(liveState.rows) ? liveState.rows : []),
+    rows: overlayRows.length ? overlayRows : baseRows,
     globals: {
-      ...(isObject(liveState.globals) ? liveState.globals : {}),
-      ...(isObject(namedState.globals) ? namedState.globals : {}),
+      ...(isObject(base.globals) ? base.globals : {}),
+      ...(isObject(overlay.globals) ? overlay.globals : {}),
     },
   });
+}
+
+function snapshotStateSlot(node, named = null) {
+  const namedSlot = isObject(named) ? named.state_slot : null;
+  if (typeof namedSlot === "string" && namedSlot.trim()) return namedSlot;
+
+  const stateSlotWidget = (Array.isArray(node?.widgets) ? node.widgets : [])
+    .find((widget) => widget?.name === "state_slot");
+  if (typeof stateSlotWidget?.value === "string" && stateSlotWidget.value.trim()) {
+    return stateSlotWidget.value;
+  }
+
+  const storedSlot = node?.properties?.dora_state_slot;
+  return typeof storedSlot === "string" && storedSlot.trim() ? storedSlot : null;
 }
 
 function prepareConfigureInfo(node, info) {
@@ -112,47 +181,61 @@ function prepareConfigureInfo(node, info) {
   const next = { ...info };
   const originalProperties = isObject(info.properties) ? info.properties : null;
   const properties = originalProperties ? { ...originalProperties } : {};
-  const hasSerializedState = Object.prototype.hasOwnProperty.call(properties, "dora_power_lora");
+  const serializedState = isObject(properties.dora_power_lora)
+    ? cloneJson(properties.dora_power_lora)
+    : null;
   const hasLegacyWidgetValues = Array.isArray(info.widgets_values) && info.widgets_values.length > 0;
-  const liveState = snapshotLiveState(node);
-  const namedState = stateFromNamedWidgetValues(info.widgets_values_named, liveState?.globals);
 
-  if (!hasSerializedState && !hasLegacyWidgetValues) {
-    const fallbackState = mergeNamedStateWithLive(namedState, liveState);
-    if (fallbackState) properties.dora_power_lora = fallbackState;
+  // Current ComfyUI serializes the actual visible standard widget values into
+  // widgets_values_named. Older loader builds could leave dora_power_lora stale
+  // even while those widget values were correct. Reconcile that snapshot into
+  // the canonical state before removing the duplicate representation.
+  const liveState = !serializedState && !hasLegacyWidgetValues
+    ? snapshotAuthoritativeState(node)
+    : null;
+  const baseState = serializedState || liveState;
+  const namedState = stateFromNamedWidgetValues(info.widgets_values_named, baseState?.globals);
+
+  if (!hasLegacyWidgetValues || serializedState) {
+    const reconciledState = mergeState(baseState, namedState);
+    if (reconciledState) properties.dora_power_lora = reconciledState;
   }
 
-  if (!Object.prototype.hasOwnProperty.call(properties, "dora_state_slot")) {
-    const namedSlot = info.widgets_values_named?.state_slot;
-    const currentSlot = node?.properties?.dora_state_slot;
-    if (typeof namedSlot === "string" && namedSlot.trim()) {
-      properties.dora_state_slot = namedSlot;
-    } else if (typeof currentSlot === "string" && currentSlot.trim()) {
-      properties.dora_state_slot = currentSlot;
-    }
-  }
+  const slot = snapshotStateSlot(node, info.widgets_values_named);
+  if (slot) properties.dora_state_slot = slot;
 
   if (originalProperties || Object.keys(properties).length) next.properties = properties;
 
-  // The loader owns a dynamic widget layout. Current ComfyUI serializes both
-  // positional and named widget state, while this loader's authoritative state
-  // lives in dora_power_lora. Named values can otherwise be replayed into a
-  // transient widget set during configure without updating loader state.
+  // dora_power_lora is the single source after reconciliation. Leaving named
+  // values in the configure payload lets LiteGraph replay values directly into
+  // transient widgets without invoking loader callbacks.
   delete next.widgets_values_named;
   return next;
 }
 
 function applyLiveStateToSerialization(node, output) {
   if (!isObject(output)) return;
-  const state = snapshotLiveState(node);
+
+  const visibleState = snapshotAuthoritativeState(node);
+  const namedState = stateFromNamedWidgetValues(output.widgets_values_named, visibleState?.globals);
+  const state = mergeState(visibleState, namedState);
   output.properties = isObject(output.properties) ? output.properties : {};
-  if (state) output.properties.dora_power_lora = state;
 
-  const slot = node?.properties?.dora_state_slot;
-  if (typeof slot === "string" && slot.trim()) output.properties.dora_state_slot = slot;
+  if (state) {
+    output.properties.dora_power_lora = state;
+    node.properties = isObject(node.properties) ? node.properties : {};
+    node.properties.dora_power_lora = cloneJson(state);
+  }
 
-  // Keep the dynamic loader state single-sourced. Positional values remain an
-  // empty compatibility marker for older workflows; named values are omitted.
+  const slot = snapshotStateSlot(node, output.widgets_values_named);
+  if (slot) {
+    output.properties.dora_state_slot = slot;
+    node.properties = isObject(node.properties) ? node.properties : {};
+    node.properties.dora_state_slot = slot;
+  }
+
+  // Keep the dynamic loader state single-sourced after first reconciling the
+  // current LiteGraph widget snapshot above.
   output.widgets_values = [];
   delete output.widgets_values_named;
 }

--- a/web/dora_power_lora_persistence.js
+++ b/web/dora_power_lora_persistence.js
@@ -1,0 +1,166 @@
+import { app } from "../../scripts/app.js";
+
+const NODE_CLASS = "DoRA Power LoRA Loader";
+const EXT_NAME = "comfyui_dora_dynamic_lora.power_lora_persistence";
+
+const GLOBAL_WIDGET_KEYS = [
+  "stack_enabled",
+  "verbose",
+  "log_unloaded_keys",
+  "broadcast_modulations",
+  "broadcast_auto_scale",
+  "broadcast_scale",
+  "broadcast_include_dora_scale",
+  "auto_strength_enabled",
+  "auto_strength_device",
+  "auto_strength_ratio_floor",
+  "auto_strength_ratio_ceiling",
+  "dora_decompose_debug",
+  "dora_decompose_debug_n",
+  "dora_decompose_debug_stack_depth",
+  "dora_slice_fix",
+  "dora_adaln_swap_fix",
+  "zimage_lumina2_compat",
+];
+
+function cloneJson(value) {
+  if (value == null) return value;
+  try {
+    return JSON.parse(JSON.stringify(value));
+  } catch (_) {
+    return value;
+  }
+}
+
+function isObject(value) {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function snapshotLiveState(node) {
+  const stored = isObject(node?.properties?.dora_power_lora)
+    ? node.properties.dora_power_lora
+    : null;
+  const liveRows = Array.isArray(node?._doraRows) ? node._doraRows : null;
+  const liveGlobals = isObject(node?._doraGlobals) ? node._doraGlobals : null;
+
+  if (!liveRows && !liveGlobals) {
+    return stored ? cloneJson(stored) : null;
+  }
+
+  return cloneJson({
+    rows: liveRows ?? (Array.isArray(stored?.rows) ? stored.rows : []),
+    globals: liveGlobals ?? (isObject(stored?.globals) ? stored.globals : {}),
+  });
+}
+
+function stateFromNamedWidgetValues(named) {
+  if (!isObject(named)) return null;
+
+  const rows = Object.entries(named)
+    .map(([key, value]) => {
+      const match = /^LORA_(\d+)$/.exec(key);
+      if (!match || !isObject(value)) return null;
+      const strengthModel = Number(value.strength ?? value.strengthModel);
+      const strengthClip = Number(value.strengthTwo ?? value.strengthClip ?? value.strength ?? value.strengthModel);
+      return {
+        index: Number(match[1]),
+        row: {
+          enabled: value.on !== undefined ? !!value.on : (value.enabled !== undefined ? !!value.enabled : true),
+          name: String(value.lora ?? value.name ?? "None"),
+          strengthModel: Number.isFinite(strengthModel) ? strengthModel : 1.0,
+          strengthClip: Number.isFinite(strengthClip)
+            ? strengthClip
+            : (Number.isFinite(strengthModel) ? strengthModel : 1.0),
+        },
+      };
+    })
+    .filter(Boolean)
+    .sort((a, b) => a.index - b.index)
+    .map((entry) => entry.row);
+
+  const globals = {};
+  let hasGlobals = false;
+  for (const key of GLOBAL_WIDGET_KEYS) {
+    if (!Object.prototype.hasOwnProperty.call(named, key)) continue;
+    globals[key] = cloneJson(named[key]);
+    hasGlobals = true;
+  }
+
+  if (!rows.length && !hasGlobals) return null;
+  return { rows, globals };
+}
+
+function prepareConfigureInfo(node, info) {
+  if (!isObject(info)) return info;
+
+  const next = { ...info };
+  const originalProperties = isObject(info.properties) ? info.properties : null;
+  const properties = originalProperties ? { ...originalProperties } : {};
+  const hasSerializedState = Object.prototype.hasOwnProperty.call(properties, "dora_power_lora");
+  const hasLegacyWidgetValues = Array.isArray(info.widgets_values) && info.widgets_values.length > 0;
+  const namedState = stateFromNamedWidgetValues(info.widgets_values_named);
+
+  if (!hasSerializedState && !hasLegacyWidgetValues) {
+    const fallbackState = namedState ?? snapshotLiveState(node);
+    if (fallbackState) properties.dora_power_lora = fallbackState;
+  }
+
+  if (!Object.prototype.hasOwnProperty.call(properties, "dora_state_slot")) {
+    const namedSlot = info.widgets_values_named?.state_slot;
+    const currentSlot = node?.properties?.dora_state_slot;
+    if (typeof namedSlot === "string" && namedSlot.trim()) {
+      properties.dora_state_slot = namedSlot;
+    } else if (typeof currentSlot === "string" && currentSlot.trim()) {
+      properties.dora_state_slot = currentSlot;
+    }
+  }
+
+  if (originalProperties || Object.keys(properties).length) next.properties = properties;
+
+  // The loader owns a dynamic widget layout. Current ComfyUI serializes both
+  // positional and named widget state, while this loader's authoritative state
+  // lives in dora_power_lora. Named values can otherwise be replayed into a
+  // transient widget set during configure without updating loader state.
+  delete next.widgets_values_named;
+  return next;
+}
+
+function applyLiveStateToSerialization(node, output) {
+  if (!isObject(output)) return;
+  const state = snapshotLiveState(node);
+  output.properties = isObject(output.properties) ? output.properties : {};
+  if (state) output.properties.dora_power_lora = state;
+
+  const slot = node?.properties?.dora_state_slot;
+  if (typeof slot === "string" && slot.trim()) output.properties.dora_state_slot = slot;
+
+  // Keep the dynamic loader state single-sourced. Positional values remain an
+  // empty compatibility marker for older workflows; named values are omitted.
+  output.widgets_values = [];
+  delete output.widgets_values_named;
+}
+
+app.registerExtension({
+  name: EXT_NAME,
+  async beforeRegisterNodeDef(nodeType, nodeData) {
+    const nodeName = nodeData?.name ?? "";
+    const displayName = nodeData?.display_name ?? "";
+    const comfyClass = nodeType?.comfyClass ?? "";
+    if (nodeName !== NODE_CLASS && displayName !== NODE_CLASS && comfyClass !== NODE_CLASS) return;
+    if (nodeType.prototype.__doraPowerLoraPersistencePatched) return;
+    nodeType.prototype.__doraPowerLoraPersistencePatched = true;
+
+    const previousConfigure = nodeType.prototype.configure;
+    nodeType.prototype.configure = function (info) {
+      const guardedInfo = prepareConfigureInfo(this, info);
+      return previousConfigure?.call(this, guardedInfo);
+    };
+
+    const previousOnSerialize = nodeType.prototype.onSerialize;
+    nodeType.prototype.onSerialize = function (output) {
+      const result = previousOnSerialize?.call(this, output);
+      applyLiveStateToSerialization(this, output);
+      return result;
+    };
+  },
+});

--- a/web/dora_power_lora_persistence.js
+++ b/web/dora_power_lora_persistence.js
@@ -2,6 +2,9 @@ import { app } from "../../scripts/app.js";
 
 const NODE_CLASS = "DoRA Power LoRA Loader";
 const EXT_NAME = "comfyui_dora_dynamic_lora.power_lora_persistence";
+const TRACE_LIMIT = 240;
+const TRACE_STORE_KEY = "__doraPowerLoraPersistenceTrace";
+const TRACE_API_KEY = "__doraPowerLoraPersistenceDebug";
 
 const GLOBAL_WIDGET_KEYS = [
   "stack_enabled",
@@ -34,6 +37,15 @@ function cloneJson(value) {
 
 function isObject(value) {
   return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function isTargetNode(node) {
+  return !!node && (
+    node.type === NODE_CLASS ||
+    node.comfyClass === NODE_CLASS ||
+    node.constructor?.comfyClass === NODE_CLASS ||
+    node.title === NODE_CLASS
+  );
 }
 
 function normalizeWidgetRow(value) {
@@ -72,6 +84,82 @@ function snapshotCanonicalState(node) {
     rows: liveRows ?? (Array.isArray(stored?.rows) ? stored.rows : []),
     globals: liveGlobals ?? (isObject(stored?.globals) ? stored.globals : {}),
   });
+}
+
+function snapshotWidgetFacade(node) {
+  const out = {};
+  for (const widget of Array.isArray(node?.widgets) ? node.widgets : []) {
+    const name = String(widget?.name ?? "");
+    if (GLOBAL_WIDGET_KEYS.includes(name) || name === "state_slot") {
+      out[name] = cloneJson(widget?.value);
+      continue;
+    }
+    if (!/^LORA_\d+$/.test(name)) continue;
+    let row = null;
+    if (isObject(widget?.row)) row = normalizeWidgetRow(widget.row);
+    if (!row && typeof widget?.serializeValue === "function") {
+      try { row = normalizeWidgetRow(widget.serializeValue()); } catch (_) {}
+    }
+    out[name] = row;
+  }
+  return out;
+}
+
+function getTraceStore() {
+  let trace = globalThis[TRACE_STORE_KEY];
+  if (!Array.isArray(trace)) {
+    trace = [];
+    globalThis[TRACE_STORE_KEY] = trace;
+  }
+  return trace;
+}
+
+function traceLifecycle(stage, node, extra = null) {
+  if (!isTargetNode(node)) return;
+  const trace = getTraceStore();
+  const entry = {
+    time: new Date().toISOString(),
+    stage,
+    node_id: node?.id ?? null,
+    graph_id: node?.graph?.id ?? null,
+    serialize_widgets: node?.serialize_widgets,
+    property_state: cloneJson(node?.properties?.dora_power_lora ?? null),
+    live_state: cloneJson({
+      rows: Array.isArray(node?._doraRows) ? node._doraRows : null,
+      globals: isObject(node?._doraGlobals) ? node._doraGlobals : null,
+    }),
+    state_slot: node?.properties?.dora_state_slot ?? null,
+    widget_facade: snapshotWidgetFacade(node),
+    extra: cloneJson(extra),
+  };
+  trace.push(entry);
+  if (trace.length > TRACE_LIMIT) trace.splice(0, trace.length - TRACE_LIMIT);
+  if (globalThis[TRACE_API_KEY]?.logToConsole === true) {
+    console.debug(`[${EXT_NAME}]`, stage, entry);
+  }
+}
+
+function installTraceApi() {
+  const existing = isObject(globalThis[TRACE_API_KEY]) ? globalThis[TRACE_API_KEY] : {};
+  globalThis[TRACE_API_KEY] = {
+    ...existing,
+    logToConsole: existing.logToConsole === true,
+    clear() {
+      const trace = getTraceStore();
+      trace.length = 0;
+      return true;
+    },
+    dump() {
+      return JSON.stringify(getTraceStore(), null, 2);
+    },
+    snapshot() {
+      return cloneJson(getTraceStore());
+    },
+    setConsoleLogging(enabled = true) {
+      this.logToConsole = !!enabled;
+      return this.logToConsole;
+    },
+  };
 }
 
 function stateFromNamedWidgetValues(named, baseGlobals = null) {
@@ -195,6 +283,8 @@ function finalizeCanonicalSerialization(node, output, prepared) {
   delete output.widgets_values_named;
 }
 
+installTraceApi();
+
 app.registerExtension({
   name: EXT_NAME,
   async beforeRegisterNodeDef(nodeType, nodeData) {
@@ -207,28 +297,58 @@ app.registerExtension({
 
     const previousOnNodeCreated = nodeType.prototype.onNodeCreated;
     nodeType.prototype.onNodeCreated = function () {
+      traceLifecycle("onNodeCreated:before", this);
       const result = previousOnNodeCreated?.apply(this, arguments);
       // Workflow persistence is property-backed. Generic LiteGraph widget
       // serialization creates a competing representation and is unnecessary.
       this.serialize_widgets = false;
+      traceLifecycle("onNodeCreated:after", this);
       return result;
     };
 
     const previousConfigure = nodeType.prototype.configure;
     nodeType.prototype.configure = function (info) {
       this.serialize_widgets = false;
+      traceLifecycle("configure:incoming", this, {
+        incoming_property_state: cloneJson(info?.properties?.dora_power_lora ?? null),
+        incoming_state_slot: info?.properties?.dora_state_slot ?? null,
+        incoming_widgets_values_named: cloneJson(info?.widgets_values_named ?? null),
+        incoming_widgets_values: cloneJson(info?.widgets_values ?? null),
+      });
       const guardedInfo = prepareConfigureInfo(this, info);
+      traceLifecycle("configure:guarded", this, {
+        guarded_property_state: cloneJson(guardedInfo?.properties?.dora_power_lora ?? null),
+        guarded_state_slot: guardedInfo?.properties?.dora_state_slot ?? null,
+        has_named_values: Object.prototype.hasOwnProperty.call(guardedInfo ?? {}, "widgets_values_named"),
+      });
       const result = previousConfigure?.call(this, guardedInfo);
       this.serialize_widgets = false;
+      traceLifecycle("configure:after", this);
+      queueMicrotask(() => traceLifecycle("configure:microtask", this));
+      setTimeout(() => traceLifecycle("configure:timeout-250ms", this), 250);
       return result;
     };
 
     const previousOnSerialize = nodeType.prototype.onSerialize;
     nodeType.prototype.onSerialize = function (output) {
+      traceLifecycle("serialize:before", this, {
+        output_property_state_before: cloneJson(output?.properties?.dora_power_lora ?? null),
+        output_named_before: cloneJson(output?.widgets_values_named ?? null),
+      });
       const prepared = prepareCanonicalSerialization(this);
       const result = previousOnSerialize?.call(this, output);
       finalizeCanonicalSerialization(this, output, prepared);
+      traceLifecycle("serialize:after", this, {
+        output_property_state_after: cloneJson(output?.properties?.dora_power_lora ?? null),
+        output_state_slot_after: output?.properties?.dora_state_slot ?? null,
+        output_widgets_values_after: cloneJson(output?.widgets_values ?? null),
+        has_named_values_after: Object.prototype.hasOwnProperty.call(output ?? {}, "widgets_values_named"),
+      });
       return result;
     };
+  },
+  loadedGraphNode(node) {
+    traceLifecycle("loadedGraphNode", node);
+    setTimeout(() => traceLifecycle("loadedGraphNode:timeout-500ms", node), 500);
   },
 });

--- a/web/dora_power_lora_persistence.js
+++ b/web/dora_power_lora_persistence.js
@@ -57,28 +57,7 @@ function normalizeWidgetRow(value) {
   };
 }
 
-function rowsFromNodeWidgets(node) {
-  const rows = [];
-  for (const widget of Array.isArray(node?.widgets) ? node.widgets : []) {
-    const match = /^LORA_(\d+)$/.exec(String(widget?.name ?? ""));
-    if (!match) continue;
-
-    let raw = isObject(widget?.row) ? widget.row : null;
-    if (!raw && typeof widget?.serializeValue === "function") {
-      try {
-        const serialized = widget.serializeValue();
-        if (isObject(serialized)) raw = serialized;
-      } catch (_) {}
-    }
-
-    const row = normalizeWidgetRow(raw);
-    if (row) rows.push({ index: Number(match[1]), row });
-  }
-  rows.sort((a, b) => a.index - b.index);
-  return rows.map((entry) => entry.row);
-}
-
-function snapshotStoredLiveState(node) {
+function snapshotCanonicalState(node) {
   const stored = isObject(node?.properties?.dora_power_lora)
     ? node.properties.dora_power_lora
     : null;
@@ -93,26 +72,6 @@ function snapshotStoredLiveState(node) {
     rows: liveRows ?? (Array.isArray(stored?.rows) ? stored.rows : []),
     globals: liveGlobals ?? (isObject(stored?.globals) ? stored.globals : {}),
   });
-}
-
-function snapshotVisibleState(node) {
-  const base = snapshotStoredLiveState(node) || { rows: [], globals: {} };
-  const widgets = Array.isArray(node?.widgets) ? node.widgets : [];
-  const widgetRows = rowsFromNodeWidgets(node);
-  const globals = isObject(base.globals) ? { ...base.globals } : {};
-  const globalKeys = new Set([...GLOBAL_WIDGET_KEYS, ...Object.keys(globals)]);
-
-  for (const widget of widgets) {
-    const name = String(widget?.name ?? "");
-    if (!globalKeys.has(name) || widget?.value === undefined) continue;
-    globals[name] = cloneJson(widget.value);
-  }
-
-  const rows = widgetRows.length
-    ? widgetRows
-    : (Array.isArray(base.rows) ? base.rows : []);
-  if (!rows.length && !Object.keys(globals).length) return null;
-  return cloneJson({ rows, globals });
 }
 
 function stateFromNamedWidgetValues(named, baseGlobals = null) {
@@ -144,29 +103,8 @@ function stateFromNamedWidgetValues(named, baseGlobals = null) {
   return { rows, globals };
 }
 
-function mergeState(baseState, overlayState) {
-  if (!baseState && !overlayState) return null;
-  const base = isObject(baseState) ? baseState : {};
-  const overlay = isObject(overlayState) ? overlayState : {};
-  const baseRows = Array.isArray(base.rows) ? base.rows : [];
-  const overlayRows = Array.isArray(overlay.rows) ? overlay.rows : [];
-  return cloneJson({
-    rows: overlayRows.length ? overlayRows : baseRows,
-    globals: {
-      ...(isObject(base.globals) ? base.globals : {}),
-      ...(isObject(overlay.globals) ? overlay.globals : {}),
-    },
-  });
-}
-
 function validStateSlot(value) {
   return typeof value === "string" && value.trim() ? value : null;
-}
-
-function currentStateSlot(node) {
-  const widget = (Array.isArray(node?.widgets) ? node.widgets : [])
-    .find((item) => item?.name === "state_slot");
-  return validStateSlot(widget?.value) || validStateSlot(node?.properties?.dora_state_slot);
 }
 
 function prepareConfigureInfo(node, info) {
@@ -180,28 +118,39 @@ function prepareConfigureInfo(node, info) {
     : null;
   const hasLegacyWidgetValues = Array.isArray(info.widgets_values) && info.widgets_values.length > 0;
 
-  // Incoming workflow data always outranks the freshly-created loader widgets.
-  // widgets_values_named is accepted only as migration data from frontend builds
-  // that previously stored loader controls there. Never derive configure state
-  // from the current widget set: on a tab reload those widgets are bootstrap
-  // defaults created before configure() runs.
-  const namedState = stateFromNamedWidgetValues(
-    info.widgets_values_named,
-    serializedState?.globals ?? node?._doraGlobals
-  );
-
-  if (serializedState || namedState) {
-    properties.dora_power_lora = mergeState(serializedState, namedState);
+  // Canonical workflow state always wins when present. widgets_values_named is
+  // migration-only for old workflows that do not contain dora_power_lora.
+  // In particular, never let stale/default named widget shadows overwrite an
+  // existing property-backed loader state during graph reconstruction.
+  if (serializedState) {
+    properties.dora_power_lora = serializedState;
   } else if (!hasLegacyWidgetValues) {
-    const liveState = snapshotStoredLiveState(node);
-    if (liveState) properties.dora_power_lora = liveState;
+    const liveState = snapshotCanonicalState(node);
+    const namedState = stateFromNamedWidgetValues(
+      info.widgets_values_named,
+      liveState?.globals
+    );
+
+    if (namedState) {
+      properties.dora_power_lora = cloneJson({
+        rows: namedState.rows.length
+          ? namedState.rows
+          : (Array.isArray(liveState?.rows) ? liveState.rows : []),
+        globals: {
+          ...(isObject(liveState?.globals) ? liveState.globals : {}),
+          ...(isObject(namedState.globals) ? namedState.globals : {}),
+        },
+      });
+    } else if (liveState) {
+      properties.dora_power_lora = liveState;
+    }
   }
 
-  const namedSlot = isObject(info.widgets_values_named)
+  const incomingSlot = validStateSlot(properties.dora_state_slot);
+  const namedSlot = !incomingSlot && !serializedState && isObject(info.widgets_values_named)
     ? validStateSlot(info.widgets_values_named.state_slot)
     : null;
-  const incomingSlot = validStateSlot(properties.dora_state_slot);
-  const slot = namedSlot || incomingSlot || validStateSlot(node?.properties?.dora_state_slot);
+  const slot = incomingSlot || namedSlot || validStateSlot(node?.properties?.dora_state_slot);
   if (slot) properties.dora_state_slot = slot;
 
   if (originalProperties || Object.keys(properties).length) next.properties = properties;
@@ -213,15 +162,17 @@ function prepareConfigureInfo(node, info) {
 }
 
 function prepareCanonicalSerialization(node) {
+  // Every loader control callback updates _doraRows/_doraGlobals and persists
+  // them into dora_power_lora. Those live objects are therefore the node-owned
+  // authority. Do not read widget.value here: alternate frontend renderers may
+  // keep a widget facade whose value lags the callback-owned loader state.
   node.serialize_widgets = false;
   node.properties = isObject(node.properties) ? node.properties : {};
 
-  const state = snapshotVisibleState(node);
+  const state = snapshotCanonicalState(node);
   if (state) node.properties.dora_power_lora = cloneJson(state);
 
-  const slot = currentStateSlot(node);
-  if (slot) node.properties.dora_state_slot = slot;
-
+  const slot = validStateSlot(node.properties.dora_state_slot);
   return { state, slot };
 }
 
@@ -274,8 +225,6 @@ app.registerExtension({
 
     const previousOnSerialize = nodeType.prototype.onSerialize;
     nodeType.prototype.onSerialize = function (output) {
-      // Reconcile the current visible controls into the canonical property
-      // before the loader/base serializer reads node.properties.
       const prepared = prepareCanonicalSerialization(this);
       const result = previousOnSerialize?.call(this, output);
       finalizeCanonicalSerialization(this, output, prepared);

--- a/web/dora_power_lora_persistence.js
+++ b/web/dora_power_lora_persistence.js
@@ -2,9 +2,6 @@ import { app } from "../../scripts/app.js";
 
 const NODE_CLASS = "DoRA Power LoRA Loader";
 const EXT_NAME = "comfyui_dora_dynamic_lora.power_lora_persistence";
-const TRACE_LIMIT = 240;
-const TRACE_STORE_KEY = "__doraPowerLoraPersistenceTrace";
-const TRACE_API_KEY = "__doraPowerLoraPersistenceDebug";
 
 const GLOBAL_WIDGET_KEYS = [
   "stack_enabled",
@@ -37,15 +34,6 @@ function cloneJson(value) {
 
 function isObject(value) {
   return !!value && typeof value === "object" && !Array.isArray(value);
-}
-
-function isTargetNode(node) {
-  return !!node && (
-    node.type === NODE_CLASS ||
-    node.comfyClass === NODE_CLASS ||
-    node.constructor?.comfyClass === NODE_CLASS ||
-    node.title === NODE_CLASS
-  );
 }
 
 function normalizeWidgetRow(value) {
@@ -84,82 +72,6 @@ function snapshotCanonicalState(node) {
     rows: liveRows ?? (Array.isArray(stored?.rows) ? stored.rows : []),
     globals: liveGlobals ?? (isObject(stored?.globals) ? stored.globals : {}),
   });
-}
-
-function snapshotWidgetFacade(node) {
-  const out = {};
-  for (const widget of Array.isArray(node?.widgets) ? node.widgets : []) {
-    const name = String(widget?.name ?? "");
-    if (GLOBAL_WIDGET_KEYS.includes(name) || name === "state_slot") {
-      out[name] = cloneJson(widget?.value);
-      continue;
-    }
-    if (!/^LORA_\d+$/.test(name)) continue;
-    let row = null;
-    if (isObject(widget?.row)) row = normalizeWidgetRow(widget.row);
-    if (!row && typeof widget?.serializeValue === "function") {
-      try { row = normalizeWidgetRow(widget.serializeValue()); } catch (_) {}
-    }
-    out[name] = row;
-  }
-  return out;
-}
-
-function getTraceStore() {
-  let trace = globalThis[TRACE_STORE_KEY];
-  if (!Array.isArray(trace)) {
-    trace = [];
-    globalThis[TRACE_STORE_KEY] = trace;
-  }
-  return trace;
-}
-
-function traceLifecycle(stage, node, extra = null) {
-  if (!isTargetNode(node)) return;
-  const trace = getTraceStore();
-  const entry = {
-    time: new Date().toISOString(),
-    stage,
-    node_id: node?.id ?? null,
-    graph_id: node?.graph?.id ?? null,
-    serialize_widgets: node?.serialize_widgets,
-    property_state: cloneJson(node?.properties?.dora_power_lora ?? null),
-    live_state: cloneJson({
-      rows: Array.isArray(node?._doraRows) ? node._doraRows : null,
-      globals: isObject(node?._doraGlobals) ? node._doraGlobals : null,
-    }),
-    state_slot: node?.properties?.dora_state_slot ?? null,
-    widget_facade: snapshotWidgetFacade(node),
-    extra: cloneJson(extra),
-  };
-  trace.push(entry);
-  if (trace.length > TRACE_LIMIT) trace.splice(0, trace.length - TRACE_LIMIT);
-  if (globalThis[TRACE_API_KEY]?.logToConsole === true) {
-    console.debug(`[${EXT_NAME}]`, stage, entry);
-  }
-}
-
-function installTraceApi() {
-  const existing = isObject(globalThis[TRACE_API_KEY]) ? globalThis[TRACE_API_KEY] : {};
-  globalThis[TRACE_API_KEY] = {
-    ...existing,
-    logToConsole: existing.logToConsole === true,
-    clear() {
-      const trace = getTraceStore();
-      trace.length = 0;
-      return true;
-    },
-    dump() {
-      return JSON.stringify(getTraceStore(), null, 2);
-    },
-    snapshot() {
-      return cloneJson(getTraceStore());
-    },
-    setConsoleLogging(enabled = true) {
-      this.logToConsole = !!enabled;
-      return this.logToConsole;
-    },
-  };
 }
 
 function stateFromNamedWidgetValues(named, baseGlobals = null) {
@@ -240,11 +152,11 @@ function installDynamicWidgetValueSync(node) {
     const name = String(arguments[1] ?? widget.name ?? "");
     if (!GLOBAL_WIDGET_KEYS.includes(name) && name !== "state_slot") return widget;
 
-    // Newer ComfyUI frontends keep widget values in WidgetValueStore. Recreating
-    // a same-name/same-type widget can therefore return the existing bootstrap
-    // state instead of adopting addWidget(..., initialValue). Always push the
-    // loader's property-backed canonical value into the registered widget after
-    // creation. On older LiteGraph this is just an ordinary value assignment.
+    // Newer ComfyUI frontends keep standard widget values in WidgetValueStore.
+    // Recreating a same-name/same-type widget can therefore reconnect it to a
+    // bootstrap/default store entry instead of adopting addWidget's initial
+    // value. Push the loader's canonical property-backed value into the newly
+    // registered widget. On older LiteGraph this is a normal value assignment.
     const desired = canonicalWidgetValue(this, name, arguments[2]);
     try { widget.value = cloneJson(desired); } catch (_) {}
     return widget;
@@ -264,8 +176,6 @@ function prepareConfigureInfo(node, info) {
 
   // Canonical workflow state always wins when present. widgets_values_named is
   // migration-only for old workflows that do not contain dora_power_lora.
-  // In particular, never let stale/default named widget shadows overwrite an
-  // existing property-backed loader state during graph reconstruction.
   if (serializedState) {
     properties.dora_power_lora = serializedState;
   } else if (!hasLegacyWidgetValues) {
@@ -306,10 +216,9 @@ function prepareConfigureInfo(node, info) {
 }
 
 function prepareCanonicalSerialization(node) {
-  // Every loader control callback updates _doraRows/_doraGlobals and persists
-  // them into dora_power_lora. Those live objects are therefore the node-owned
-  // authority. Do not read widget.value here: alternate frontend renderers may
-  // keep a widget facade whose value lags the callback-owned loader state.
+  // Loader callbacks persist every control into _doraRows/_doraGlobals and the
+  // canonical property. Do not persist from widget.value: a store-backed
+  // frontend facade can temporarily lag the loader-owned state.
   node.serialize_widgets = false;
   node.properties = isObject(node.properties) ? node.properties : {};
 
@@ -339,8 +248,6 @@ function finalizeCanonicalSerialization(node, output, prepared) {
   delete output.widgets_values_named;
 }
 
-installTraceApi();
-
 app.registerExtension({
   name: EXT_NAME,
   async beforeRegisterNodeDef(nodeType, nodeData) {
@@ -353,13 +260,10 @@ app.registerExtension({
 
     const previousOnNodeCreated = nodeType.prototype.onNodeCreated;
     nodeType.prototype.onNodeCreated = function () {
-      traceLifecycle("onNodeCreated:before", this);
       installDynamicWidgetValueSync(this);
       const result = previousOnNodeCreated?.apply(this, arguments);
-      // Workflow persistence is property-backed. Generic LiteGraph widget
-      // serialization creates a competing representation and is unnecessary.
       this.serialize_widgets = false;
-      traceLifecycle("onNodeCreated:after", this);
+      syncKnownWidgetFacade(this);
       return result;
     };
 
@@ -367,47 +271,19 @@ app.registerExtension({
     nodeType.prototype.configure = function (info) {
       this.serialize_widgets = false;
       installDynamicWidgetValueSync(this);
-      traceLifecycle("configure:incoming", this, {
-        incoming_property_state: cloneJson(info?.properties?.dora_power_lora ?? null),
-        incoming_state_slot: info?.properties?.dora_state_slot ?? null,
-        incoming_widgets_values_named: cloneJson(info?.widgets_values_named ?? null),
-        incoming_widgets_values: cloneJson(info?.widgets_values ?? null),
-      });
       const guardedInfo = prepareConfigureInfo(this, info);
-      traceLifecycle("configure:guarded", this, {
-        guarded_property_state: cloneJson(guardedInfo?.properties?.dora_power_lora ?? null),
-        guarded_state_slot: guardedInfo?.properties?.dora_state_slot ?? null,
-        has_named_values: Object.prototype.hasOwnProperty.call(guardedInfo ?? {}, "widgets_values_named"),
-      });
       const result = previousConfigure?.call(this, guardedInfo);
       this.serialize_widgets = false;
       syncKnownWidgetFacade(this);
-      traceLifecycle("configure:after", this);
-      queueMicrotask(() => traceLifecycle("configure:microtask", this));
-      setTimeout(() => traceLifecycle("configure:timeout-250ms", this), 250);
       return result;
     };
 
     const previousOnSerialize = nodeType.prototype.onSerialize;
     nodeType.prototype.onSerialize = function (output) {
-      traceLifecycle("serialize:before", this, {
-        output_property_state_before: cloneJson(output?.properties?.dora_power_lora ?? null),
-        output_named_before: cloneJson(output?.widgets_values_named ?? null),
-      });
       const prepared = prepareCanonicalSerialization(this);
       const result = previousOnSerialize?.call(this, output);
       finalizeCanonicalSerialization(this, output, prepared);
-      traceLifecycle("serialize:after", this, {
-        output_property_state_after: cloneJson(output?.properties?.dora_power_lora ?? null),
-        output_state_slot_after: output?.properties?.dora_state_slot ?? null,
-        output_widgets_values_after: cloneJson(output?.widgets_values ?? null),
-        has_named_values_after: Object.prototype.hasOwnProperty.call(output ?? {}, "widgets_values_named"),
-      });
       return result;
     };
-  },
-  loadedGraphNode(node) {
-    traceLifecycle("loadedGraphNode", node);
-    setTimeout(() => traceLifecycle("loadedGraphNode:timeout-500ms", node), 500);
   },
 });

--- a/web/dora_power_lora_persistence.js
+++ b/web/dora_power_lora_persistence.js
@@ -161,18 +161,20 @@ function mergeState(baseState, overlayState) {
   });
 }
 
+function validStateSlot(value) {
+  return typeof value === "string" && value.trim() ? value : null;
+}
+
 function snapshotStateSlot(node, named = null) {
-  const namedSlot = isObject(named) ? named.state_slot : null;
-  if (typeof namedSlot === "string" && namedSlot.trim()) return namedSlot;
+  const namedSlot = isObject(named) ? validStateSlot(named.state_slot) : null;
+  if (namedSlot) return namedSlot;
 
   const stateSlotWidget = (Array.isArray(node?.widgets) ? node.widgets : [])
     .find((widget) => widget?.name === "state_slot");
-  if (typeof stateSlotWidget?.value === "string" && stateSlotWidget.value.trim()) {
-    return stateSlotWidget.value;
-  }
+  const widgetSlot = validStateSlot(stateSlotWidget?.value);
+  if (widgetSlot) return widgetSlot;
 
-  const storedSlot = node?.properties?.dora_state_slot;
-  return typeof storedSlot === "string" && storedSlot.trim() ? storedSlot : null;
+  return validStateSlot(node?.properties?.dora_state_slot);
 }
 
 function prepareConfigureInfo(node, info) {
@@ -201,7 +203,11 @@ function prepareConfigureInfo(node, info) {
     if (reconciledState) properties.dora_power_lora = reconciledState;
   }
 
-  const slot = snapshotStateSlot(node, info.widgets_values_named);
+  const namedSlot = isObject(info.widgets_values_named)
+    ? validStateSlot(info.widgets_values_named.state_slot)
+    : null;
+  const incomingSlot = validStateSlot(properties.dora_state_slot);
+  const slot = namedSlot || incomingSlot || snapshotStateSlot(node);
   if (slot) properties.dora_state_slot = slot;
 
   if (originalProperties || Object.keys(properties).length) next.properties = properties;

--- a/web/dora_power_lora_persistence.js
+++ b/web/dora_power_lora_persistence.js
@@ -195,6 +195,62 @@ function validStateSlot(value) {
   return typeof value === "string" && value.trim() ? value : null;
 }
 
+function canonicalWidgetValue(node, name, fallback) {
+  if (GLOBAL_WIDGET_KEYS.includes(name)) {
+    const storedGlobals = isObject(node?.properties?.dora_power_lora?.globals)
+      ? node.properties.dora_power_lora.globals
+      : null;
+    if (storedGlobals && Object.prototype.hasOwnProperty.call(storedGlobals, name)) {
+      return cloneJson(storedGlobals[name]);
+    }
+    if (isObject(node?._doraGlobals) && Object.prototype.hasOwnProperty.call(node._doraGlobals, name)) {
+      return cloneJson(node._doraGlobals[name]);
+    }
+  }
+  if (name === "state_slot") {
+    return validStateSlot(node?.properties?.dora_state_slot) ?? fallback;
+  }
+  return fallback;
+}
+
+function syncKnownWidgetFacade(node) {
+  if (!node) return;
+  for (const widget of Array.isArray(node.widgets) ? node.widgets : []) {
+    const name = String(widget?.name ?? "");
+    if (!GLOBAL_WIDGET_KEYS.includes(name) && name !== "state_slot") continue;
+    const desired = canonicalWidgetValue(node, name, widget?.value);
+    try { widget.value = cloneJson(desired); } catch (_) {}
+  }
+}
+
+function installDynamicWidgetValueSync(node) {
+  if (!node || node.__doraPowerLoraWidgetValueSyncInstalled) return;
+  if (typeof node.addWidget !== "function") return;
+
+  const originalAddWidget = node.addWidget;
+  Object.defineProperty(node, "__doraPowerLoraWidgetValueSyncInstalled", {
+    value: true,
+    configurable: true,
+  });
+
+  node.addWidget = function () {
+    const widget = originalAddWidget.apply(this, arguments);
+    if (!widget) return widget;
+
+    const name = String(arguments[1] ?? widget.name ?? "");
+    if (!GLOBAL_WIDGET_KEYS.includes(name) && name !== "state_slot") return widget;
+
+    // Newer ComfyUI frontends keep widget values in WidgetValueStore. Recreating
+    // a same-name/same-type widget can therefore return the existing bootstrap
+    // state instead of adopting addWidget(..., initialValue). Always push the
+    // loader's property-backed canonical value into the registered widget after
+    // creation. On older LiteGraph this is just an ordinary value assignment.
+    const desired = canonicalWidgetValue(this, name, arguments[2]);
+    try { widget.value = cloneJson(desired); } catch (_) {}
+    return widget;
+  };
+}
+
 function prepareConfigureInfo(node, info) {
   if (!isObject(info)) return info;
 
@@ -298,10 +354,12 @@ app.registerExtension({
     const previousOnNodeCreated = nodeType.prototype.onNodeCreated;
     nodeType.prototype.onNodeCreated = function () {
       traceLifecycle("onNodeCreated:before", this);
+      installDynamicWidgetValueSync(this);
       const result = previousOnNodeCreated?.apply(this, arguments);
       // Workflow persistence is property-backed. Generic LiteGraph widget
       // serialization creates a competing representation and is unnecessary.
       this.serialize_widgets = false;
+      syncKnownWidgetFacade(this);
       traceLifecycle("onNodeCreated:after", this);
       return result;
     };
@@ -309,6 +367,7 @@ app.registerExtension({
     const previousConfigure = nodeType.prototype.configure;
     nodeType.prototype.configure = function (info) {
       this.serialize_widgets = false;
+      installDynamicWidgetValueSync(this);
       traceLifecycle("configure:incoming", this, {
         incoming_property_state: cloneJson(info?.properties?.dora_power_lora ?? null),
         incoming_state_slot: info?.properties?.dora_state_slot ?? null,
@@ -323,9 +382,16 @@ app.registerExtension({
       });
       const result = previousConfigure?.call(this, guardedInfo);
       this.serialize_widgets = false;
+      syncKnownWidgetFacade(this);
       traceLifecycle("configure:after", this);
-      queueMicrotask(() => traceLifecycle("configure:microtask", this));
-      setTimeout(() => traceLifecycle("configure:timeout-250ms", this), 250);
+      queueMicrotask(() => {
+        syncKnownWidgetFacade(this);
+        traceLifecycle("configure:microtask", this);
+      });
+      setTimeout(() => {
+        syncKnownWidgetFacade(this);
+        traceLifecycle("configure:timeout-250ms", this);
+      }, 250);
       return result;
     };
 
@@ -348,7 +414,11 @@ app.registerExtension({
     };
   },
   loadedGraphNode(node) {
+    syncKnownWidgetFacade(node);
     traceLifecycle("loadedGraphNode", node);
-    setTimeout(() => traceLifecycle("loadedGraphNode:timeout-500ms", node), 500);
+    setTimeout(() => {
+      syncKnownWidgetFacade(node);
+      traceLifecycle("loadedGraphNode:timeout-500ms", node);
+    }, 500);
   },
 });

--- a/web/dora_power_lora_persistence.js
+++ b/web/dora_power_lora_persistence.js
@@ -95,25 +95,23 @@ function snapshotStoredLiveState(node) {
   });
 }
 
-function snapshotAuthoritativeState(node) {
+function snapshotVisibleState(node) {
   const base = snapshotStoredLiveState(node) || { rows: [], globals: {} };
   const widgets = Array.isArray(node?.widgets) ? node.widgets : [];
   const widgetRows = rowsFromNodeWidgets(node);
   const globals = isObject(base.globals) ? { ...base.globals } : {};
   const globalKeys = new Set([...GLOBAL_WIDGET_KEYS, ...Object.keys(globals)]);
-  let capturedGlobal = false;
 
   for (const widget of widgets) {
     const name = String(widget?.name ?? "");
     if (!globalKeys.has(name) || widget?.value === undefined) continue;
     globals[name] = cloneJson(widget.value);
-    capturedGlobal = true;
   }
 
   const rows = widgetRows.length
     ? widgetRows
     : (Array.isArray(base.rows) ? base.rows : []);
-  if (!rows.length && !Object.keys(globals).length && !capturedGlobal) return null;
+  if (!rows.length && !Object.keys(globals).length) return null;
   return cloneJson({ rows, globals });
 }
 
@@ -165,16 +163,10 @@ function validStateSlot(value) {
   return typeof value === "string" && value.trim() ? value : null;
 }
 
-function snapshotStateSlot(node, named = null) {
-  const namedSlot = isObject(named) ? validStateSlot(named.state_slot) : null;
-  if (namedSlot) return namedSlot;
-
-  const stateSlotWidget = (Array.isArray(node?.widgets) ? node.widgets : [])
-    .find((widget) => widget?.name === "state_slot");
-  const widgetSlot = validStateSlot(stateSlotWidget?.value);
-  if (widgetSlot) return widgetSlot;
-
-  return validStateSlot(node?.properties?.dora_state_slot);
+function currentStateSlot(node) {
+  const widget = (Array.isArray(node?.widgets) ? node.widgets : [])
+    .find((item) => item?.name === "state_slot");
+  return validStateSlot(widget?.value) || validStateSlot(node?.properties?.dora_state_slot);
 }
 
 function prepareConfigureInfo(node, info) {
@@ -188,60 +180,66 @@ function prepareConfigureInfo(node, info) {
     : null;
   const hasLegacyWidgetValues = Array.isArray(info.widgets_values) && info.widgets_values.length > 0;
 
-  // Current ComfyUI serializes the actual visible standard widget values into
-  // widgets_values_named. Older loader builds could leave dora_power_lora stale
-  // even while those widget values were correct. Reconcile that snapshot into
-  // the canonical state before removing the duplicate representation.
-  const liveState = !serializedState && !hasLegacyWidgetValues
-    ? snapshotAuthoritativeState(node)
-    : null;
-  const baseState = serializedState || liveState;
-  const namedState = stateFromNamedWidgetValues(info.widgets_values_named, baseState?.globals);
+  // Incoming workflow data always outranks the freshly-created loader widgets.
+  // widgets_values_named is accepted only as migration data from frontend builds
+  // that previously stored loader controls there. Never derive configure state
+  // from the current widget set: on a tab reload those widgets are bootstrap
+  // defaults created before configure() runs.
+  const namedState = stateFromNamedWidgetValues(
+    info.widgets_values_named,
+    serializedState?.globals ?? node?._doraGlobals
+  );
 
-  if (!hasLegacyWidgetValues || serializedState) {
-    const reconciledState = mergeState(baseState, namedState);
-    if (reconciledState) properties.dora_power_lora = reconciledState;
+  if (serializedState || namedState) {
+    properties.dora_power_lora = mergeState(serializedState, namedState);
+  } else if (!hasLegacyWidgetValues) {
+    const liveState = snapshotStoredLiveState(node);
+    if (liveState) properties.dora_power_lora = liveState;
   }
 
   const namedSlot = isObject(info.widgets_values_named)
     ? validStateSlot(info.widgets_values_named.state_slot)
     : null;
   const incomingSlot = validStateSlot(properties.dora_state_slot);
-  const slot = namedSlot || incomingSlot || snapshotStateSlot(node);
+  const slot = namedSlot || incomingSlot || validStateSlot(node?.properties?.dora_state_slot);
   if (slot) properties.dora_state_slot = slot;
 
   if (originalProperties || Object.keys(properties).length) next.properties = properties;
 
-  // dora_power_lora is the single source after reconciliation. Leaving named
-  // values in the configure payload lets LiteGraph replay values directly into
-  // transient widgets without invoking loader callbacks.
+  // The loader owns its dynamic widget restoration. Do not let LiteGraph replay
+  // named values directly into a transient/default widget layout.
   delete next.widgets_values_named;
   return next;
 }
 
-function applyLiveStateToSerialization(node, output) {
-  if (!isObject(output)) return;
+function prepareCanonicalSerialization(node) {
+  node.serialize_widgets = false;
+  node.properties = isObject(node.properties) ? node.properties : {};
 
-  const visibleState = snapshotAuthoritativeState(node);
-  const namedState = stateFromNamedWidgetValues(output.widgets_values_named, visibleState?.globals);
-  const state = mergeState(visibleState, namedState);
+  const state = snapshotVisibleState(node);
+  if (state) node.properties.dora_power_lora = cloneJson(state);
+
+  const slot = currentStateSlot(node);
+  if (slot) node.properties.dora_state_slot = slot;
+
+  return { state, slot };
+}
+
+function finalizeCanonicalSerialization(node, output, prepared) {
+  if (!isObject(output)) return;
   output.properties = isObject(output.properties) ? output.properties : {};
 
-  if (state) {
-    output.properties.dora_power_lora = state;
-    node.properties = isObject(node.properties) ? node.properties : {};
-    node.properties.dora_power_lora = cloneJson(state);
+  if (prepared.state) {
+    output.properties.dora_power_lora = cloneJson(prepared.state);
+    node.properties.dora_power_lora = cloneJson(prepared.state);
+  }
+  if (prepared.slot) {
+    output.properties.dora_state_slot = prepared.slot;
+    node.properties.dora_state_slot = prepared.slot;
   }
 
-  const slot = snapshotStateSlot(node, output.widgets_values_named);
-  if (slot) {
-    output.properties.dora_state_slot = slot;
-    node.properties = isObject(node.properties) ? node.properties : {};
-    node.properties.dora_state_slot = slot;
-  }
-
-  // Keep the dynamic loader state single-sourced after first reconciling the
-  // current LiteGraph widget snapshot above.
+  // Older loader builds intentionally emitted an empty positional list. Keep
+  // that harmless compatibility marker, but never emit a second named state.
   output.widgets_values = [];
   delete output.widgets_values_named;
 }
@@ -256,16 +254,31 @@ app.registerExtension({
     if (nodeType.prototype.__doraPowerLoraPersistencePatched) return;
     nodeType.prototype.__doraPowerLoraPersistencePatched = true;
 
+    const previousOnNodeCreated = nodeType.prototype.onNodeCreated;
+    nodeType.prototype.onNodeCreated = function () {
+      const result = previousOnNodeCreated?.apply(this, arguments);
+      // Workflow persistence is property-backed. Generic LiteGraph widget
+      // serialization creates a competing representation and is unnecessary.
+      this.serialize_widgets = false;
+      return result;
+    };
+
     const previousConfigure = nodeType.prototype.configure;
     nodeType.prototype.configure = function (info) {
+      this.serialize_widgets = false;
       const guardedInfo = prepareConfigureInfo(this, info);
-      return previousConfigure?.call(this, guardedInfo);
+      const result = previousConfigure?.call(this, guardedInfo);
+      this.serialize_widgets = false;
+      return result;
     };
 
     const previousOnSerialize = nodeType.prototype.onSerialize;
     nodeType.prototype.onSerialize = function (output) {
+      // Reconcile the current visible controls into the canonical property
+      // before the loader/base serializer reads node.properties.
+      const prepared = prepareCanonicalSerialization(this);
       const result = previousOnSerialize?.call(this, output);
-      applyLiveStateToSerialization(this, output);
+      finalizeCanonicalSerialization(this, output, prepared);
       return result;
     };
   },

--- a/web/index.js
+++ b/web/index.js
@@ -1,2 +1,3 @@
 import "./dora_power_lora_loader.js";
+import "./dora_power_lora_persistence.js";
 import "./dora_state_manager.js";


### PR DESCRIPTION
## Summary
- fix DoRA Power LoRA Loader settings appearing to reset after switching away from a ComfyUI workflow tab and returning
- keep `properties.dora_power_lora` as the single authoritative workflow representation
- keep `_doraRows` / `_doraGlobals` as the loader-owned live state
- disable generic LiteGraph widget workflow serialization for this dynamic loader so `widgets_values` / `widgets_values_named` cannot become competing persistent state stores
- synchronize dynamically recreated standard loader widgets back to the canonical property-backed value after frontend widget registration
- retain named/positional widget formats strictly as migration inputs when canonical state is absent
- preserve legacy workflows, partial reconfiguration, null-state recovery, LoRA rows, and state-slot persistence
- prepare release metadata and notes for v1.0.40

## Confirmed root cause
The real browser trace showed that workflow persistence itself was working.

With non-default auto-strength values such as floor `0.95` and ceiling `2.0`:

1. outgoing serialization contained `0.95 / 2.0` in the canonical `properties.dora_power_lora` state;
2. switching back to the workflow delivered the same correct values to the returning node's `configure()` call;
3. the canonical property and live `_doraGlobals` remained correct after restore;
4. only the visible widget facade stayed at bootstrap defaults `0.30 / 1.50`.

The current ComfyUI frontend backs standard widget values with `WidgetValueStore`. Widgets are keyed by graph ID, node ID, widget name, and type. The DoRA loader dynamically rebuilds its widgets: a fresh node first creates bootstrap/default widgets, then `configure()` restores canonical state and recreates the same widget names. On newer frontends, the recreated same-name/same-type widget can reconnect to the already-registered bootstrap store entry instead of adopting the restored `addWidget(..., initialValue)` value.

That produced a split state: the loader internally held the correct workflow values while the UI continued to display defaults.

## Fix
The compatibility layer installs a narrow per-node `addWidget()` wrapper for the DoRA Power LoRA Loader only.

After a known loader-global widget or `state_slot` widget is created and frontend registration has occurred, the wrapper explicitly assigns the canonical property-backed value to the returned widget. On store-backed frontends this writes through the retained widget state object; on older LiteGraph/frontends it reduces to an ordinary value assignment.

A single deterministic post-`configure()` reconciliation synchronizes already-attached known widgets. There are no timeout repair loops.

The temporary browser lifecycle instrumentation used to identify the bug has been removed from the final PR.

## Persistence invariants
- `properties.dora_power_lora` is authoritative for workflow persistence.
- `_doraRows` / `_doraGlobals` are authoritative live loader state.
- generic LiteGraph `serialize_widgets` is disabled for this dynamic loader.
- `widgets_values_named` is migration-only when canonical state is absent.
- legacy positional `widgets_values` migration remains supported.
- state-slot persistence remains property-backed.

## Regression coverage
The frontend regression suite covers:
- generic LiteGraph widget workflow serialization disabled for the loader
- bootstrap defaults never overriding incoming canonical state
- canonical state beating conflicting stale named-widget data
- #14897-style workflow-tab round trip
- stale frontend widget facades not overwriting loader-owned state during serialization
- same-name store-backed widget reconstruction being synchronized to canonical floor, ceiling, device, and state-slot values
- named widget migration only when canonical state is absent
- partial configure preserving live state
- `dora_power_lora: null` recovery
- legacy positional migration

## Release
`pyproject.toml` is bumped to `1.0.40` and `RELEASE_NOTES.md` documents the confirmed root cause, fix, compatibility behavior, and browser validation. After merge, the existing workflows publish the updated package to the Comfy Registry and create the GitHub v1.0.40 release only after the `tests` workflow succeeds on `main`.