### PR TITLE
Support plain LoKr adapters in runtime bypass

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,10 +57,19 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
         shell: bash
         run: |
-          test -s "dist/ComfyUI-DoRA-Dynamic-LoRA-Loader-v${VERSION}.zip"
+          archive="dist/ComfyUI-DoRA-Dynamic-LoRA-Loader-v${VERSION}.zip"
+          prefix="ComfyUI-DoRA-Dynamic-LoRA-Loader-v${VERSION}"
+          test -s "${archive}"
           test -s dist/SHA256SUMS
           test -s RELEASE_NOTES.md
           grep -F "ComfyUI-DoRA-Dynamic-LoRA-Loader-v${VERSION}.zip" dist/SHA256SUMS
+          listing="$(unzip -Z1 "${archive}")"
+          for required in \
+            state_manager_api.py \
+            state_manager_store.py \
+            web/dora_state_manager.js; do
+            printf '%s\n' "${listing}" | grep -Fx "${prefix}/${required}"
+          done
 
       - name: Publish GitHub release
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,6 +76,11 @@ jobs:
             torch_version: "2.10.0"
             torchvision_version: "0.25.0"
             torchaudio_version: "2.10.0"
+          - comfy_version: 2026-08-21
+            comfy_ref: 28864ca8fed67cc05a957710f88ce23aff75fd2f
+            torch_version: "2.10.0"
+            torchvision_version: "0.25.0"
+            torchaudio_version: "2.10.0"
     runs-on: ubuntu-latest
     steps:
       - name: Check out custom node

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ This implementation was reworked for the unified DoRA + standard LoRA path in th
 
 ---
 
-## Runtime bypass LoRA (low VRAM)
+## Runtime bypass adapters (low VRAM)
 
-The loader includes an optional **Runtime bypass LoRA (low VRAM)** mode for supported standard LoRAs.
+The loader includes an optional **Runtime bypass LoRA (low VRAM)** mode for supported standard LoRA and plain LoKr adapters.
 
 The word **bypass** refers to bypassing **weight materialization**, not bypassing or weakening the LoRA effect. For a normal additive LoRA, the regular merged path evaluates a layer with `W + ΔW`, while the runtime path keeps `W` untouched and evaluates the equivalent low-rank contribution during the forward pass:
 
@@ -40,6 +40,12 @@ Normal materialized patching may need to retain the original model weights while
 
 Runtime bypass keeps the base model weights unchanged and stores/evaluates the low-rank adapter tensors directly, avoiding that full patched-model copy for supported adapters.
 
+### Plain LoKr support
+
+Plain LoKr adapters use ComfyUI's native LoKr forward-bypass implementation when it is available. Direct-factor, decomposed, and mixed LoRA + LoKr stacks are supported. The runtime-only adapter metadata is normalized where current ComfyUI's LoKr materialization and bypass paths use different alpha/rank conventions; the source adapter remains unchanged.
+
+Older ComfyUI revisions without a real `LoKrAdapter.h()` implementation reject LoKr runtime bypass with an explicit update/disable message. DoRA-LoKr magnitude scaling remains unsupported because ComfyUI's LoKr bypass path does not implement DoRA normalization.
+
 ### Important limitation: DoRA is not runtime-bypassed
 
 Current ComfyUI bypass LoRA math implements the additive LoRA path, but not DoRA magnitude normalization/rescaling. Treating a DoRA as ordinary bypass LoRA would therefore change its mathematics.
@@ -49,7 +55,7 @@ This loader deliberately **fails closed** when runtime bypass encounters DoRA or
 Runtime bypass currently refuses:
 
 - DoRA / magnitude-vector LoRAs (`dora_scale`, Diffusers/PEFT `lora_magnitude_vector`, `w_norm`, `b_norm`)
-- non-LoRA weight-adapter types
+- DoRA-LoKr and adapter types other than standard LoRA/plain LoKr
 - LoRA reshape metadata
 - sliced / offset / transformed adapter targets
 - non-default `strength_model` patch semantics
@@ -441,11 +447,11 @@ These patches affect DoRA / LoRA application in the running ComfyUI process, not
 
 ## Troubleshooting
 
-### Runtime bypass rejects a LoRA
+### Runtime bypass rejects an adapter
 
 Runtime bypass only takes adapters for which the supported forward-pass path preserves the normal patch semantics. In particular, current ComfyUI bypass LoRA does **not** implement DoRA magnitude normalization.
 
-If the loader reports DoRA/magnitude-vector, reshape, offset/transform, or another unsupported adapter form, disable **Runtime bypass LoRA (low VRAM)** for that file rather than trying to force it through the runtime path.
+If the loader reports DoRA/magnitude-vector, reshape, offset/transform, an older ComfyUI build without LoKr bypass math, or another unsupported adapter form, disable **Runtime bypass LoRA (low VRAM)** for that file.
 
 ### Flux2 DoRA instability
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,15 @@
-# Unreleased
+# DoRA Dynamic LoRA Loader v1.0.41
+
+This release moves State Manager presets into a backend-authoritative per-user library and adds mathematically equivalent runtime bypass support for plain LoKr adapters on compatible ComfyUI revisions.
+
+## Plain LoKr runtime bypass
+
+- Adds runtime bypass support for plain direct-factor, decomposed, and mixed LoRA + LoKr adapter stacks when ComfyUI provides native LoKr bypass math.
+- Preserves current ComfyUI materialized LoKr semantics across direct-factor alpha values and unequal decomposed ranks through runtime-only adapter copies.
+- Keeps source adapters unchanged and continues to reject DoRA-LoKr, sliced/offset/transformed targets, reshape LoRA, and unsupported adapter forms.
+- Rejects LoKr runtime mode explicitly on older ComfyUI revisions whose `LoKrAdapter` lacks forward-bypass math.
+- Defers deterministic runtime validation failures across the base loader's retry boundary and commits captured adapters transactionally, preventing partial or duplicate hooks after a failed materialized-patch attempt.
+- Adds parity, mixed-stack, rejection, retry, rollback, and hook-restoration coverage against a pinned current ComfyUI revision.
 
 ## State Manager persistent library architecture
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "dora-dynamic-lora-loader"
 description = "A ComfyUI custom node that loads and stacks regular LoRAs and DoRA LoRAs with Flux/Flux2 and OneTrainer compatibility fixes."
-version = "1.0.40"
+version = "1.0.41"
 license = { file = "LICENSE" }
 
 [project.urls]

--- a/runtime_bypass.py
+++ b/runtime_bypass.py
@@ -445,6 +445,7 @@ class RuntimeBypassDoraPowerLoraLoader(_base.DoraPowerLoraLoader):
 
                 regular: Dict[Any, Any] = {}
                 applied: List[Any] = []
+                staged_capture: List[Dict[str, Any]] = []
 
                 for raw_key, patch_data in patches.items():
                     key, offset, function = _patch_target(raw_key)
@@ -458,7 +459,7 @@ class RuntimeBypassDoraPowerLoraLoader(_base.DoraPowerLoraLoader):
                                 "Runtime bypass does not currently support sliced/offset or transformed adapter targets. "
                                 f"{lora_name!r} uses one at {raw_key!r}. Disable Runtime bypass LoRA for this file."
                             )
-                        capture.append(
+                        staged_capture.append(
                             {
                                 "key": key,
                                 "adapter": runtime_adapter,
@@ -485,6 +486,11 @@ class RuntimeBypassDoraPowerLoraLoader(_base.DoraPowerLoraLoader):
                         target,
                     )
 
+                # Commit runtime captures only after every adapter validates and
+                # any materialized patches complete. The base loader retries
+                # add_patches() after an exception; mutating the shared capture
+                # earlier would retain a partial attempt and duplicate adapters.
+                capture.extend(staged_capture)
                 return applied
             except RuntimeBypassUnsupportedError as exc:
                 if deferred_errors is None:

--- a/runtime_bypass.py
+++ b/runtime_bypass.py
@@ -1,17 +1,18 @@
-"""Opt-in runtime/bypass LoRA mode for the DoRA Power LoRA Loader.
+"""Opt-in runtime/bypass adapter mode for the DoRA Power LoRA Loader.
 
 The normal ComfyUI LoRA path materializes patched model weights. On very large
-HIGH_VRAM models that can retain a second full copy of every LoRA-targeted base
+HIGH_VRAM models that can retain a second full copy of every adapter-targeted base
 weight. Runtime bypass mode keeps the base weights untouched and evaluates
-standard LoRA adapters in the module forward pass instead.
+supported adapters in the module forward pass instead.
 
-Safety is deliberate: ComfyUI's bypass LoRA implementation does not implement
+Safety is deliberate: ComfyUI's bypass adapter implementation does not implement
 DoRA magnitude normalization, so this mode refuses DoRA and other adapter forms
 that cannot be represented exactly by the supported runtime path.
 """
 
 from __future__ import annotations
 
+import copy
 import json
 import logging
 import os
@@ -32,7 +33,7 @@ _RUNTIME_INJECTION_PREFIX = "dora_runtime_bypass_lora"
 
 
 class RuntimeBypassUnsupportedError(RuntimeError):
-    """Raised when runtime mode would change the mathematical meaning of a LoRA."""
+    """Raised when runtime mode would change the mathematical meaning of an adapter."""
 
 
 def _as_bool(value: Any, default: bool = False) -> bool:
@@ -138,35 +139,119 @@ def _resolve_module(root: Any, weight_key: str) -> Any:
 
 
 def _validate_lora_adapter(adapter: Any, lora_name: str, raw_key: Any) -> None:
-    if not isinstance(adapter, comfy.weight_adapter.LoRAAdapter):
-        raise RuntimeBypassUnsupportedError(
-            "Runtime bypass currently supports standard LoRA adapters only. "
-            f"{lora_name!r} produced {type(adapter).__name__} for {raw_key!r}. "
-            "Disable Runtime bypass LoRA for this file."
-        )
-
+    """Fail closed unless the adapter has runtime math equivalent to materialized patching."""
     weights = getattr(adapter, "weights", None)
     if not isinstance(weights, (tuple, list)):
         raise RuntimeBypassUnsupportedError(
-            f"Runtime bypass could not inspect the LoRA adapter for {lora_name!r} at {raw_key!r}."
+            f"Runtime bypass could not inspect {type(adapter).__name__} for {lora_name!r} at {raw_key!r}."
         )
 
-    # ComfyUI LoRAAdapter weights are:
-    # (up, down, alpha, mid, dora_scale, reshape)
-    dora_scale = weights[4] if len(weights) > 4 else None
-    reshape = weights[5] if len(weights) > 5 else None
-    if dora_scale is not None:
-        raise RuntimeBypassUnsupportedError(
-            "Runtime bypass LoRA is enabled, but "
-            f"{lora_name!r} contains DoRA magnitude scaling at {raw_key!r}. "
-            "ComfyUI's runtime bypass path does not apply DoRA magnitude normalization, "
-            "so running it would silently change the result. Disable Runtime bypass LoRA for this DoRA."
-        )
-    if reshape is not None:
-        raise RuntimeBypassUnsupportedError(
-            "Runtime bypass does not currently support LoRA reshape metadata. "
-            f"{lora_name!r} uses it at {raw_key!r}. Disable Runtime bypass LoRA for this file."
-        )
+    if isinstance(adapter, comfy.weight_adapter.LoRAAdapter):
+        # ComfyUI LoRAAdapter weights are:
+        # (up, down, alpha, mid, dora_scale, reshape)
+        dora_scale = weights[4] if len(weights) > 4 else None
+        reshape = weights[5] if len(weights) > 5 else None
+        if dora_scale is not None:
+            raise RuntimeBypassUnsupportedError(
+                "Runtime bypass LoRA is enabled, but "
+                f"{lora_name!r} contains DoRA magnitude scaling at {raw_key!r}. "
+                "ComfyUI's runtime bypass path does not apply DoRA magnitude normalization, "
+                "so running it would silently change the result. Disable Runtime bypass LoRA for this DoRA."
+            )
+        if reshape is not None:
+            raise RuntimeBypassUnsupportedError(
+                "Runtime bypass does not currently support LoRA reshape metadata. "
+                f"{lora_name!r} uses it at {raw_key!r}. Disable Runtime bypass LoRA for this file."
+            )
+        return
+
+    lokr_type = getattr(comfy.weight_adapter, "LoKrAdapter", None)
+    if isinstance(lokr_type, type) and isinstance(adapter, lokr_type):
+        # A WeightAdapterBase subclass that inherits the base h() would silently add
+        # zeros in bypass mode. Require ComfyUI's real LoKr bypass implementation.
+        base_h = getattr(comfy.weight_adapter.WeightAdapterBase, "h", None)
+        lokr_h = getattr(type(adapter), "h", None)
+        if not callable(lokr_h) or lokr_h is base_h:
+            raise RuntimeBypassUnsupportedError(
+                "Runtime bypass received a LoKr adapter, but this ComfyUI build does not implement "
+                f"LoKr bypass math for {lora_name!r} at {raw_key!r}. Update ComfyUI or disable Runtime bypass LoRA."
+            )
+
+        # ComfyUI LoKrAdapter weights are:
+        # (w1, w2, alpha, w1_a, w1_b, w2_a, w2_b, t2, dora_scale)
+        if len(weights) < 9:
+            raise RuntimeBypassUnsupportedError(
+                f"Runtime bypass could not inspect the complete LoKr weights for {lora_name!r} at {raw_key!r}."
+            )
+        dora_scale = weights[8]
+        if dora_scale is not None:
+            raise RuntimeBypassUnsupportedError(
+                "Runtime bypass LoRA is enabled, but "
+                f"{lora_name!r} contains LoKr DoRA magnitude scaling at {raw_key!r}. "
+                "ComfyUI's LoKr bypass path does not apply DoRA magnitude normalization, "
+                "so running it would silently change the result. Disable Runtime bypass LoRA for this DoRA-LoKr."
+            )
+        return
+
+    raise RuntimeBypassUnsupportedError(
+        "Runtime bypass currently supports standard LoRA and plain LoKr adapters only. "
+        f"{lora_name!r} produced {type(adapter).__name__} for {raw_key!r}. "
+        "Disable Runtime bypass LoRA for this file."
+    )
+
+
+def _runtime_adapter_for_bypass(adapter: Any, lora_name: str, raw_key: Any) -> Any:
+    """Return an adapter whose bypass math matches ComfyUI materialized semantics."""
+    _validate_lora_adapter(adapter, lora_name, raw_key)
+
+    lokr_type = getattr(comfy.weight_adapter, "LoKrAdapter", None)
+    if not (isinstance(lokr_type, type) and isinstance(adapter, lokr_type)):
+        return adapter
+
+    weights = list(adapter.weights)
+    w1, w2, alpha = weights[0], weights[1], weights[2]
+    w1_b = weights[4]
+    w2_b = weights[6]
+
+    # Current ComfyUI materialized LoKr intentionally ignores alpha when both
+    # Kronecker factors are stored directly. Its bypass h() instead expresses that
+    # as alpha / alpha, which becomes NaN for alpha=Inf and divides by zero for
+    # alpha=0. Normalize the runtime-only copy to 1.0 so the bypass result exactly
+    # follows materialized semantics for every direct-factor alpha value.
+    if w1 is not None and w2 is not None:
+        weights[2] = 1.0
+        runtime_adapter = copy.copy(adapter)
+        runtime_adapter.weights = tuple(weights) if isinstance(adapter.weights, tuple) else weights
+        return runtime_adapter
+
+    # When both factors are decomposed, current ComfyUI materialization uses the
+    # w2 decomposition rank for alpha scaling while bypass h() selects the w1 rank.
+    # Equal ranks are already equivalent. For unequal ranks, adjust alpha only on
+    # the runtime copy so alpha_runtime/rank_w1 == alpha_materialized/rank_w2.
+    if w1 is None and w2 is None and alpha is not None:
+        try:
+            rank_w1 = int(w1_b.shape[0])
+            rank_w2 = int(w2_b.shape[0])
+        except Exception as exc:
+            raise RuntimeBypassUnsupportedError(
+                f"Runtime bypass could not determine LoKr decomposition ranks for {lora_name!r} at {raw_key!r}."
+            ) from exc
+        if rank_w1 <= 0 or rank_w2 <= 0:
+            raise RuntimeBypassUnsupportedError(
+                f"Runtime bypass received invalid LoKr decomposition ranks {rank_w1}/{rank_w2} for {lora_name!r} at {raw_key!r}."
+            )
+        if rank_w1 != rank_w2:
+            try:
+                weights[2] = float(alpha) * (float(rank_w1) / float(rank_w2))
+            except Exception as exc:
+                raise RuntimeBypassUnsupportedError(
+                    f"Runtime bypass could not normalize LoKr alpha scaling for {lora_name!r} at {raw_key!r}."
+                ) from exc
+            runtime_adapter = copy.copy(adapter)
+            runtime_adapter.weights = tuple(weights) if isinstance(adapter.weights, tuple) else weights
+            return runtime_adapter
+
+    return adapter
 
 
 def _make_stacked_injection(
@@ -216,7 +301,7 @@ def _make_stacked_injection(
             raise
 
     def eject_all(_model_patcher):
-        # Multiple LoRAs on one module form nested forward wrappers. They MUST be
+        # Multiple adapters on one module form nested forward wrappers. They MUST be
         # removed in reverse order or an older wrapper can be restored accidentally.
         first_error = None
         while active_hooks:
@@ -259,7 +344,7 @@ def _instance_override(obj: Any, name: str, replacement: Any):
 
 
 class RuntimeBypassDoraPowerLoraLoader(_base.DoraPowerLoraLoader):
-    """DoRA Power LoRA Loader with an opt-in low-VRAM standard-LoRA runtime path."""
+    """DoRA Power LoRA Loader with an opt-in low-VRAM runtime adapter path."""
 
     @classmethod
     def INPUT_TYPES(cls):
@@ -271,7 +356,7 @@ class RuntimeBypassDoraPowerLoraLoader(_base.DoraPowerLoraLoader):
                 {
                     "default": False,
                     "tooltip": (
-                        "Apply standard LoRAs in the forward pass instead of materializing patched model weights. "
+                        "Apply supported LoRA/LoKr adapters in the forward pass instead of materializing patched model weights. "
                         "Greatly reduces persistent VRAM on very large HIGH_VRAM models. DoRA and unsupported "
                         "adapter/offset forms are refused rather than approximated."
                     ),
@@ -320,7 +405,7 @@ class RuntimeBypassDoraPowerLoraLoader(_base.DoraPowerLoraLoader):
             suffix = "" if len(dora_keys) <= 3 else f" (+{len(dora_keys) - 3} more)"
             raise RuntimeBypassUnsupportedError(
                 "Runtime bypass LoRA is enabled, but "
-                f"{lora_name!r} is a DoRA/magnitude LoRA ({examples}{suffix}). "
+                f"{lora_name!r} is a DoRA/magnitude adapter ({examples}{suffix}). "
                 "ComfyUI's bypass adapter math does not implement DoRA magnitude normalization. "
                 "Disable Runtime bypass LoRA for this file; it will not be silently approximated."
             )
@@ -331,69 +416,81 @@ class RuntimeBypassDoraPowerLoraLoader(_base.DoraPowerLoraLoader):
         state_dict_keys: set[str],
         original_add_patches: Any,
         lora_name: str,
+        deferred_errors=None,
     ):
         capture = self._runtime_bypass_capture[target]
 
         def add_patches_runtime(patches, *args, **kwargs):
-            strength_patch = kwargs.get("strength_patch", args[0] if args else 1.0)
-            strength_model = kwargs.get("strength_model", args[1] if len(args) > 1 else 1.0)
+            # The base loader currently retries add_patches() after any exception.
+            # Runtime validation failures are deterministic, so defer them until
+            # _load_one() returns and raise once outside that retry block.
+            if deferred_errors:
+                return []
             try:
-                strength_patch_f = float(strength_patch)
-                strength_model_f = float(strength_model)
-            except Exception as exc:
-                raise RuntimeBypassUnsupportedError(
-                    f"Runtime bypass received non-scalar patch strengths for {lora_name!r}."
-                ) from exc
+                strength_patch = kwargs.get("strength_patch", args[0] if args else 1.0)
+                strength_model = kwargs.get("strength_model", args[1] if len(args) > 1 else 1.0)
+                try:
+                    strength_patch_f = float(strength_patch)
+                    strength_model_f = float(strength_model)
+                except Exception as exc:
+                    raise RuntimeBypassUnsupportedError(
+                        f"Runtime bypass received non-scalar patch strengths for {lora_name!r}."
+                    ) from exc
 
-            if abs(strength_model_f - 1.0) > 1e-12:
-                raise RuntimeBypassUnsupportedError(
-                    "Runtime bypass cannot reproduce ModelPatcher strength_model scaling. "
-                    f"{lora_name!r} requested strength_model={strength_model_f}."
-                )
-
-            regular: Dict[Any, Any] = {}
-            applied: List[Any] = []
-
-            for raw_key, patch_data in patches.items():
-                key, offset, function = _patch_target(raw_key)
-                if key not in state_dict_keys:
-                    continue
-
-                if isinstance(patch_data, comfy.weight_adapter.WeightAdapterBase):
-                    _validate_lora_adapter(patch_data, lora_name, raw_key)
-                    if offset is not None or function is not None:
-                        raise RuntimeBypassUnsupportedError(
-                            "Runtime bypass does not currently support sliced/offset or transformed LoRA targets. "
-                            f"{lora_name!r} uses one at {raw_key!r}. Disable Runtime bypass LoRA for this file."
-                        )
-                    capture.append(
-                        {
-                            "key": key,
-                            "adapter": patch_data,
-                            "strength": strength_patch_f,
-                            "lora_name": lora_name,
-                        }
+                if abs(strength_model_f - 1.0) > 1e-12:
+                    raise RuntimeBypassUnsupportedError(
+                        "Runtime bypass cannot reproduce ModelPatcher strength_model scaling. "
+                        f"{lora_name!r} requested strength_model={strength_model_f}."
                     )
-                    applied.append(raw_key)
-                else:
-                    # Match ComfyUI's own bypass loader: non-adapter patches retain
-                    # their normal materialized semantics. Standard LoRA files should
-                    # overwhelmingly/entirely take the adapter path above.
-                    regular[raw_key] = patch_data
 
-            if regular:
-                result = original_add_patches(regular, *args, **kwargs)
-                if result:
-                    applied.extend(result)
-                _LOG.warning(
-                    "[DoRA Power LoRA Loader] runtime bypass: %s contains %d non-adapter patch(es) for %s; "
-                    "those patches still use normal materialized weight patching.",
-                    lora_name,
-                    len(regular),
-                    target,
-                )
+                regular: Dict[Any, Any] = {}
+                applied: List[Any] = []
 
-            return applied
+                for raw_key, patch_data in patches.items():
+                    key, offset, function = _patch_target(raw_key)
+                    if key not in state_dict_keys:
+                        continue
+
+                    if isinstance(patch_data, comfy.weight_adapter.WeightAdapterBase):
+                        runtime_adapter = _runtime_adapter_for_bypass(patch_data, lora_name, raw_key)
+                        if offset is not None or function is not None:
+                            raise RuntimeBypassUnsupportedError(
+                                "Runtime bypass does not currently support sliced/offset or transformed adapter targets. "
+                                f"{lora_name!r} uses one at {raw_key!r}. Disable Runtime bypass LoRA for this file."
+                            )
+                        capture.append(
+                            {
+                                "key": key,
+                                "adapter": runtime_adapter,
+                                "strength": strength_patch_f,
+                                "lora_name": lora_name,
+                            }
+                        )
+                        applied.append(raw_key)
+                    else:
+                        # Match ComfyUI's own bypass loader: non-adapter patches retain
+                        # their normal materialized semantics. Supported runtime adapter
+                        # files should overwhelmingly/entirely take the adapter path above.
+                        regular[raw_key] = patch_data
+
+                if regular:
+                    result = original_add_patches(regular, *args, **kwargs)
+                    if result:
+                        applied.extend(result)
+                    _LOG.warning(
+                        "[DoRA Power LoRA Loader] runtime bypass: %s contains %d non-adapter patch(es) for %s; "
+                        "those patches still use normal materialized weight patching.",
+                        lora_name,
+                        len(regular),
+                        target,
+                    )
+
+                return applied
+            except RuntimeBypassUnsupportedError as exc:
+                if deferred_errors is None:
+                    raise
+                deferred_errors.append(exc)
+                return []
 
         return add_patches_runtime
 
@@ -408,6 +505,7 @@ class RuntimeBypassDoraPowerLoraLoader(_base.DoraPowerLoraLoader):
         self._runtime_preflight(lora_name)
 
         restores = []
+        deferred_errors: List[BaseException] = []
         try:
             if model is not None:
                 model_keys = set(model.model.state_dict().keys())
@@ -416,7 +514,13 @@ class RuntimeBypassDoraPowerLoraLoader(_base.DoraPowerLoraLoader):
                     _instance_override(
                         model,
                         "add_patches",
-                        self._capture_add_patches("model", model_keys, original, lora_name),
+                        self._capture_add_patches(
+                            "model",
+                            model_keys,
+                            original,
+                            lora_name,
+                            deferred_errors,
+                        ),
                     )
                 )
 
@@ -427,11 +531,20 @@ class RuntimeBypassDoraPowerLoraLoader(_base.DoraPowerLoraLoader):
                     _instance_override(
                         clip,
                         "add_patches",
-                        self._capture_add_patches("clip", clip_keys, original, lora_name),
+                        self._capture_add_patches(
+                            "clip",
+                            clip_keys,
+                            original,
+                            lora_name,
+                            deferred_errors,
+                        ),
                     )
                 )
 
-            return super()._load_one(model, clip, *args, **kwargs)
+            output = super()._load_one(model, clip, *args, **kwargs)
+            if deferred_errors:
+                raise deferred_errors[0]
+            return output
         finally:
             for restore in reversed(restores):
                 restore()
@@ -460,7 +573,7 @@ class RuntimeBypassDoraPowerLoraLoader(_base.DoraPowerLoraLoader):
             if not isinstance(output, dict) or "result" not in output:
                 if captured:
                     raise RuntimeBypassUnsupportedError(
-                        "Runtime bypass captured LoRA adapters, but the loader output shape is unsupported, "
+                        "Runtime bypass captured adapters, but the loader output shape is unsupported, "
                         "so the adapters cannot be injected. Disable Runtime bypass LoRA."
                     )
                 return output
@@ -469,7 +582,7 @@ class RuntimeBypassDoraPowerLoraLoader(_base.DoraPowerLoraLoader):
             if not isinstance(result, (tuple, list)):
                 if captured:
                     raise RuntimeBypassUnsupportedError(
-                        "Runtime bypass captured LoRA adapters, but the loader result is not a sequence, "
+                        "Runtime bypass captured adapters, but the loader result is not a sequence, "
                         "so the adapters cannot be injected. Disable Runtime bypass LoRA."
                     )
                 return output
@@ -493,7 +606,7 @@ class RuntimeBypassDoraPowerLoraLoader(_base.DoraPowerLoraLoader):
 
             _LOG.info(
                 "[DoRA Power LoRA Loader] Runtime bypass LoRA enabled: model_hooks=%d clip_hooks=%d. "
-                "Base weights remain unmaterialized for these standard-LoRA adapters.",
+                "Base weights remain unmaterialized for these runtime adapters.",
                 model_count,
                 clip_count,
             )

--- a/tests/test_runtime_bypass_error_deferral.py
+++ b/tests/test_runtime_bypass_error_deferral.py
@@ -16,6 +16,20 @@ def make_dora_adapter(comfy_weight_adapter):
     )
 
 
+def make_lora_adapter(comfy_weight_adapter):
+    return comfy_weight_adapter.LoRAAdapter(
+        set(),
+        (
+            torch.tensor([[1.0], [0.5]], dtype=torch.float32),
+            torch.tensor([[0.25, -0.5, 1.0]], dtype=torch.float32),
+            1.0,
+            None,
+            None,
+            None,
+        ),
+    )
+
+
 def test_runtime_validation_error_is_deferred_only_once(dora_modules):
     _, runtime = dora_modules
     loader = runtime.RuntimeBypassDoraPowerLoraLoader()
@@ -40,6 +54,64 @@ def test_runtime_validation_error_is_deferred_only_once(dora_modules):
     # no-op and cannot generate another copy of the same exception.
     assert capture_add({"layer.weight": adapter}, 1.0) == []
     assert len(deferred) == 1
+    assert loader._runtime_bypass_capture["model"] == []
+
+
+def test_runtime_capture_is_transactional_across_base_retry(dora_modules):
+    _, runtime = dora_modules
+    loader = runtime.RuntimeBypassDoraPowerLoraLoader()
+    loader._runtime_bypass_capture = {"model": [], "clip": []}
+    adapter = make_lora_adapter(runtime.comfy.weight_adapter)
+    attempts = []
+
+    def materialize_regular(patches, *args, **kwargs):
+        attempts.append(dict(patches))
+        if len(attempts) == 1:
+            raise RuntimeError("transient materialization failure")
+        return list(patches)
+
+    capture_add = loader._capture_add_patches(
+        "model",
+        {"layer.weight", "layer.bias"},
+        materialize_regular,
+        "mixed.safetensors",
+    )
+    patches = {
+        "layer.weight": adapter,
+        "layer.bias": torch.tensor([0.25, -0.5], dtype=torch.float32),
+    }
+
+    with pytest.raises(RuntimeError, match="transient materialization failure"):
+        capture_add(patches, 0.75)
+    assert loader._runtime_bypass_capture["model"] == []
+
+    assert capture_add(patches, 0.75) == ["layer.weight", "layer.bias"]
+    assert len(attempts) == 2
+    assert len(loader._runtime_bypass_capture["model"]) == 1
+    assert loader._runtime_bypass_capture["model"][0]["adapter"] is adapter
+
+
+def test_deferred_validation_does_not_commit_partial_capture(dora_modules):
+    _, runtime = dora_modules
+    loader = runtime.RuntimeBypassDoraPowerLoraLoader()
+    loader._runtime_bypass_capture = {"model": [], "clip": []}
+    deferred = []
+    patches = {
+        "first.weight": make_lora_adapter(runtime.comfy.weight_adapter),
+        "second.weight": make_dora_adapter(runtime.comfy.weight_adapter),
+    }
+
+    capture_add = loader._capture_add_patches(
+        "model",
+        set(patches),
+        lambda regular, *args, **kwargs: list(regular),
+        "partially-supported.safetensors",
+        deferred,
+    )
+
+    assert capture_add(patches, 1.0) == []
+    assert len(deferred) == 1
+    assert isinstance(deferred[0], runtime.RuntimeBypassUnsupportedError)
     assert loader._runtime_bypass_capture["model"] == []
 
 

--- a/tests/test_runtime_bypass_error_deferral.py
+++ b/tests/test_runtime_bypass_error_deferral.py
@@ -1,0 +1,97 @@
+import pytest
+import torch
+
+
+def make_dora_adapter(comfy_weight_adapter):
+    return comfy_weight_adapter.LoRAAdapter(
+        set(),
+        (
+            torch.tensor([[1.0], [0.5]], dtype=torch.float32),
+            torch.tensor([[0.25, -0.5, 1.0]], dtype=torch.float32),
+            1.0,
+            None,
+            torch.ones(2, dtype=torch.float32),
+            None,
+        ),
+    )
+
+
+def test_runtime_validation_error_is_deferred_only_once(dora_modules):
+    _, runtime = dora_modules
+    loader = runtime.RuntimeBypassDoraPowerLoraLoader()
+    loader._runtime_bypass_capture = {"model": [], "clip": []}
+    adapter = make_dora_adapter(runtime.comfy.weight_adapter)
+    deferred = []
+
+    capture_add = loader._capture_add_patches(
+        "model",
+        {"layer.weight"},
+        lambda patches, *args, **kwargs: list(patches),
+        "dora.safetensors",
+        deferred,
+    )
+
+    assert capture_add({"layer.weight": adapter}, 1.0) == []
+    assert len(deferred) == 1
+    assert isinstance(deferred[0], runtime.RuntimeBypassUnsupportedError)
+
+    # nodes.py currently retries add_patches() after a raised exception. Once a
+    # runtime validation failure has been deferred, a second invocation becomes a
+    # no-op and cannot generate another copy of the same exception.
+    assert capture_add({"layer.weight": adapter}, 1.0) == []
+    assert len(deferred) == 1
+    assert loader._runtime_bypass_capture["model"] == []
+
+
+def test_runtime_load_one_raises_deferred_validation_after_base_retry_boundary(
+    dora_modules,
+    monkeypatch,
+):
+    _, runtime = dora_modules
+    adapter = make_dora_adapter(runtime.comfy.weight_adapter)
+    base_cls = runtime._base.DoraPowerLoraLoader
+    add_attempts = []
+
+    class TinyModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.layer = torch.nn.Linear(3, 2, bias=False)
+
+    class FakePatcher:
+        def __init__(self):
+            self.model = TinyModel()
+
+        def add_patches(self, patches, strength_patch=1.0, strength_model=1.0):
+            raise AssertionError("runtime adapter validation should intercept before materialization")
+
+    def fake_base_load_one(self, model, clip, *args, **kwargs):
+        # Mirror the current base loader's try/retry shape. With deferral, the first
+        # call returns normally, so this retry path is never entered.
+        try:
+            add_attempts.append("first")
+            model.add_patches({"layer.weight": adapter}, 1.0)
+        except Exception:
+            add_attempts.append("retry")
+            model.add_patches({"layer.weight": adapter}, 1.0)
+        return model, clip, {}
+
+    monkeypatch.setattr(base_cls, "_load_one", fake_base_load_one)
+    monkeypatch.setattr(
+        runtime.RuntimeBypassDoraPowerLoraLoader,
+        "_runtime_preflight",
+        lambda self, lora_name: None,
+    )
+
+    loader = runtime.RuntimeBypassDoraPowerLoraLoader()
+    loader._runtime_bypass_active = True
+    loader._runtime_bypass_capture = {"model": [], "clip": []}
+
+    with pytest.raises(runtime.RuntimeBypassUnsupportedError, match="DoRA magnitude scaling"):
+        loader._load_one(
+            FakePatcher(),
+            None,
+            lora_name="dora.safetensors",
+        )
+
+    assert add_attempts == ["first"]
+    assert loader._runtime_bypass_capture["model"] == []

--- a/tests/test_runtime_bypass_lokr.py
+++ b/tests/test_runtime_bypass_lokr.py
@@ -1,0 +1,379 @@
+import pytest
+import torch
+import torch.nn.functional as F
+
+
+def make_lora_adapter(comfy_weight_adapter, up, down, *, alpha=1.0):
+    return comfy_weight_adapter.LoRAAdapter(
+        set(),
+        (
+            torch.tensor(up, dtype=torch.float32),
+            torch.tensor(down, dtype=torch.float32),
+            alpha,
+            None,
+            None,
+            None,
+        ),
+    )
+
+
+def make_lokr_adapter(
+    comfy_weight_adapter,
+    w1,
+    w2,
+    *,
+    alpha=1.0,
+    dora_scale=None,
+    require_bypass=True,
+):
+    lokr_type = getattr(comfy_weight_adapter, "LoKrAdapter", None)
+    if lokr_type is None:
+        pytest.skip("This ComfyUI revision does not expose LoKrAdapter")
+    if require_bypass:
+        base_h = getattr(comfy_weight_adapter.WeightAdapterBase, "h", None)
+        lokr_h = getattr(lokr_type, "h", None)
+        if not callable(lokr_h) or lokr_h is base_h:
+            pytest.skip("This ComfyUI revision does not implement LoKr bypass math")
+    return lokr_type(
+        set(),
+        (
+            torch.tensor(w1, dtype=torch.float32),
+            torch.tensor(w2, dtype=torch.float32),
+            alpha,
+            None,
+            None,
+            None,
+            None,
+            None,
+            dora_scale,
+        ),
+    )
+
+
+def test_plain_lokr_adapter_is_accepted_when_comfy_has_native_bypass(dora_modules):
+    _, runtime = dora_modules
+    adapter = make_lokr_adapter(
+        runtime.comfy.weight_adapter,
+        [[1.0, -0.25], [0.5, 0.75]],
+        [[0.3, -0.2, 0.1], [0.4, 0.6, -0.5]],
+    )
+
+    runtime._validate_lora_adapter(adapter, "plain_lokr.safetensors", "layer.weight")
+
+
+def test_lokr_dora_scale_is_refused(dora_modules):
+    _, runtime = dora_modules
+    adapter = make_lokr_adapter(
+        runtime.comfy.weight_adapter,
+        [[1.0]],
+        [[0.3, -0.2, 0.1], [0.4, 0.6, -0.5]],
+        dora_scale=torch.ones(2, dtype=torch.float32),
+    )
+
+    with pytest.raises(runtime.RuntimeBypassUnsupportedError, match="LoKr DoRA magnitude scaling"):
+        runtime._validate_lora_adapter(adapter, "dora_lokr.safetensors", "layer.weight")
+
+
+def test_lokr_without_real_comfy_bypass_math_is_refused(dora_modules, monkeypatch):
+    _, runtime = dora_modules
+    comfy_weight_adapter = runtime.comfy.weight_adapter
+    adapter = make_lokr_adapter(
+        comfy_weight_adapter,
+        [[1.0]],
+        [[0.3, -0.2, 0.1], [0.4, 0.6, -0.5]],
+        require_bypass=False,
+    )
+
+    monkeypatch.setattr(
+        type(adapter),
+        "h",
+        comfy_weight_adapter.WeightAdapterBase.h,
+    )
+
+    with pytest.raises(runtime.RuntimeBypassUnsupportedError, match="does not implement LoKr bypass math"):
+        runtime._validate_lora_adapter(adapter, "old_comfy_lokr.safetensors", "layer.weight")
+
+
+def test_lokr_is_captured_without_materializing_patch(dora_modules):
+    _, runtime = dora_modules
+    loader = runtime.RuntimeBypassDoraPowerLoraLoader()
+    loader._runtime_bypass_capture = {"model": [], "clip": []}
+    adapter = make_lokr_adapter(
+        runtime.comfy.weight_adapter,
+        [[1.0, -0.25], [0.5, 0.75]],
+        [[0.3, -0.2, 0.1], [0.4, 0.6, -0.5]],
+    )
+    materialized_calls = []
+
+    def original_add_patches(patches, *args, **kwargs):
+        materialized_calls.append((patches, args, kwargs))
+        return list(patches)
+
+    capture_add = loader._capture_add_patches(
+        "model",
+        {"layer.weight"},
+        original_add_patches,
+        "plain_lokr.safetensors",
+    )
+    applied = capture_add({"layer.weight": adapter}, 0.65)
+
+    assert applied == ["layer.weight"]
+    assert materialized_calls == []
+    captured = loader._runtime_bypass_capture["model"]
+    assert len(captured) == 1
+    assert captured[0]["key"] == "layer.weight"
+    assert captured[0]["adapter"] is not adapter
+    assert captured[0]["adapter"].weights[2] == pytest.approx(1.0)
+    assert captured[0]["strength"] == pytest.approx(0.65)
+    assert captured[0]["lora_name"] == "plain_lokr.safetensors"
+
+
+def test_direct_lokr_nonfinite_alpha_is_normalized_to_materialized_semantics(dora_modules):
+    _, runtime = dora_modules
+    comfy_weight_adapter = runtime.comfy.weight_adapter
+    loader = runtime.RuntimeBypassDoraPowerLoraLoader()
+    loader._runtime_bypass_capture = {"model": [], "clip": []}
+
+    w1 = torch.tensor([[0.5, -0.25], [0.75, 0.2]], dtype=torch.float32)
+    w2 = torch.tensor([[0.3, -0.2, 0.1], [0.4, 0.6, -0.5]], dtype=torch.float32)
+    adapter = make_lokr_adapter(
+        comfy_weight_adapter,
+        w1.tolist(),
+        w2.tolist(),
+        alpha=float("inf"),
+    )
+
+    capture_add = loader._capture_add_patches(
+        "model",
+        {"layer.weight"},
+        lambda patches, *args, **kwargs: list(patches),
+        "inf_alpha_lokr.safetensors",
+    )
+    capture_add({"layer.weight": adapter}, 0.7)
+    captured_adapter = loader._runtime_bypass_capture["model"][0]["adapter"]
+
+    assert captured_adapter is not adapter
+    assert adapter.weights[2] == float("inf")
+    assert captured_adapter.weights[2] == pytest.approx(1.0)
+
+    class TinyModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.layer = torch.nn.Linear(6, 4, bias=False)
+
+    model = TinyModel()
+    x = torch.tensor([[0.2, -0.7, 1.1, 0.3, -0.4, 0.9]], dtype=torch.float32)
+    base = model.layer(x).detach().clone()
+    expected_delta = F.linear(x, torch.kron(w1, w2)) * 0.7
+
+    injections, _ = runtime._make_stacked_injection(
+        model,
+        [{"key": "layer.weight", "adapter": captured_adapter, "strength": 0.7, "lora_name": "inf_alpha"}],
+    )
+    injections[0].inject(None)
+    try:
+        actual = model.layer(x)
+        assert torch.isfinite(actual).all()
+        torch.testing.assert_close(actual, base + expected_delta)
+    finally:
+        injections[0].eject(None)
+
+
+def test_unequal_decomposed_lokr_ranks_are_normalized_to_materialized_scale(dora_modules):
+    _, runtime = dora_modules
+    comfy_weight_adapter = runtime.comfy.weight_adapter
+    lokr_type = getattr(comfy_weight_adapter, "LoKrAdapter", None)
+    if lokr_type is None:
+        pytest.skip("This ComfyUI revision does not expose LoKrAdapter")
+    base_h = getattr(comfy_weight_adapter.WeightAdapterBase, "h", None)
+    lokr_h = getattr(lokr_type, "h", None)
+    if not callable(lokr_h) or lokr_h is base_h:
+        pytest.skip("This ComfyUI revision does not implement LoKr bypass math")
+
+    w1_a = torch.tensor([[0.5], [0.3]], dtype=torch.float32)
+    w1_b = torch.tensor([[0.8, -0.4]], dtype=torch.float32)  # rank_w1 = 1
+    w2_a = torch.tensor([[0.4, -0.3], [0.2, 0.9]], dtype=torch.float32)
+    w2_b = torch.tensor([[0.5, -0.1, 0.7], [-0.6, 0.8, 0.2]], dtype=torch.float32)  # rank_w2 = 2
+    alpha = 1.5
+    adapter = lokr_type(
+        set(),
+        (None, None, alpha, w1_a, w1_b, w2_a, w2_b, None, None),
+    )
+
+    runtime_adapter = runtime._runtime_adapter_for_bypass(
+        adapter,
+        "unequal_rank_lokr.safetensors",
+        "layer.weight",
+    )
+    assert runtime_adapter is not adapter
+    assert adapter.weights[2] == pytest.approx(alpha)
+    assert runtime_adapter.weights[2] == pytest.approx(alpha * 1.0 / 2.0)
+
+    class TinyModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.layer = torch.nn.Linear(6, 4, bias=False)
+
+    model = TinyModel()
+    x = torch.tensor([[0.2, -0.7, 1.1, 0.3, -0.4, 0.9]], dtype=torch.float32)
+    base = model.layer(x).detach().clone()
+    materialized_delta = torch.kron(w1_a @ w1_b, w2_a @ w2_b) * (alpha / w2_b.shape[0])
+    strength = 0.45
+
+    injections, _ = runtime._make_stacked_injection(
+        model,
+        [{"key": "layer.weight", "adapter": runtime_adapter, "strength": strength, "lora_name": "unequal"}],
+    )
+    injections[0].inject(None)
+    try:
+        torch.testing.assert_close(
+            model.layer(x),
+            base + F.linear(x, materialized_delta) * strength,
+        )
+    finally:
+        injections[0].eject(None)
+
+
+def test_runtime_lokr_matches_materialized_kronecker_math_and_restores_forward(dora_modules):
+    _, runtime = dora_modules
+    comfy_weight_adapter = runtime.comfy.weight_adapter
+
+    class TinyModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.layer = torch.nn.Linear(6, 4, bias=False)
+
+    model = TinyModel()
+    with torch.no_grad():
+        model.layer.weight.copy_(torch.arange(24, dtype=torch.float32).reshape(4, 6) / 50.0)
+
+    w1 = torch.tensor([[0.5, -0.25], [0.75, 0.2]], dtype=torch.float32)
+    w2 = torch.tensor([[0.3, -0.2, 0.1], [0.4, 0.6, -0.5]], dtype=torch.float32)
+    adapter = make_lokr_adapter(comfy_weight_adapter, w1.tolist(), w2.tolist())
+    strength = 0.7
+    x = torch.tensor(
+        [
+            [0.2, -0.7, 1.1, 0.3, -0.4, 0.9],
+            [1.3, 0.4, -0.2, 0.8, -0.6, 0.1],
+        ],
+        dtype=torch.float32,
+    )
+
+    base = model.layer(x).detach().clone()
+    expected_delta = F.linear(x, torch.kron(w1, w2)) * strength
+
+    injections, hook_count = runtime._make_stacked_injection(
+        model,
+        [
+            {
+                "key": "layer.weight",
+                "adapter": adapter,
+                "strength": strength,
+                "lora_name": "plain_lokr.safetensors",
+            }
+        ],
+    )
+    assert hook_count == 1
+
+    injections[0].inject(None)
+    try:
+        torch.testing.assert_close(model.layer(x), base + expected_delta)
+    finally:
+        injections[0].eject(None)
+
+    torch.testing.assert_close(model.layer(x), base)
+
+
+def test_decomposed_lokr_bypass_matches_materialized_scale(dora_modules):
+    _, runtime = dora_modules
+    comfy_weight_adapter = runtime.comfy.weight_adapter
+    lokr_type = getattr(comfy_weight_adapter, "LoKrAdapter", None)
+    if lokr_type is None:
+        pytest.skip("This ComfyUI revision does not expose LoKrAdapter")
+    base_h = getattr(comfy_weight_adapter.WeightAdapterBase, "h", None)
+    lokr_h = getattr(lokr_type, "h", None)
+    if not callable(lokr_h) or lokr_h is base_h:
+        pytest.skip("This ComfyUI revision does not implement LoKr bypass math")
+
+    class TinyModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.layer = torch.nn.Linear(6, 4, bias=False)
+
+    w1_a = torch.tensor([[0.5, -0.2], [0.3, 0.7]], dtype=torch.float32)
+    w1_b = torch.tensor([[0.8, -0.4], [0.1, 0.6]], dtype=torch.float32)
+    w2_a = torch.tensor([[0.4, -0.3], [0.2, 0.9]], dtype=torch.float32)
+    w2_b = torch.tensor([[0.5, -0.1, 0.7], [-0.6, 0.8, 0.2]], dtype=torch.float32)
+    alpha = 1.5
+    rank = w2_b.shape[0]
+    adapter = lokr_type(
+        set(),
+        (None, None, alpha, w1_a, w1_b, w2_a, w2_b, None, None),
+    )
+
+    model = TinyModel()
+    x = torch.tensor([[0.2, -0.7, 1.1, 0.3, -0.4, 0.9]], dtype=torch.float32)
+    base = model.layer(x).detach().clone()
+    materialized_delta = torch.kron(w1_a @ w1_b, w2_a @ w2_b) * (alpha / rank)
+    strength = 0.45
+
+    injections, _ = runtime._make_stacked_injection(
+        model,
+        [{"key": "layer.weight", "adapter": adapter, "strength": strength, "lora_name": "factorized"}],
+    )
+    injections[0].inject(None)
+    try:
+        torch.testing.assert_close(
+            model.layer(x),
+            base + F.linear(x, materialized_delta) * strength,
+        )
+    finally:
+        injections[0].eject(None)
+
+    torch.testing.assert_close(model.layer(x), base)
+
+
+def test_mixed_lora_and_lokr_stack_matches_materialized_math(dora_modules):
+    _, runtime = dora_modules
+    comfy_weight_adapter = runtime.comfy.weight_adapter
+
+    class TinyModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.layer = torch.nn.Linear(6, 4, bias=False)
+
+    model = TinyModel()
+    with torch.no_grad():
+        model.layer.weight.copy_(torch.arange(24, dtype=torch.float32).reshape(4, 6) / 40.0)
+
+    lora_up = torch.tensor([[0.8], [-0.3], [0.25], [0.6]], dtype=torch.float32)
+    lora_down = torch.tensor([[0.4, -0.2, 0.6, 0.1, -0.5, 0.3]], dtype=torch.float32)
+    lora = make_lora_adapter(comfy_weight_adapter, lora_up.tolist(), lora_down.tolist())
+
+    lokr_w1 = torch.tensor([[0.5, -0.25], [0.75, 0.2]], dtype=torch.float32)
+    lokr_w2 = torch.tensor([[0.3, -0.2, 0.1], [0.4, 0.6, -0.5]], dtype=torch.float32)
+    lokr = make_lokr_adapter(comfy_weight_adapter, lokr_w1.tolist(), lokr_w2.tolist())
+
+    lora_strength = 0.55
+    lokr_strength = -0.35
+    x = torch.tensor([[0.2, -0.7, 1.1, 0.3, -0.4, 0.9]], dtype=torch.float32)
+    base = model.layer(x).detach().clone()
+    expected_lora = F.linear(F.linear(x, lora_down), lora_up) * lora_strength
+    expected_lokr = F.linear(x, torch.kron(lokr_w1, lokr_w2)) * lokr_strength
+
+    injections, hook_count = runtime._make_stacked_injection(
+        model,
+        [
+            {"key": "layer.weight", "adapter": lora, "strength": lora_strength, "lora_name": "a"},
+            {"key": "layer.weight", "adapter": lokr, "strength": lokr_strength, "lora_name": "b"},
+        ],
+    )
+    assert hook_count == 2
+
+    injections[0].inject(None)
+    try:
+        torch.testing.assert_close(model.layer(x), base + expected_lora + expected_lokr)
+    finally:
+        injections[0].eject(None)
+
+    torch.testing.assert_close(model.layer(x), base)


### PR DESCRIPTION
## Summary
- allow plain `LoKrAdapter` patches to use Runtime bypass when the installed ComfyUI provides real LoKr bypass math
- keep DoRA-LoKr, sliced/offset/transformed targets, reshape LoRA, and unsupported adapter forms fail-closed
- normalize LoKr runtime-only alpha semantics to exactly match ComfyUI materialized LoKr, including direct-factor non-finite/zero alpha and unequal decomposed ranks
- defer Runtime-bypass validation failures past the base loader's identical `add_patches()` retry boundary so an intentional rejection is raised once
- retain compatibility with older ComfyUI revisions by rejecting LoKr runtime mode when `LoKrAdapter.h()` is not implemented
- add a pinned 2026-08-21 ComfyUI revision to CI so the new LoKr bypass path is exercised rather than skipped on older revisions

## Root cause
The runtime loader still restricted captured adapters to `LoRAAdapter`, while current ComfyUI's bypass system implements forward-pass math for `LoKrAdapter`. That stale gate rejected mathematically supported plain LoKr files such as the reported H3 LoKr adapter.

Current ComfyUI also has two LoKr bypass/materialization edge differences that matter for exactness:
- direct `w1`/`w2` materialization ignores `alpha`, while bypass computes the equivalent scale as `alpha / alpha`; a stored `Inf`, `NaN`, or zero alpha can therefore poison bypass unless the runtime copy is normalized
- when both LoKr factors are decomposed with unequal ranks, materialization scales by the `w2` rank while bypass selects the `w1` rank; the runtime-only alpha is compensated so both paths agree

The loader never mutates the source adapter for these normalizations; it uses a shallow runtime copy with adjusted scalar metadata.

## Safety
Runtime mode still refuses any adapter form whose forward bypass path cannot reproduce materialized patch semantics. In particular, LoKr `dora_scale` remains unsupported because ComfyUI's LoKr bypass path does not perform DoRA magnitude normalization.

Runtime-specific validation errors are deferred only within the current `_load_one()` call and then raised once. This avoids the base loader's identical exception retry without weakening fail-closed behavior or converting an unsupported adapter to materialized mode.

## Tests
CI covers the existing compatibility matrix plus pinned current ComfyUI, with regression tests for:
- plain LoKr acceptance/capture without materialization
- LoKr DoRA rejection
- older ComfyUI without LoKr bypass implementation
- direct LoKr Kronecker parity
- direct LoKr with `alpha=Inf` remaining finite and matching materialized semantics
- decomposed LoKr parity and alpha/rank scaling, including unequal factor ranks
- mixed LoRA + LoKr stacking and hook restoration
- one-shot propagation of deferred Runtime-bypass validation failures across the base loader retry boundary

## Integration and release hardening
- Stacks this LoKr work on PR #67 so both open changes land through one tested v1.0.41 main-branch commit and one release run.
- Commits runtime captures only after all adapter validation and mixed materialized patches succeed, preventing partial or duplicate hooks across the base loader retry.
- Updates the runtime-bypass documentation and v1.0.41 release notes.
- Verifies the release ZIP contains both State Manager backend modules and the frontend extension.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Runtime bypass now supports compatible plain LoKr adapters alongside standard LoRAs.
  - Mixed LoRA and LoKr adapter stacks are supported with preserved scaling and restoration behavior.
  - Added clearer handling and messaging for unsupported adapter configurations.

- **Bug Fixes**
  - Improved validation, retry handling, and rollback to prevent partial adapter state.

- **Documentation**
  - Updated usage and troubleshooting guidance for LoKr bypass compatibility.

- **Release**
  - Released DoRA Dynamic LoRA Loader v1.0.41.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->