### PR TITLE
Release v1.0.41: persistent State Manager library and LoKr runtime bypass

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,10 +57,19 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
         shell: bash
         run: |
-          test -s "dist/ComfyUI-DoRA-Dynamic-LoRA-Loader-v${VERSION}.zip"
+          archive="dist/ComfyUI-DoRA-Dynamic-LoRA-Loader-v${VERSION}.zip"
+          prefix="ComfyUI-DoRA-Dynamic-LoRA-Loader-v${VERSION}"
+          test -s "${archive}"
           test -s dist/SHA256SUMS
           test -s RELEASE_NOTES.md
           grep -F "ComfyUI-DoRA-Dynamic-LoRA-Loader-v${VERSION}.zip" dist/SHA256SUMS
+          listing="$(unzip -Z1 "${archive}")"
+          for required in \
+            state_manager_api.py \
+            state_manager_store.py \
+            web/dora_state_manager.js; do
+            printf '%s\n' "${listing}" | grep -Fx "${prefix}/${required}"
+          done
 
       - name: Publish GitHub release
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
           node-version: "22"
 
       - name: Compile Python sources
-        run: python -m py_compile __init__.py nodes.py runtime_bypass.py
+        run: python -m py_compile __init__.py nodes.py runtime_bypass.py state_manager_api.py state_manager_store.py
 
       - name: Check frontend JavaScript syntax
         shell: bash
@@ -40,7 +40,7 @@ jobs:
           done < <(find web -type f -name '*.js' -print0)
 
       - name: Run frontend persistence regression tests
-        run: node --test tests/test_frontend_state_persistence.mjs
+        run: node --test tests/test_frontend_state_persistence.mjs tests/test_state_manager_frontend.mjs
 
       - name: Build package wheel
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,6 +76,11 @@ jobs:
             torch_version: "2.10.0"
             torchvision_version: "0.25.0"
             torchaudio_version: "2.10.0"
+          - comfy_version: 2026-08-21
+            comfy_ref: 28864ca8fed67cc05a957710f88ce23aff75fd2f
+            torch_version: "2.10.0"
+            torchvision_version: "0.25.0"
+            torchaudio_version: "2.10.0"
     runs-on: ubuntu-latest
     steps:
       - name: Check out custom node

--- a/README.md
+++ b/README.md
@@ -557,7 +557,7 @@ The **State Manager** uses a persistent user library for reusable characters and
 The library is stored under the active ComfyUI user directory:
 
 ```text
-<ComfyUI user directory>/dora_state_manager/state-library.json
+<ComfyUI user directory>/<active user id>/dora_state_manager/state-library.json
 ```
 
 Ordinary workflow JSON contains only the selected character/prompt UUID binding and workflow-specific queue options. Character names, prompt text, LoRA stacks, settings, thumbnails, reference-image metadata, and filename prefixes are not embedded in workflow JSON.
@@ -604,6 +604,8 @@ If a workflow references UUIDs that are unavailable on the current machine, the 
 - A stale write from another browser tab is rejected. Use **Reload library** to load the current revision before editing again.
 
 The old workflow/node-keyed browser backup is no longer used or read. Browser-local UI state cannot repopulate a sanitized workflow with private presets.
+
+Presets that exist only in an old browser backup require an explicit transition: run v1.0.40, open the workflow so its backup is restored, export or save the restored state, then update and import/migrate it. The redesign does not delete old browser entries, so this recovery remains possible by temporarily returning to v1.0.40.
 
 ### Basic wiring
 

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ This implementation was reworked for the unified DoRA + standard LoRA path in th
 
 ---
 
-## Runtime bypass LoRA (low VRAM)
+## Runtime bypass adapters (low VRAM)
 
-The loader includes an optional **Runtime bypass LoRA (low VRAM)** mode for supported standard LoRAs.
+The loader includes an optional **Runtime bypass LoRA (low VRAM)** mode for supported standard LoRA and plain LoKr adapters.
 
 The word **bypass** refers to bypassing **weight materialization**, not bypassing or weakening the LoRA effect. For a normal additive LoRA, the regular merged path evaluates a layer with `W + ΔW`, while the runtime path keeps `W` untouched and evaluates the equivalent low-rank contribution during the forward pass:
 
@@ -40,6 +40,12 @@ Normal materialized patching may need to retain the original model weights while
 
 Runtime bypass keeps the base model weights unchanged and stores/evaluates the low-rank adapter tensors directly, avoiding that full patched-model copy for supported adapters.
 
+### Plain LoKr support
+
+Plain LoKr adapters use ComfyUI's native LoKr forward-bypass implementation when it is available. Direct-factor, decomposed, and mixed LoRA + LoKr stacks are supported. The runtime-only adapter metadata is normalized where current ComfyUI's LoKr materialization and bypass paths use different alpha/rank conventions; the source adapter remains unchanged.
+
+Older ComfyUI revisions without a real `LoKrAdapter.h()` implementation reject LoKr runtime bypass with an explicit update/disable message. DoRA-LoKr magnitude scaling remains unsupported because ComfyUI's LoKr bypass path does not implement DoRA normalization.
+
 ### Important limitation: DoRA is not runtime-bypassed
 
 Current ComfyUI bypass LoRA math implements the additive LoRA path, but not DoRA magnitude normalization/rescaling. Treating a DoRA as ordinary bypass LoRA would therefore change its mathematics.
@@ -49,7 +55,7 @@ This loader deliberately **fails closed** when runtime bypass encounters DoRA or
 Runtime bypass currently refuses:
 
 - DoRA / magnitude-vector LoRAs (`dora_scale`, Diffusers/PEFT `lora_magnitude_vector`, `w_norm`, `b_norm`)
-- non-LoRA weight-adapter types
+- DoRA-LoKr and adapter types other than standard LoRA/plain LoKr
 - LoRA reshape metadata
 - sliced / offset / transformed adapter targets
 - non-default `strength_model` patch semantics
@@ -441,11 +447,11 @@ These patches affect DoRA / LoRA application in the running ComfyUI process, not
 
 ## Troubleshooting
 
-### Runtime bypass rejects a LoRA
+### Runtime bypass rejects an adapter
 
 Runtime bypass only takes adapters for which the supported forward-pass path preserves the normal patch semantics. In particular, current ComfyUI bypass LoRA does **not** implement DoRA magnitude normalization.
 
-If the loader reports DoRA/magnitude-vector, reshape, offset/transform, or another unsupported adapter form, disable **Runtime bypass LoRA (low VRAM)** for that file rather than trying to force it through the runtime path.
+If the loader reports DoRA/magnitude-vector, reshape, offset/transform, an older ComfyUI build without LoKr bypass math, or another unsupported adapter form, disable **Runtime bypass LoRA (low VRAM)** for that file.
 
 ### Flux2 DoRA instability
 

--- a/README.md
+++ b/README.md
@@ -552,7 +552,15 @@ This repo is meant for cases where plain ComfyUI LoRA loading is not enough, esp
 
 ## State Manager
 
-This build adds a **State Manager** node for workflow-serialized character states. Workflows made with the older **DoRA State Manager** node name remain supported through a legacy alias.
+The **State Manager** uses a persistent user library for reusable characters and prompt presets. Workflows made with the older **DoRA State Manager** node name remain supported through a legacy alias.
+
+The library is stored under the active ComfyUI user directory:
+
+```text
+<ComfyUI user directory>/dora_state_manager/state-library.json
+```
+
+Ordinary workflow JSON contains only the selected character/prompt UUID binding and workflow-specific queue options. Character names, prompt text, LoRA stacks, settings, thumbnails, reference-image metadata, and filename prefixes are not embedded in workflow JSON.
 
 The manager separates **saved state** from **runtime execution**:
 
@@ -582,7 +590,20 @@ The State Manager opens with the saved-state library as its largest pane:
 - Preset, character, LoRA, settings/seed, and queue editing live in tabs in the detail pane.
 - Resizing the node gives the library the additional space; the collection has no fixed-height cap.
 
-The UI-only redesign does not change node class names, widget names/order, state JSON, selection widgets, outputs, or the legacy **DoRA State Manager** alias. Existing workflows continue through the same normalization and migration paths.
+The storage redesign keeps node class names, widget order, selection widgets, outputs, connected save/load behavior, and the legacy **DoRA State Manager** alias. Existing schema-v3 embedded libraries are imported into persistent storage on first load. Migration is fingerprinted and idempotent, preserves valid collision-free UUIDs, remaps unsafe/colliding IDs, and never overwrites an unrelated local preset.
+
+If a workflow references UUIDs that are unavailable on the current machine, the node reports that the selected preset is unavailable. It does not fall back to another local character. A deliberately empty/default node continues to use an ephemeral built-in **Default Character** until it is edited into a persistent character.
+
+### Library portability and recovery
+
+- **Export character** downloads only the selected character and its prompt presets.
+- **Export library** downloads a versioned backup of the entire persistent library.
+- **Import** accepts character exports, library exports, and legacy State Manager exports.
+- Library writes use a lock, optimistic revisions, a flushed temporary file, atomic `os.replace()`, and directory fsync where supported.
+- Malformed storage is quarantined as `state-library.json.corrupt-<timestamp>` instead of being overwritten.
+- A stale write from another browser tab is rejected. Use **Reload library** to load the current revision before editing again.
+
+The old workflow/node-keyed browser backup is no longer used or read. Browser-local UI state cannot repopulate a sanitized workflow with private presets.
 
 ### Basic wiring
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,11 +4,12 @@
 
 - Moves reusable characters, prompt presets, LoRA stacks, settings, thumbnails, reference metadata, and filename prefixes into a backend-authoritative library under the ComfyUI user directory.
 - Limits workflow serialization to UUID bindings and workflow-specific queue configuration.
-- Removes workflow/node-keyed `localStorage` library backups and their automatic restore path.
+- Removes workflow/node-keyed `localStorage` library backups and their automatic restore path. This is a breaking change for presets that exist only in a browser backup: before updating, open the workflow with v1.0.40, let the backup restore, then save/export it. After updating, the old browser entry remains untouched and can still be recovered by temporarily returning to v1.0.40 and exporting the restored state.
 - Adds atomic, revisioned storage with UUID validation, locking, corruption quarantine, explicit missing-preset errors, and stale-write rejection.
 - Adds idempotent migration for legacy embedded schema-v3 libraries plus explicit character/library import and export.
 - Keeps runtime outputs, connected save/load/apply, text boxes, seeds, multiple loaders, queue wildcarding, and the legacy node alias compatible.
 - Keeps queue-time library values transient and out of the queued workflow copy.
+- Scopes backend libraries to the active ComfyUI user, including multi-user installations.
 
 # DoRA Dynamic LoRA Loader v1.0.40
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,15 @@
-# Unreleased
+# DoRA Dynamic LoRA Loader v1.0.41
+
+This release moves State Manager presets into a backend-authoritative per-user library and adds mathematically equivalent runtime bypass support for plain LoKr adapters on compatible ComfyUI revisions.
+
+## Plain LoKr runtime bypass
+
+- Adds runtime bypass support for plain direct-factor, decomposed, and mixed LoRA + LoKr adapter stacks when ComfyUI provides native LoKr bypass math.
+- Preserves current ComfyUI materialized LoKr semantics across direct-factor alpha values and unequal decomposed ranks through runtime-only adapter copies.
+- Keeps source adapters unchanged and continues to reject DoRA-LoKr, sliced/offset/transformed targets, reshape LoRA, and unsupported adapter forms.
+- Rejects LoKr runtime mode explicitly on older ComfyUI revisions whose `LoKrAdapter` lacks forward-bypass math.
+- Defers deterministic runtime validation failures across the base loader's retry boundary and commits captured adapters transactionally, preventing partial or duplicate hooks after a failed materialized-patch attempt.
+- Adds parity, mixed-stack, rejection, retry, rollback, and hook-restoration coverage against a pinned current ComfyUI revision.
 
 ## State Manager persistent library architecture
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,15 @@
+# Unreleased
+
+## State Manager persistent library architecture
+
+- Moves reusable characters, prompt presets, LoRA stacks, settings, thumbnails, reference metadata, and filename prefixes into a backend-authoritative library under the ComfyUI user directory.
+- Limits workflow serialization to UUID bindings and workflow-specific queue configuration.
+- Removes workflow/node-keyed `localStorage` library backups and their automatic restore path.
+- Adds atomic, revisioned storage with UUID validation, locking, corruption quarantine, explicit missing-preset errors, and stale-write rejection.
+- Adds idempotent migration for legacy embedded schema-v3 libraries plus explicit character/library import and export.
+- Keeps runtime outputs, connected save/load/apply, text boxes, seeds, multiple loaders, queue wildcarding, and the legacy node alias compatible.
+- Keeps queue-time library values transient and out of the queued workflow copy.
+
 # DoRA Dynamic LoRA Loader v1.0.40
 
 This release fixes DoRA Power LoRA Loader settings appearing to reset when switching away from a ComfyUI workflow tab and returning to it on newer store-backed ComfyUI frontends.

--- a/__init__.py
+++ b/__init__.py
@@ -1,3 +1,5 @@
+import logging
+
 from .nodes import (
     DoraStateManager,
     StateManager,
@@ -22,13 +24,18 @@ async def dora_dynamic_lora_list_loras(request):
     return web.json_response(folder_paths.get_filename_list("loras"))
 
 
-register_state_manager_routes(
-    folder_paths,
-    PromptServer,
-    web,
-    _normalize_state_manager_state,
-    _state_manager_default_state,
-)
+try:
+    register_state_manager_routes(
+        folder_paths,
+        PromptServer,
+        web,
+        _normalize_state_manager_state,
+        _state_manager_default_state,
+    )
+except Exception:
+    logging.getLogger(__name__).exception(
+        "State Manager library routes could not be registered; State Manager persistence will be unavailable."
+    )
 
 # Tell ComfyUI to load our frontend extension.
 WEB_DIRECTORY = "./web"

--- a/__init__.py
+++ b/__init__.py
@@ -1,5 +1,13 @@
-from .nodes import DoraStateManager, StateManager, StateManagerSeed, StateManagerTextBox
+from .nodes import (
+    DoraStateManager,
+    StateManager,
+    StateManagerSeed,
+    StateManagerTextBox,
+    _normalize_state_manager_state,
+    _state_manager_default_state,
+)
 from .runtime_bypass import RuntimeBypassDoraPowerLoraLoader
+from .state_manager_api import register_routes as register_state_manager_routes
 
 # Backend API for frontend LoRA dropdown (avoids relying on /object_info variants).
 import folder_paths
@@ -12,6 +20,15 @@ async def dora_dynamic_lora_list_loras(request):
     # Return plain list of filenames from ComfyUI's "loras" folder_paths category.
     # Frontend will prepend "None".
     return web.json_response(folder_paths.get_filename_list("loras"))
+
+
+register_state_manager_routes(
+    folder_paths,
+    PromptServer,
+    web,
+    _normalize_state_manager_state,
+    _state_manager_default_state,
+)
 
 # Tell ComfyUI to load our frontend extension.
 WEB_DIRECTORY = "./web"

--- a/nodes.py
+++ b/nodes.py
@@ -16,12 +16,19 @@ import comfy.utils
 import folder_paths
 import torch
 
+try:
+    from .state_manager_store import StatePresetNotFound, get_state_manager_store
+except ImportError:  # pragma: no cover - direct module loading outside the package
+    from state_manager_store import StatePresetNotFound, get_state_manager_store
+
 _LOG = logging.getLogger(__name__)
 
 
 _STATE_SEED_MIN = -1125899906842624
 _STATE_SEED_MAX = 1125899906842624
 _STATE_SEED_SPECIALS = {-1, -2, -3}
+_DORA_STATE_MANAGER_BINDING_VERSION = 1
+_DORA_STATE_MANAGER_BINDING_KIND = "dora_state_manager_binding"
 
 
 def _state_manager_new_random_seed() -> int:
@@ -532,6 +539,26 @@ def _state_manager_default_state() -> Dict[str, Any]:
             }
         ],
     }
+
+
+def _state_manager_default_binding() -> Dict[str, Any]:
+    return {
+        "version": _DORA_STATE_MANAGER_BINDING_VERSION,
+        "kind": _DORA_STATE_MANAGER_BINDING_KIND,
+    }
+
+
+def _get_state_manager_store():
+    path = os.path.join(
+        folder_paths.get_user_directory(),
+        "dora_state_manager",
+        "state-library.json",
+    )
+    return get_state_manager_store(
+        path=path,
+        normalize_state=_normalize_state_manager_state,
+        default_state=_state_manager_default_state,
+    )
 
 
 def _safe_json_load(raw: Any, fallback: Any) -> Any:
@@ -1080,8 +1107,8 @@ def _pick_state_manager_prompt(character: Dict[str, Any], selected_prompt_id: An
     return prompts[0] if prompts else _state_manager_default_state()["characters"][0]["prompts"][0]
 
 
-def _resolve_dora_state_payload(
-    state_json: Any,
+def _resolve_dora_state_payload_from_state(
+    state: Dict[str, Any],
     selected_character_id: Any,
     selected_prompt_id: Any,
 ) -> Dict[str, Any]:
@@ -1091,7 +1118,6 @@ def _resolve_dora_state_payload(
     is handled by the frontend as explicit graph editing; runtime execution must stay
     acyclic.
     """
-    state = _normalize_state_manager_state(state_json)
     character = _pick_state_manager_character(state, selected_character_id)
     prompt = _pick_state_manager_prompt(character, selected_prompt_id)
 
@@ -1134,6 +1160,55 @@ def _resolve_dora_state_payload(
     }
 
 
+def _state_manager_legacy_state(raw: Any) -> Optional[Dict[str, Any]]:
+    parsed = _safe_json_load(raw, None)
+    if isinstance(parsed, dict) and isinstance(parsed.get("characters"), list):
+        return parsed
+    return None
+
+
+def _state_manager_is_default_legacy_state(state: Dict[str, Any]) -> bool:
+    return _normalize_state_manager_state(state) == _normalize_state_manager_state(_state_manager_default_state())
+
+
+def _resolve_state_manager_selection(
+    state_json: Any,
+    selected_character_id: Any,
+    selected_prompt_id: Any,
+) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    character_id = str(selected_character_id or "").strip()
+    prompt_id = str(selected_prompt_id or "").strip()
+    legacy = _state_manager_legacy_state(state_json)
+    store = _get_state_manager_store()
+    if legacy is not None and not _state_manager_is_default_legacy_state(legacy):
+        migration = store.migrate_legacy(legacy, character_id, prompt_id)
+        mapped_character = str(migration.get("selected_character_id", "") or "")
+        mapped_prompt = str(migration.get("selected_prompt_id", "") or "")
+        if not mapped_character or not mapped_prompt:
+            raise StatePresetNotFound(
+                "Legacy State Manager data was imported, but its selected preset could not be mapped. Select a local character and prompt."
+            )
+        character_id, prompt_id = mapped_character, mapped_prompt
+    elif legacy is not None:
+        character_id = character_id or "default_character"
+        prompt_id = prompt_id or "default_prompt"
+    return store.resolve(character_id, prompt_id)
+
+
+def _resolve_dora_state_payload(
+    state_json: Any,
+    selected_character_id: Any,
+    selected_prompt_id: Any,
+) -> Dict[str, Any]:
+    character, prompt = _resolve_state_manager_selection(
+        state_json,
+        selected_character_id,
+        selected_prompt_id,
+    )
+    state = {"version": _DORA_STATE_MANAGER_SCHEMA_VERSION, "characters": [character]}
+    return _resolve_dora_state_payload_from_state(state, character.get("id"), prompt.get("id"))
+
+
 def _build_state_settings_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
     settings = _normalize_settings_with_canonical_seed(payload.get("settings", {}))
     seed = _extract_seed_from_settings(settings)
@@ -1147,12 +1222,14 @@ def _build_state_settings_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
-def _queued_runtime_state_from_ui_state(ui_state_json: Any) -> Optional[Dict[str, Any]]:
+def _queued_runtime_seed_from_ui_state(ui_state_json: Any) -> Optional[int]:
     parsed = _safe_json_load(ui_state_json, {})
     if not isinstance(parsed, dict):
         return None
-    raw = parsed.get("__dsm_queued_runtime_state")
-    return _normalize_runtime_dora_state_payload(raw)
+    if "__dsm_runtime_seed" not in parsed:
+        return None
+    seed = _coerce_state_manager_seed(parsed.get("__dsm_runtime_seed"), -1)
+    return None if seed in _STATE_SEED_SPECIALS else seed
 
 
 def _settings_with_runtime_seed(settings: Any, seed: int) -> Dict[str, Any]:
@@ -4606,9 +4683,9 @@ def _build_auto_strength_stack_text_report(stack_report: Dict[str, Any]) -> str:
 
 class StateManager:
     """
-    Workflow-serialized preset manager for character LoRA stacks, prompt templates,
-    settings, and seed state. Runtime execution is source-only and acyclic: capture/load
-    actions are explicit frontend graph edits, not execution-time input feedback.
+    Workflow-bound view of the persistent State Manager library. Workflows serialize
+    only preset UUID bindings; runtime data is resolved from the user library without
+    downstream state reads or execution-time graph cycles.
     """
 
     @classmethod
@@ -4618,7 +4695,7 @@ class StateManager:
                 "state_json": (
                     "STRING",
                     {
-                        "default": json.dumps(_state_manager_default_state(), separators=(",", ":")),
+                        "default": json.dumps(_state_manager_default_binding(), separators=(",", ":")),
                         "multiline": True,
                     },
                 ),
@@ -4664,11 +4741,16 @@ class StateManager:
             "selected_character_id": selected_character_id,
             "selected_prompt_id": selected_prompt_id,
         }
-        resolved = _queued_runtime_state_from_ui_state(ui_state_json) or _resolve_dora_state_payload(
+        resolved = _resolve_dora_state_payload(
             state_json,
             selected_character_id,
             selected_prompt_id,
         )
+        queued_seed = _queued_runtime_seed_from_ui_state(ui_state_json)
+        if queued_seed is not None:
+            resolved = dict(resolved)
+            resolved["settings"] = _settings_with_runtime_seed(resolved.get("settings", {}), queued_seed)
+        payload["library_revision"] = _get_state_manager_store().revision()
         if _extract_seed_from_settings(resolved.get("settings", {})) in _STATE_SEED_SPECIALS:
             payload["runtime_seed_nonce"] = _state_manager_new_random_seed()
         return json.dumps(payload, sort_keys=True, default=str)
@@ -4682,13 +4764,12 @@ class StateManager:
         selected_prompt_id: Any = "",
     ):
         del ui_state_json
-        state = _normalize_state_manager_state(state_json)
-        character = _pick_state_manager_character(state, selected_character_id)
-        prompt = _pick_state_manager_prompt(character, selected_prompt_id)
-        if not character:
-            return "State Manager: no character states are available."
-        if not prompt:
-            return "State Manager: no prompt states are available for the selected character."
+        try:
+            _resolve_state_manager_selection(state_json, selected_character_id, selected_prompt_id)
+        except StatePresetNotFound as exc:
+            return f"State Manager: {exc}"
+        except Exception as exc:
+            return f"State Manager library error: {exc}"
         return True
 
     def resolve_state(
@@ -4698,28 +4779,18 @@ class StateManager:
         selected_character_id: Any = "",
         selected_prompt_id: Any = "",
     ):
-        runtime_payload = _queued_runtime_state_from_ui_state(ui_state_json)
-        if runtime_payload is not None:
-            payload = _resolve_state_manager_runtime_seed(runtime_payload)
-            state = _normalize_state_manager_state(state_json)
-            character = _pick_state_manager_character(
-                state,
-                (payload.get("character") or {}).get("id", selected_character_id) if isinstance(payload.get("character"), dict) else selected_character_id,
-            )
-            prompt = _pick_state_manager_prompt(
-                character,
-                (payload.get("prompt") or {}).get("id", selected_prompt_id) if isinstance(payload.get("prompt"), dict) else selected_prompt_id,
-            )
-        else:
-            payload = _resolve_dora_state_payload(
-                state_json,
-                selected_character_id,
-                selected_prompt_id,
-            )
-            payload = _resolve_state_manager_runtime_seed(payload)
-            state = _normalize_state_manager_state(state_json)
-            character = _pick_state_manager_character(state, selected_character_id)
-            prompt = _pick_state_manager_prompt(character, selected_prompt_id)
+        character, prompt = _resolve_state_manager_selection(
+            state_json,
+            selected_character_id,
+            selected_prompt_id,
+        )
+        state = {"version": _DORA_STATE_MANAGER_SCHEMA_VERSION, "characters": [character]}
+        payload = _resolve_dora_state_payload_from_state(state, character.get("id"), prompt.get("id"))
+        queued_seed = _queued_runtime_seed_from_ui_state(ui_state_json)
+        if queued_seed is not None:
+            payload = dict(payload)
+            payload["settings"] = _settings_with_runtime_seed(payload.get("settings", {}), queued_seed)
+        payload = _resolve_state_manager_runtime_seed(payload)
         settings = _normalize_settings_with_canonical_seed(payload.get("settings", {}))
         settings_json = json.dumps(settings, ensure_ascii=False, sort_keys=True, indent=2)
         lora_stack_payload = _build_lora_stack_payload(

--- a/nodes.py
+++ b/nodes.py
@@ -17,9 +17,9 @@ import folder_paths
 import torch
 
 try:
-    from .state_manager_store import StatePresetNotFound, get_state_manager_store
+    from .state_manager_store import InvalidStateLibrary, StatePresetNotFound, get_state_manager_store, state_manager_library_path
 except ImportError:  # pragma: no cover - direct module loading outside the package
-    from state_manager_store import StatePresetNotFound, get_state_manager_store
+    from state_manager_store import InvalidStateLibrary, StatePresetNotFound, get_state_manager_store, state_manager_library_path
 
 _LOG = logging.getLogger(__name__)
 
@@ -548,14 +548,9 @@ def _state_manager_default_binding() -> Dict[str, Any]:
     }
 
 
-def _get_state_manager_store():
-    path = os.path.join(
-        folder_paths.get_user_directory(),
-        "dora_state_manager",
-        "state-library.json",
-    )
+def _get_state_manager_store(user_id: Any = "default"):
     return get_state_manager_store(
-        path=path,
+        path=state_manager_library_path(folder_paths, user_id),
         normalize_state=_normalize_state_manager_state,
         default_state=_state_manager_default_state,
     )
@@ -1175,20 +1170,22 @@ def _resolve_state_manager_selection(
     state_json: Any,
     selected_character_id: Any,
     selected_prompt_id: Any,
+    library_user_id: Any = "default",
 ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
     character_id = str(selected_character_id or "").strip()
     prompt_id = str(selected_prompt_id or "").strip()
     legacy = _state_manager_legacy_state(state_json)
-    store = _get_state_manager_store()
+    store = _get_state_manager_store(library_user_id)
     if legacy is not None and not _state_manager_is_default_legacy_state(legacy):
         migration = store.migrate_legacy(legacy, character_id, prompt_id)
         mapped_character = str(migration.get("selected_character_id", "") or "")
         mapped_prompt = str(migration.get("selected_prompt_id", "") or "")
-        if not mapped_character or not mapped_prompt:
+        character_id = mapped_character or character_id
+        prompt_id = mapped_prompt or prompt_id
+        if not character_id or not prompt_id:
             raise StatePresetNotFound(
                 "Legacy State Manager data was imported, but its selected preset could not be mapped. Select a local character and prompt."
             )
-        character_id, prompt_id = mapped_character, mapped_prompt
     elif legacy is not None:
         character_id = character_id or "default_character"
         prompt_id = prompt_id or "default_prompt"
@@ -1199,11 +1196,13 @@ def _resolve_dora_state_payload(
     state_json: Any,
     selected_character_id: Any,
     selected_prompt_id: Any,
+    library_user_id: Any = "default",
 ) -> Dict[str, Any]:
     character, prompt = _resolve_state_manager_selection(
         state_json,
         selected_character_id,
         selected_prompt_id,
+        library_user_id,
     )
     state = {"version": _DORA_STATE_MANAGER_SCHEMA_VERSION, "characters": [character]}
     return _resolve_dora_state_payload_from_state(state, character.get("id"), prompt.get("id"))
@@ -1230,6 +1229,13 @@ def _queued_runtime_seed_from_ui_state(ui_state_json: Any) -> Optional[int]:
         return None
     seed = _coerce_state_manager_seed(parsed.get("__dsm_runtime_seed"), -1)
     return None if seed in _STATE_SEED_SPECIALS else seed
+
+
+def _queued_library_user_from_ui_state(ui_state_json: Any) -> str:
+    parsed = _safe_json_load(ui_state_json, {})
+    if not isinstance(parsed, dict):
+        return "default"
+    return str(parsed.get("__dsm_library_user_id", "default") or "default").strip() or "default"
 
 
 def _settings_with_runtime_seed(settings: Any, seed: int) -> Dict[str, Any]:
@@ -4741,16 +4747,22 @@ class StateManager:
             "selected_character_id": selected_character_id,
             "selected_prompt_id": selected_prompt_id,
         }
-        resolved = _resolve_dora_state_payload(
-            state_json,
-            selected_character_id,
-            selected_prompt_id,
-        )
-        queued_seed = _queued_runtime_seed_from_ui_state(ui_state_json)
-        if queued_seed is not None:
-            resolved = dict(resolved)
-            resolved["settings"] = _settings_with_runtime_seed(resolved.get("settings", {}), queued_seed)
-        payload["library_revision"] = _get_state_manager_store().revision()
+        library_user_id = _queued_library_user_from_ui_state(ui_state_json)
+        try:
+            resolved = _resolve_dora_state_payload(
+                state_json,
+                selected_character_id,
+                selected_prompt_id,
+                library_user_id,
+            )
+            queued_seed = _queued_runtime_seed_from_ui_state(ui_state_json)
+            if queued_seed is not None:
+                resolved = dict(resolved)
+                resolved["settings"] = _settings_with_runtime_seed(resolved.get("settings", {}), queued_seed)
+            payload["library_revision"] = _get_state_manager_store(library_user_id).revision()
+        except (InvalidStateLibrary, StatePresetNotFound, OSError) as exc:
+            resolved = {}
+            payload["library_error"] = type(exc).__name__
         if _extract_seed_from_settings(resolved.get("settings", {})) in _STATE_SEED_SPECIALS:
             payload["runtime_seed_nonce"] = _state_manager_new_random_seed()
         return json.dumps(payload, sort_keys=True, default=str)
@@ -4763,9 +4775,14 @@ class StateManager:
         selected_character_id: Any = "",
         selected_prompt_id: Any = "",
     ):
-        del ui_state_json
+        library_user_id = _queued_library_user_from_ui_state(ui_state_json)
         try:
-            _resolve_state_manager_selection(state_json, selected_character_id, selected_prompt_id)
+            _resolve_state_manager_selection(
+                state_json,
+                selected_character_id,
+                selected_prompt_id,
+                library_user_id,
+            )
         except StatePresetNotFound as exc:
             return f"State Manager: {exc}"
         except Exception as exc:
@@ -4779,10 +4796,12 @@ class StateManager:
         selected_character_id: Any = "",
         selected_prompt_id: Any = "",
     ):
+        library_user_id = _queued_library_user_from_ui_state(ui_state_json)
         character, prompt = _resolve_state_manager_selection(
             state_json,
             selected_character_id,
             selected_prompt_id,
+            library_user_id,
         )
         state = {"version": _DORA_STATE_MANAGER_SCHEMA_VERSION, "characters": [character]}
         payload = _resolve_dora_state_payload_from_state(state, character.get("id"), prompt.get("id"))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "dora-dynamic-lora-loader"
 description = "A ComfyUI custom node that loads and stacks regular LoRAs and DoRA LoRAs with Flux/Flux2 and OneTrainer compatibility fixes."
-version = "1.0.40"
+version = "1.0.41"
 license = { file = "LICENSE" }
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,4 +13,4 @@ Documentation = "https://github.com/xmarre/ComfyUI-DoRA-Dynamic-LoRA-Loader#read
 PublisherId = "xmarre"
 DisplayName = "ComfyUI-DoRA-Dynamic-LoRA-Loader"
 Icon = ""
-includes = ["__init__.py", "nodes.py", "runtime_bypass.py", "web"]
+includes = ["__init__.py", "nodes.py", "runtime_bypass.py", "state_manager_api.py", "state_manager_store.py", "web"]

--- a/runtime_bypass.py
+++ b/runtime_bypass.py
@@ -1,17 +1,18 @@
-"""Opt-in runtime/bypass LoRA mode for the DoRA Power LoRA Loader.
+"""Opt-in runtime/bypass adapter mode for the DoRA Power LoRA Loader.
 
 The normal ComfyUI LoRA path materializes patched model weights. On very large
-HIGH_VRAM models that can retain a second full copy of every LoRA-targeted base
+HIGH_VRAM models that can retain a second full copy of every adapter-targeted base
 weight. Runtime bypass mode keeps the base weights untouched and evaluates
-standard LoRA adapters in the module forward pass instead.
+supported adapters in the module forward pass instead.
 
-Safety is deliberate: ComfyUI's bypass LoRA implementation does not implement
+Safety is deliberate: ComfyUI's bypass adapter implementation does not implement
 DoRA magnitude normalization, so this mode refuses DoRA and other adapter forms
 that cannot be represented exactly by the supported runtime path.
 """
 
 from __future__ import annotations
 
+import copy
 import json
 import logging
 import os
@@ -32,7 +33,7 @@ _RUNTIME_INJECTION_PREFIX = "dora_runtime_bypass_lora"
 
 
 class RuntimeBypassUnsupportedError(RuntimeError):
-    """Raised when runtime mode would change the mathematical meaning of a LoRA."""
+    """Raised when runtime mode would change the mathematical meaning of an adapter."""
 
 
 def _as_bool(value: Any, default: bool = False) -> bool:
@@ -138,35 +139,119 @@ def _resolve_module(root: Any, weight_key: str) -> Any:
 
 
 def _validate_lora_adapter(adapter: Any, lora_name: str, raw_key: Any) -> None:
-    if not isinstance(adapter, comfy.weight_adapter.LoRAAdapter):
-        raise RuntimeBypassUnsupportedError(
-            "Runtime bypass currently supports standard LoRA adapters only. "
-            f"{lora_name!r} produced {type(adapter).__name__} for {raw_key!r}. "
-            "Disable Runtime bypass LoRA for this file."
-        )
-
+    """Fail closed unless the adapter has runtime math equivalent to materialized patching."""
     weights = getattr(adapter, "weights", None)
     if not isinstance(weights, (tuple, list)):
         raise RuntimeBypassUnsupportedError(
-            f"Runtime bypass could not inspect the LoRA adapter for {lora_name!r} at {raw_key!r}."
+            f"Runtime bypass could not inspect {type(adapter).__name__} for {lora_name!r} at {raw_key!r}."
         )
 
-    # ComfyUI LoRAAdapter weights are:
-    # (up, down, alpha, mid, dora_scale, reshape)
-    dora_scale = weights[4] if len(weights) > 4 else None
-    reshape = weights[5] if len(weights) > 5 else None
-    if dora_scale is not None:
-        raise RuntimeBypassUnsupportedError(
-            "Runtime bypass LoRA is enabled, but "
-            f"{lora_name!r} contains DoRA magnitude scaling at {raw_key!r}. "
-            "ComfyUI's runtime bypass path does not apply DoRA magnitude normalization, "
-            "so running it would silently change the result. Disable Runtime bypass LoRA for this DoRA."
-        )
-    if reshape is not None:
-        raise RuntimeBypassUnsupportedError(
-            "Runtime bypass does not currently support LoRA reshape metadata. "
-            f"{lora_name!r} uses it at {raw_key!r}. Disable Runtime bypass LoRA for this file."
-        )
+    if isinstance(adapter, comfy.weight_adapter.LoRAAdapter):
+        # ComfyUI LoRAAdapter weights are:
+        # (up, down, alpha, mid, dora_scale, reshape)
+        dora_scale = weights[4] if len(weights) > 4 else None
+        reshape = weights[5] if len(weights) > 5 else None
+        if dora_scale is not None:
+            raise RuntimeBypassUnsupportedError(
+                "Runtime bypass LoRA is enabled, but "
+                f"{lora_name!r} contains DoRA magnitude scaling at {raw_key!r}. "
+                "ComfyUI's runtime bypass path does not apply DoRA magnitude normalization, "
+                "so running it would silently change the result. Disable Runtime bypass LoRA for this DoRA."
+            )
+        if reshape is not None:
+            raise RuntimeBypassUnsupportedError(
+                "Runtime bypass does not currently support LoRA reshape metadata. "
+                f"{lora_name!r} uses it at {raw_key!r}. Disable Runtime bypass LoRA for this file."
+            )
+        return
+
+    lokr_type = getattr(comfy.weight_adapter, "LoKrAdapter", None)
+    if isinstance(lokr_type, type) and isinstance(adapter, lokr_type):
+        # A WeightAdapterBase subclass that inherits the base h() would silently add
+        # zeros in bypass mode. Require ComfyUI's real LoKr bypass implementation.
+        base_h = getattr(comfy.weight_adapter.WeightAdapterBase, "h", None)
+        lokr_h = getattr(type(adapter), "h", None)
+        if not callable(lokr_h) or lokr_h is base_h:
+            raise RuntimeBypassUnsupportedError(
+                "Runtime bypass received a LoKr adapter, but this ComfyUI build does not implement "
+                f"LoKr bypass math for {lora_name!r} at {raw_key!r}. Update ComfyUI or disable Runtime bypass LoRA."
+            )
+
+        # ComfyUI LoKrAdapter weights are:
+        # (w1, w2, alpha, w1_a, w1_b, w2_a, w2_b, t2, dora_scale)
+        if len(weights) < 9:
+            raise RuntimeBypassUnsupportedError(
+                f"Runtime bypass could not inspect the complete LoKr weights for {lora_name!r} at {raw_key!r}."
+            )
+        dora_scale = weights[8]
+        if dora_scale is not None:
+            raise RuntimeBypassUnsupportedError(
+                "Runtime bypass LoRA is enabled, but "
+                f"{lora_name!r} contains LoKr DoRA magnitude scaling at {raw_key!r}. "
+                "ComfyUI's LoKr bypass path does not apply DoRA magnitude normalization, "
+                "so running it would silently change the result. Disable Runtime bypass LoRA for this DoRA-LoKr."
+            )
+        return
+
+    raise RuntimeBypassUnsupportedError(
+        "Runtime bypass currently supports standard LoRA and plain LoKr adapters only. "
+        f"{lora_name!r} produced {type(adapter).__name__} for {raw_key!r}. "
+        "Disable Runtime bypass LoRA for this file."
+    )
+
+
+def _runtime_adapter_for_bypass(adapter: Any, lora_name: str, raw_key: Any) -> Any:
+    """Return an adapter whose bypass math matches ComfyUI materialized semantics."""
+    _validate_lora_adapter(adapter, lora_name, raw_key)
+
+    lokr_type = getattr(comfy.weight_adapter, "LoKrAdapter", None)
+    if not (isinstance(lokr_type, type) and isinstance(adapter, lokr_type)):
+        return adapter
+
+    weights = list(adapter.weights)
+    w1, w2, alpha = weights[0], weights[1], weights[2]
+    w1_b = weights[4]
+    w2_b = weights[6]
+
+    # Current ComfyUI materialized LoKr intentionally ignores alpha when both
+    # Kronecker factors are stored directly. Its bypass h() instead expresses that
+    # as alpha / alpha, which becomes NaN for alpha=Inf and divides by zero for
+    # alpha=0. Normalize the runtime-only copy to 1.0 so the bypass result exactly
+    # follows materialized semantics for every direct-factor alpha value.
+    if w1 is not None and w2 is not None:
+        weights[2] = 1.0
+        runtime_adapter = copy.copy(adapter)
+        runtime_adapter.weights = tuple(weights) if isinstance(adapter.weights, tuple) else weights
+        return runtime_adapter
+
+    # When both factors are decomposed, current ComfyUI materialization uses the
+    # w2 decomposition rank for alpha scaling while bypass h() selects the w1 rank.
+    # Equal ranks are already equivalent. For unequal ranks, adjust alpha only on
+    # the runtime copy so alpha_runtime/rank_w1 == alpha_materialized/rank_w2.
+    if w1 is None and w2 is None and alpha is not None:
+        try:
+            rank_w1 = int(w1_b.shape[0])
+            rank_w2 = int(w2_b.shape[0])
+        except Exception as exc:
+            raise RuntimeBypassUnsupportedError(
+                f"Runtime bypass could not determine LoKr decomposition ranks for {lora_name!r} at {raw_key!r}."
+            ) from exc
+        if rank_w1 <= 0 or rank_w2 <= 0:
+            raise RuntimeBypassUnsupportedError(
+                f"Runtime bypass received invalid LoKr decomposition ranks {rank_w1}/{rank_w2} for {lora_name!r} at {raw_key!r}."
+            )
+        if rank_w1 != rank_w2:
+            try:
+                weights[2] = float(alpha) * (float(rank_w1) / float(rank_w2))
+            except Exception as exc:
+                raise RuntimeBypassUnsupportedError(
+                    f"Runtime bypass could not normalize LoKr alpha scaling for {lora_name!r} at {raw_key!r}."
+                ) from exc
+            runtime_adapter = copy.copy(adapter)
+            runtime_adapter.weights = tuple(weights) if isinstance(adapter.weights, tuple) else weights
+            return runtime_adapter
+
+    return adapter
 
 
 def _make_stacked_injection(
@@ -216,7 +301,7 @@ def _make_stacked_injection(
             raise
 
     def eject_all(_model_patcher):
-        # Multiple LoRAs on one module form nested forward wrappers. They MUST be
+        # Multiple adapters on one module form nested forward wrappers. They MUST be
         # removed in reverse order or an older wrapper can be restored accidentally.
         first_error = None
         while active_hooks:
@@ -259,7 +344,7 @@ def _instance_override(obj: Any, name: str, replacement: Any):
 
 
 class RuntimeBypassDoraPowerLoraLoader(_base.DoraPowerLoraLoader):
-    """DoRA Power LoRA Loader with an opt-in low-VRAM standard-LoRA runtime path."""
+    """DoRA Power LoRA Loader with an opt-in low-VRAM runtime adapter path."""
 
     @classmethod
     def INPUT_TYPES(cls):
@@ -271,7 +356,7 @@ class RuntimeBypassDoraPowerLoraLoader(_base.DoraPowerLoraLoader):
                 {
                     "default": False,
                     "tooltip": (
-                        "Apply standard LoRAs in the forward pass instead of materializing patched model weights. "
+                        "Apply supported LoRA/LoKr adapters in the forward pass instead of materializing patched model weights. "
                         "Greatly reduces persistent VRAM on very large HIGH_VRAM models. DoRA and unsupported "
                         "adapter/offset forms are refused rather than approximated."
                     ),
@@ -320,7 +405,7 @@ class RuntimeBypassDoraPowerLoraLoader(_base.DoraPowerLoraLoader):
             suffix = "" if len(dora_keys) <= 3 else f" (+{len(dora_keys) - 3} more)"
             raise RuntimeBypassUnsupportedError(
                 "Runtime bypass LoRA is enabled, but "
-                f"{lora_name!r} is a DoRA/magnitude LoRA ({examples}{suffix}). "
+                f"{lora_name!r} is a DoRA/magnitude adapter ({examples}{suffix}). "
                 "ComfyUI's bypass adapter math does not implement DoRA magnitude normalization. "
                 "Disable Runtime bypass LoRA for this file; it will not be silently approximated."
             )
@@ -331,69 +416,87 @@ class RuntimeBypassDoraPowerLoraLoader(_base.DoraPowerLoraLoader):
         state_dict_keys: set[str],
         original_add_patches: Any,
         lora_name: str,
+        deferred_errors=None,
     ):
         capture = self._runtime_bypass_capture[target]
 
         def add_patches_runtime(patches, *args, **kwargs):
-            strength_patch = kwargs.get("strength_patch", args[0] if args else 1.0)
-            strength_model = kwargs.get("strength_model", args[1] if len(args) > 1 else 1.0)
+            # The base loader currently retries add_patches() after any exception.
+            # Runtime validation failures are deterministic, so defer them until
+            # _load_one() returns and raise once outside that retry block.
+            if deferred_errors:
+                return []
             try:
-                strength_patch_f = float(strength_patch)
-                strength_model_f = float(strength_model)
-            except Exception as exc:
-                raise RuntimeBypassUnsupportedError(
-                    f"Runtime bypass received non-scalar patch strengths for {lora_name!r}."
-                ) from exc
+                strength_patch = kwargs.get("strength_patch", args[0] if args else 1.0)
+                strength_model = kwargs.get("strength_model", args[1] if len(args) > 1 else 1.0)
+                try:
+                    strength_patch_f = float(strength_patch)
+                    strength_model_f = float(strength_model)
+                except Exception as exc:
+                    raise RuntimeBypassUnsupportedError(
+                        f"Runtime bypass received non-scalar patch strengths for {lora_name!r}."
+                    ) from exc
 
-            if abs(strength_model_f - 1.0) > 1e-12:
-                raise RuntimeBypassUnsupportedError(
-                    "Runtime bypass cannot reproduce ModelPatcher strength_model scaling. "
-                    f"{lora_name!r} requested strength_model={strength_model_f}."
-                )
-
-            regular: Dict[Any, Any] = {}
-            applied: List[Any] = []
-
-            for raw_key, patch_data in patches.items():
-                key, offset, function = _patch_target(raw_key)
-                if key not in state_dict_keys:
-                    continue
-
-                if isinstance(patch_data, comfy.weight_adapter.WeightAdapterBase):
-                    _validate_lora_adapter(patch_data, lora_name, raw_key)
-                    if offset is not None or function is not None:
-                        raise RuntimeBypassUnsupportedError(
-                            "Runtime bypass does not currently support sliced/offset or transformed LoRA targets. "
-                            f"{lora_name!r} uses one at {raw_key!r}. Disable Runtime bypass LoRA for this file."
-                        )
-                    capture.append(
-                        {
-                            "key": key,
-                            "adapter": patch_data,
-                            "strength": strength_patch_f,
-                            "lora_name": lora_name,
-                        }
+                if abs(strength_model_f - 1.0) > 1e-12:
+                    raise RuntimeBypassUnsupportedError(
+                        "Runtime bypass cannot reproduce ModelPatcher strength_model scaling. "
+                        f"{lora_name!r} requested strength_model={strength_model_f}."
                     )
-                    applied.append(raw_key)
-                else:
-                    # Match ComfyUI's own bypass loader: non-adapter patches retain
-                    # their normal materialized semantics. Standard LoRA files should
-                    # overwhelmingly/entirely take the adapter path above.
-                    regular[raw_key] = patch_data
 
-            if regular:
-                result = original_add_patches(regular, *args, **kwargs)
-                if result:
-                    applied.extend(result)
-                _LOG.warning(
-                    "[DoRA Power LoRA Loader] runtime bypass: %s contains %d non-adapter patch(es) for %s; "
-                    "those patches still use normal materialized weight patching.",
-                    lora_name,
-                    len(regular),
-                    target,
-                )
+                regular: Dict[Any, Any] = {}
+                applied: List[Any] = []
+                staged_capture: List[Dict[str, Any]] = []
 
-            return applied
+                for raw_key, patch_data in patches.items():
+                    key, offset, function = _patch_target(raw_key)
+                    if key not in state_dict_keys:
+                        continue
+
+                    if isinstance(patch_data, comfy.weight_adapter.WeightAdapterBase):
+                        runtime_adapter = _runtime_adapter_for_bypass(patch_data, lora_name, raw_key)
+                        if offset is not None or function is not None:
+                            raise RuntimeBypassUnsupportedError(
+                                "Runtime bypass does not currently support sliced/offset or transformed adapter targets. "
+                                f"{lora_name!r} uses one at {raw_key!r}. Disable Runtime bypass LoRA for this file."
+                            )
+                        staged_capture.append(
+                            {
+                                "key": key,
+                                "adapter": runtime_adapter,
+                                "strength": strength_patch_f,
+                                "lora_name": lora_name,
+                            }
+                        )
+                        applied.append(raw_key)
+                    else:
+                        # Match ComfyUI's own bypass loader: non-adapter patches retain
+                        # their normal materialized semantics. Supported runtime adapter
+                        # files should overwhelmingly/entirely take the adapter path above.
+                        regular[raw_key] = patch_data
+
+                if regular:
+                    result = original_add_patches(regular, *args, **kwargs)
+                    if result:
+                        applied.extend(result)
+                    _LOG.warning(
+                        "[DoRA Power LoRA Loader] runtime bypass: %s contains %d non-adapter patch(es) for %s; "
+                        "those patches still use normal materialized weight patching.",
+                        lora_name,
+                        len(regular),
+                        target,
+                    )
+
+                # Commit runtime captures only after every adapter validates and
+                # any materialized patches complete. The base loader retries
+                # add_patches() after an exception; mutating the shared capture
+                # earlier would retain a partial attempt and duplicate adapters.
+                capture.extend(staged_capture)
+                return applied
+            except RuntimeBypassUnsupportedError as exc:
+                if deferred_errors is None:
+                    raise
+                deferred_errors.append(exc)
+                return []
 
         return add_patches_runtime
 
@@ -408,6 +511,7 @@ class RuntimeBypassDoraPowerLoraLoader(_base.DoraPowerLoraLoader):
         self._runtime_preflight(lora_name)
 
         restores = []
+        deferred_errors: List[BaseException] = []
         try:
             if model is not None:
                 model_keys = set(model.model.state_dict().keys())
@@ -416,7 +520,13 @@ class RuntimeBypassDoraPowerLoraLoader(_base.DoraPowerLoraLoader):
                     _instance_override(
                         model,
                         "add_patches",
-                        self._capture_add_patches("model", model_keys, original, lora_name),
+                        self._capture_add_patches(
+                            "model",
+                            model_keys,
+                            original,
+                            lora_name,
+                            deferred_errors,
+                        ),
                     )
                 )
 
@@ -427,11 +537,20 @@ class RuntimeBypassDoraPowerLoraLoader(_base.DoraPowerLoraLoader):
                     _instance_override(
                         clip,
                         "add_patches",
-                        self._capture_add_patches("clip", clip_keys, original, lora_name),
+                        self._capture_add_patches(
+                            "clip",
+                            clip_keys,
+                            original,
+                            lora_name,
+                            deferred_errors,
+                        ),
                     )
                 )
 
-            return super()._load_one(model, clip, *args, **kwargs)
+            output = super()._load_one(model, clip, *args, **kwargs)
+            if deferred_errors:
+                raise deferred_errors[0]
+            return output
         finally:
             for restore in reversed(restores):
                 restore()
@@ -460,7 +579,7 @@ class RuntimeBypassDoraPowerLoraLoader(_base.DoraPowerLoraLoader):
             if not isinstance(output, dict) or "result" not in output:
                 if captured:
                     raise RuntimeBypassUnsupportedError(
-                        "Runtime bypass captured LoRA adapters, but the loader output shape is unsupported, "
+                        "Runtime bypass captured adapters, but the loader output shape is unsupported, "
                         "so the adapters cannot be injected. Disable Runtime bypass LoRA."
                     )
                 return output
@@ -469,7 +588,7 @@ class RuntimeBypassDoraPowerLoraLoader(_base.DoraPowerLoraLoader):
             if not isinstance(result, (tuple, list)):
                 if captured:
                     raise RuntimeBypassUnsupportedError(
-                        "Runtime bypass captured LoRA adapters, but the loader result is not a sequence, "
+                        "Runtime bypass captured adapters, but the loader result is not a sequence, "
                         "so the adapters cannot be injected. Disable Runtime bypass LoRA."
                     )
                 return output
@@ -493,7 +612,7 @@ class RuntimeBypassDoraPowerLoraLoader(_base.DoraPowerLoraLoader):
 
             _LOG.info(
                 "[DoRA Power LoRA Loader] Runtime bypass LoRA enabled: model_hooks=%d clip_hooks=%d. "
-                "Base weights remain unmaterialized for these standard-LoRA adapters.",
+                "Base weights remain unmaterialized for these runtime adapters.",
                 model_count,
                 clip_count,
             )

--- a/state_manager_api.py
+++ b/state_manager_api.py
@@ -1,7 +1,6 @@
 import asyncio
 import json
 import logging
-import os
 from typing import Any, Callable, Dict
 
 from .state_manager_store import (
@@ -9,6 +8,7 @@ from .state_manager_store import (
     StateLibraryRevisionConflict,
     StatePresetNotFound,
     get_state_manager_store,
+    state_manager_library_path,
 )
 
 
@@ -16,24 +16,31 @@ LOGGER = logging.getLogger(__name__)
 _ROUTES_REGISTERED = False
 
 
-def _library_path(folder_paths_module: Any) -> str:
-    return os.path.join(
-        folder_paths_module.get_user_directory(),
-        "dora_state_manager",
-        "state-library.json",
-    )
-
-
 def configure_store(
     folder_paths_module: Any,
     normalize_state: Callable[[Any], Dict[str, Any]],
     default_state: Callable[[], Dict[str, Any]],
+    user_id: Any = "default",
 ):
     return get_state_manager_store(
-        path=_library_path(folder_paths_module),
+        path=state_manager_library_path(folder_paths_module, user_id),
         normalize_state=normalize_state,
         default_state=default_state,
     )
+
+
+def _import_payload(store, payload: Dict[str, Any]):
+    kind = str(payload.get("kind", ""))
+    if kind == "dora_state_manager_library_export":
+        return store.merge_library(payload.get("characters"))
+    if kind == "dora_state_manager_character_export":
+        return store.import_character(payload.get("character"))
+    if isinstance(payload.get("character"), dict):
+        return store.import_character(payload.get("character"))
+    characters = payload.get("characters")
+    if characters is None and isinstance(payload.get("state"), dict):
+        characters = payload["state"].get("characters")
+    return store.merge_library(characters)
 
 
 def register_routes(
@@ -47,8 +54,19 @@ def register_routes(
     if _ROUTES_REGISTERED:
         return
     _ROUTES_REGISTERED = True
-    store = configure_store(folder_paths_module, normalize_state, default_state)
     routes = prompt_server.instance.routes
+
+    def store_for_request(request):
+        user_manager = getattr(prompt_server.instance, "user_manager", None)
+        user_id = user_manager.get_request_user_id(request) if user_manager is not None else "default"
+        return configure_store(folder_paths_module, normalize_state, default_state, user_id), str(user_id)
+
+    def with_user_id(payload: Dict[str, Any], user_id: str) -> Dict[str, Any]:
+        result = dict(payload)
+        result["user_id"] = user_id
+        if isinstance(result.get("snapshot"), dict):
+            result["snapshot"] = {**result["snapshot"], "user_id": user_id}
+        return result
 
     def error_response(exc: Exception):
         if isinstance(exc, StateLibraryRevisionConflict):
@@ -58,21 +76,26 @@ def register_routes(
             )
         if isinstance(exc, StatePresetNotFound):
             return web.json_response({"error": str(exc) or "State Manager preset not found."}, status=404)
+        if isinstance(exc, KeyError):
+            return web.json_response({"error": "Invalid ComfyUI user."}, status=403)
         if isinstance(exc, (InvalidStateLibrary, json.JSONDecodeError, ValueError, TypeError)):
             return web.json_response({"error": str(exc)}, status=400)
         LOGGER.exception("State Manager library API failed.")
         return web.json_response({"error": "Unable to update the State Manager library."}, status=500)
 
     @routes.get("/dora_dynamic_lora/state-library")
-    async def state_manager_list_library(_request):
+    async def state_manager_list_library(request):
         try:
-            return web.json_response(await asyncio.to_thread(store.snapshot))
+            store, user_id = store_for_request(request)
+            snapshot = await asyncio.to_thread(store.snapshot)
+            return web.json_response(with_user_id(snapshot, user_id))
         except Exception as exc:
             return error_response(exc)
 
     @routes.put("/dora_dynamic_lora/state-library")
     async def state_manager_replace_library(request):
         try:
+            store, user_id = store_for_request(request)
             payload = await request.json()
             if not isinstance(payload, dict):
                 raise InvalidStateLibrary("The State Manager library request is malformed.")
@@ -81,13 +104,14 @@ def register_routes(
                 payload.get("characters"),
                 payload.get("expected_revision"),
             )
-            return web.json_response(snapshot)
+            return web.json_response(with_user_id(snapshot, user_id))
         except Exception as exc:
             return error_response(exc)
 
     @routes.post("/dora_dynamic_lora/state-library/migrate")
     async def state_manager_migrate_library(request):
         try:
+            store, user_id = store_for_request(request)
             payload = await request.json()
             if not isinstance(payload, dict):
                 raise InvalidStateLibrary("The State Manager migration request is malformed.")
@@ -97,13 +121,14 @@ def register_routes(
                 payload.get("selected_character_id", ""),
                 payload.get("selected_prompt_id", ""),
             )
-            return web.json_response(result)
+            return web.json_response(with_user_id(result, user_id))
         except Exception as exc:
             return error_response(exc)
 
     @routes.get("/dora_dynamic_lora/state-library/export")
-    async def state_manager_export_library(_request):
+    async def state_manager_export_library(request):
         try:
+            store, _user_id = store_for_request(request)
             return web.json_response(await asyncio.to_thread(store.export_library))
         except Exception as exc:
             return error_response(exc)
@@ -111,6 +136,7 @@ def register_routes(
     @routes.get("/dora_dynamic_lora/state-library/characters/{character_id}/export")
     async def state_manager_export_character(request):
         try:
+            store, _user_id = store_for_request(request)
             payload = await asyncio.to_thread(
                 store.export_character,
                 request.match_info["character_id"],
@@ -122,17 +148,11 @@ def register_routes(
     @routes.post("/dora_dynamic_lora/state-library/import")
     async def state_manager_import_library(request):
         try:
+            store, user_id = store_for_request(request)
             payload = await request.json()
             if not isinstance(payload, dict):
                 raise InvalidStateLibrary("The State Manager import is malformed.")
-            kind = str(payload.get("kind", ""))
-            if kind == "dora_state_manager_character_export" or isinstance(payload.get("character"), dict):
-                result = await asyncio.to_thread(store.import_character, payload.get("character"))
-            else:
-                characters = payload.get("characters")
-                if characters is None and isinstance(payload.get("state"), dict):
-                    characters = payload["state"].get("characters")
-                result = await asyncio.to_thread(store.merge_library, characters)
-            return web.json_response(result)
+            result = await asyncio.to_thread(_import_payload, store, payload)
+            return web.json_response(with_user_id(result, user_id))
         except Exception as exc:
             return error_response(exc)

--- a/state_manager_api.py
+++ b/state_manager_api.py
@@ -1,0 +1,138 @@
+import asyncio
+import json
+import logging
+import os
+from typing import Any, Callable, Dict
+
+from .state_manager_store import (
+    InvalidStateLibrary,
+    StateLibraryRevisionConflict,
+    StatePresetNotFound,
+    get_state_manager_store,
+)
+
+
+LOGGER = logging.getLogger(__name__)
+_ROUTES_REGISTERED = False
+
+
+def _library_path(folder_paths_module: Any) -> str:
+    return os.path.join(
+        folder_paths_module.get_user_directory(),
+        "dora_state_manager",
+        "state-library.json",
+    )
+
+
+def configure_store(
+    folder_paths_module: Any,
+    normalize_state: Callable[[Any], Dict[str, Any]],
+    default_state: Callable[[], Dict[str, Any]],
+):
+    return get_state_manager_store(
+        path=_library_path(folder_paths_module),
+        normalize_state=normalize_state,
+        default_state=default_state,
+    )
+
+
+def register_routes(
+    folder_paths_module: Any,
+    prompt_server: Any,
+    web: Any,
+    normalize_state: Callable[[Any], Dict[str, Any]],
+    default_state: Callable[[], Dict[str, Any]],
+) -> None:
+    global _ROUTES_REGISTERED
+    if _ROUTES_REGISTERED:
+        return
+    _ROUTES_REGISTERED = True
+    store = configure_store(folder_paths_module, normalize_state, default_state)
+    routes = prompt_server.instance.routes
+
+    def error_response(exc: Exception):
+        if isinstance(exc, StateLibraryRevisionConflict):
+            return web.json_response(
+                {"error": str(exc), "code": "revision_conflict", "snapshot": exc.current},
+                status=409,
+            )
+        if isinstance(exc, StatePresetNotFound):
+            return web.json_response({"error": str(exc) or "State Manager preset not found."}, status=404)
+        if isinstance(exc, (InvalidStateLibrary, json.JSONDecodeError, ValueError, TypeError)):
+            return web.json_response({"error": str(exc)}, status=400)
+        LOGGER.exception("State Manager library API failed.")
+        return web.json_response({"error": "Unable to update the State Manager library."}, status=500)
+
+    @routes.get("/dora_dynamic_lora/state-library")
+    async def state_manager_list_library(_request):
+        try:
+            return web.json_response(await asyncio.to_thread(store.snapshot))
+        except Exception as exc:
+            return error_response(exc)
+
+    @routes.put("/dora_dynamic_lora/state-library")
+    async def state_manager_replace_library(request):
+        try:
+            payload = await request.json()
+            if not isinstance(payload, dict):
+                raise InvalidStateLibrary("The State Manager library request is malformed.")
+            snapshot = await asyncio.to_thread(
+                store.replace,
+                payload.get("characters"),
+                payload.get("expected_revision"),
+            )
+            return web.json_response(snapshot)
+        except Exception as exc:
+            return error_response(exc)
+
+    @routes.post("/dora_dynamic_lora/state-library/migrate")
+    async def state_manager_migrate_library(request):
+        try:
+            payload = await request.json()
+            if not isinstance(payload, dict):
+                raise InvalidStateLibrary("The State Manager migration request is malformed.")
+            result = await asyncio.to_thread(
+                store.migrate_legacy,
+                payload.get("state"),
+                payload.get("selected_character_id", ""),
+                payload.get("selected_prompt_id", ""),
+            )
+            return web.json_response(result)
+        except Exception as exc:
+            return error_response(exc)
+
+    @routes.get("/dora_dynamic_lora/state-library/export")
+    async def state_manager_export_library(_request):
+        try:
+            return web.json_response(await asyncio.to_thread(store.export_library))
+        except Exception as exc:
+            return error_response(exc)
+
+    @routes.get("/dora_dynamic_lora/state-library/characters/{character_id}/export")
+    async def state_manager_export_character(request):
+        try:
+            payload = await asyncio.to_thread(
+                store.export_character,
+                request.match_info["character_id"],
+            )
+            return web.json_response(payload)
+        except Exception as exc:
+            return error_response(exc)
+
+    @routes.post("/dora_dynamic_lora/state-library/import")
+    async def state_manager_import_library(request):
+        try:
+            payload = await request.json()
+            if not isinstance(payload, dict):
+                raise InvalidStateLibrary("The State Manager import is malformed.")
+            kind = str(payload.get("kind", ""))
+            if kind == "dora_state_manager_character_export" or isinstance(payload.get("character"), dict):
+                result = await asyncio.to_thread(store.import_character, payload.get("character"))
+            else:
+                characters = payload.get("characters")
+                if characters is None and isinstance(payload.get("state"), dict):
+                    characters = payload["state"].get("characters")
+                result = await asyncio.to_thread(store.merge_library, characters)
+            return web.json_response(result)
+        except Exception as exc:
+            return error_response(exc)

--- a/state_manager_store.py
+++ b/state_manager_store.py
@@ -1,0 +1,503 @@
+import hashlib
+import json
+import logging
+import os
+import tempfile
+import threading
+import time
+import uuid
+from copy import deepcopy
+from pathlib import PurePosixPath, PureWindowsPath
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+class InvalidStateLibrary(ValueError):
+    pass
+
+
+class UnsupportedStateLibraryVersion(InvalidStateLibrary):
+    pass
+
+
+class StatePresetNotFound(LookupError):
+    pass
+
+
+class StateLibraryRevisionConflict(RuntimeError):
+    def __init__(self, current: Dict[str, Any]):
+        super().__init__("The State Manager library changed since it was loaded.")
+        self.current = current
+
+
+def _is_uuid(value: Any) -> bool:
+    try:
+        uuid.UUID(str(value or "").strip())
+        return True
+    except (ValueError, AttributeError, TypeError):
+        return False
+
+
+def _new_uuid() -> str:
+    return str(uuid.uuid4())
+
+
+def _json_copy(value: Any) -> Any:
+    return json.loads(json.dumps(value, ensure_ascii=False))
+
+
+def _canonical(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def _normalize_relative_component(value: Any, label: str) -> str:
+    raw = str(value or "").strip().replace("\\", "/")
+    if not raw:
+        return ""
+    if "\x00" in raw:
+        raise InvalidStateLibrary(f"{label} contains a null byte.")
+    posix = PurePosixPath(raw)
+    windows = PureWindowsPath(raw)
+    if posix.is_absolute() or windows.is_absolute() or windows.drive:
+        raise InvalidStateLibrary(f"{label} must be relative.")
+    if any(part in {"", ".", ".."} for part in raw.split("/")):
+        raise InvalidStateLibrary(f"{label} contains an unsafe path segment.")
+    return raw
+
+
+def _validate_image_reference(value: Any) -> None:
+    if not value:
+        return
+    if not isinstance(value, dict):
+        raise InvalidStateLibrary("Image references must be objects.")
+    filename = str(value.get("filename", "") or "").strip()
+    url = str(value.get("url", "") or "").strip()
+    if filename:
+        if filename in {".", ".."} or "\x00" in filename or "/" in filename or "\\" in filename:
+            raise InvalidStateLibrary("Image filenames must not contain a path.")
+        _normalize_relative_component(value.get("subfolder", ""), "Image subfolder")
+        storage_type = str(value.get("type", "input") or "input").strip().lower()
+        if storage_type not in {"input", "output", "temp"}:
+            raise InvalidStateLibrary("Image type must be input, output, or temp.")
+    elif url and not (url.startswith("https://") or url.startswith("http://") or url.startswith("data:image/")):
+        raise InvalidStateLibrary("Image URLs must use http(s) or an image data URL.")
+
+
+class StateLibraryStore:
+    VERSION = 1
+    MAX_MIGRATIONS = 2048
+
+    def __init__(
+        self,
+        path: str,
+        normalize_state: Callable[[Any], Dict[str, Any]],
+        default_state: Callable[[], Dict[str, Any]],
+    ):
+        self.path = os.path.realpath(path)
+        self._normalize_state = normalize_state
+        self._default_state = default_state
+        self._lock = threading.RLock()
+        self._recovery_pending = False
+
+    @staticmethod
+    def _empty_document() -> Dict[str, Any]:
+        return {
+            "version": StateLibraryStore.VERSION,
+            "revision": 0,
+            "characters": [],
+            "migrations": [],
+        }
+
+    def _normalize_characters(self, characters: Any, *, require_uuids: bool) -> List[Dict[str, Any]]:
+        if not isinstance(characters, list):
+            raise InvalidStateLibrary("The State Manager library must contain a character list.")
+        if not characters:
+            return []
+        normalized = self._normalize_state({"version": 3, "characters": characters})
+        result = normalized.get("characters") if isinstance(normalized, dict) else None
+        if not isinstance(result, list):
+            raise InvalidStateLibrary("The State Manager character library is malformed.")
+        character_ids = set()
+        prompt_ids = set()
+        for character in result:
+            character_id = str(character.get("id", ""))
+            if require_uuids and not _is_uuid(character_id):
+                raise InvalidStateLibrary("Persistent character IDs must be UUIDs.")
+            if character_id in character_ids:
+                raise InvalidStateLibrary("The State Manager library contains duplicate character IDs.")
+            character_ids.add(character_id)
+            _validate_image_reference(character.get("thumbnail", {}))
+            prompts = character.get("prompts")
+            if not isinstance(prompts, list) or not prompts:
+                raise InvalidStateLibrary("Every persistent character must contain at least one prompt.")
+            for prompt in prompts:
+                prompt_id = str(prompt.get("id", ""))
+                if require_uuids and not _is_uuid(prompt_id):
+                    raise InvalidStateLibrary("Persistent prompt IDs must be UUIDs.")
+                if prompt_id in prompt_ids:
+                    raise InvalidStateLibrary("Persistent prompt IDs must be globally unique.")
+                prompt_ids.add(prompt_id)
+                _validate_image_reference(prompt.get("reference_image", {}))
+        return result
+
+    def _normalize_document(self, raw: Any) -> Dict[str, Any]:
+        if not isinstance(raw, dict):
+            raise InvalidStateLibrary("The State Manager library document is malformed.")
+        if raw.get("version") != self.VERSION:
+            raise UnsupportedStateLibraryVersion(
+                f"Unsupported State Manager library version {raw.get('version')!r}; expected {self.VERSION}."
+            )
+        try:
+            revision = max(0, int(raw.get("revision", 0)))
+        except (TypeError, ValueError) as exc:
+            raise InvalidStateLibrary("The State Manager library revision is invalid.") from exc
+        migrations = raw.get("migrations", [])
+        if not isinstance(migrations, list):
+            raise InvalidStateLibrary("The State Manager migration index is malformed.")
+        normalized_migrations = []
+        fingerprints = set()
+        for entry in migrations[-self.MAX_MIGRATIONS :]:
+            if not isinstance(entry, dict):
+                raise InvalidStateLibrary("The State Manager migration index is malformed.")
+            fingerprint = str(entry.get("fingerprint", "") or "").strip().lower()
+            if len(fingerprint) != 64 or any(char not in "0123456789abcdef" for char in fingerprint):
+                raise InvalidStateLibrary("The State Manager migration index contains an invalid fingerprint.")
+            if fingerprint in fingerprints:
+                continue
+            fingerprints.add(fingerprint)
+            normalized_migrations.append({
+                "fingerprint": fingerprint,
+                "character_ids": {
+                    str(key): str(value)
+                    for key, value in (entry.get("character_ids") or {}).items()
+                    if _is_uuid(value)
+                },
+                "prompt_ids": {
+                    str(key): str(value)
+                    for key, value in (entry.get("prompt_ids") or {}).items()
+                    if _is_uuid(value)
+                },
+                "imported_at": max(0, int(entry.get("imported_at", 0) or 0)),
+            })
+        return {
+            "version": self.VERSION,
+            "revision": revision,
+            "characters": self._normalize_characters(raw.get("characters"), require_uuids=True),
+            "migrations": normalized_migrations,
+        }
+
+    def _quarantine(self) -> Optional[str]:
+        if not os.path.exists(self.path):
+            return None
+        quarantine = f"{self.path}.corrupt-{int(time.time() * 1000)}"
+        try:
+            os.replace(self.path, quarantine)
+            return quarantine
+        except OSError:
+            LOGGER.exception("State Manager could not quarantine malformed library storage.")
+            return None
+
+    def _load_unlocked(self) -> Dict[str, Any]:
+        try:
+            with open(self.path, "r", encoding="utf-8") as handle:
+                return self._normalize_document(json.load(handle))
+        except FileNotFoundError:
+            return self._empty_document()
+        except OSError:
+            LOGGER.warning("State Manager could not read library storage.", exc_info=True)
+            raise
+        except UnsupportedStateLibraryVersion:
+            LOGGER.error("State Manager library was created by an incompatible version; leaving it untouched.")
+            raise
+        except (UnicodeError, json.JSONDecodeError, InvalidStateLibrary, ValueError, TypeError):
+            LOGGER.warning("State Manager library storage was malformed and has been quarantined.", exc_info=True)
+            self._quarantine()
+            self._recovery_pending = True
+            return self._empty_document()
+
+    def _write_unlocked(self, document: Dict[str, Any]) -> None:
+        parent = os.path.dirname(self.path)
+        os.makedirs(parent, exist_ok=True)
+        descriptor, temporary = tempfile.mkstemp(prefix=".state-library-", suffix=".tmp", dir=parent)
+        try:
+            with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+                json.dump(document, handle, ensure_ascii=False, separators=(",", ":"))
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temporary, self.path)
+            self._recovery_pending = False
+            try:
+                directory_fd = os.open(parent, os.O_RDONLY)
+                try:
+                    os.fsync(directory_fd)
+                finally:
+                    os.close(directory_fd)
+            except OSError:
+                pass
+        finally:
+            try:
+                os.unlink(temporary)
+            except OSError:
+                pass
+
+    @staticmethod
+    def _public(document: Dict[str, Any]) -> Dict[str, Any]:
+        return _json_copy({
+            "version": document["version"],
+            "revision": document["revision"],
+            "characters": document["characters"],
+        })
+
+    def snapshot(self) -> Dict[str, Any]:
+        with self._lock:
+            recovery_was_pending = self._recovery_pending
+            document = self._load_unlocked()
+            if recovery_was_pending and not os.path.exists(self.path):
+                # A read after quarantine explicitly acknowledges the recovered
+                # empty library. The discovering request itself cannot write it.
+                self._recovery_pending = False
+            return self._public(document)
+
+    def revision(self) -> int:
+        with self._lock:
+            return int(self._load_unlocked()["revision"])
+
+    def _require_recovery_acknowledgement(self) -> None:
+        if self._recovery_pending:
+            raise InvalidStateLibrary(
+                "The malformed library was quarantined. Reload the empty recovered library before saving."
+            )
+
+    def replace(self, characters: Any, expected_revision: Any) -> Dict[str, Any]:
+        with self._lock:
+            document = self._load_unlocked()
+            self._require_recovery_acknowledgement()
+            try:
+                expected = int(expected_revision)
+            except (TypeError, ValueError) as exc:
+                raise InvalidStateLibrary("An expected library revision is required.") from exc
+            if expected != document["revision"]:
+                raise StateLibraryRevisionConflict(self._public(document))
+            document["characters"] = self._normalize_characters(characters, require_uuids=True)
+            document["revision"] += 1
+            self._write_unlocked(document)
+            return self._public(document)
+
+    @staticmethod
+    def _without_ids(character: Dict[str, Any]) -> Dict[str, Any]:
+        value = deepcopy(character)
+        value.pop("id", None)
+        for prompt in value.get("prompts", []):
+            if isinstance(prompt, dict):
+                prompt.pop("id", None)
+        return value
+
+    @staticmethod
+    def _unique_name(name: str, characters: List[Dict[str, Any]]) -> str:
+        used = {str(character.get("name", "")).casefold() for character in characters}
+        if name.casefold() not in used:
+            return name
+        suffix = 2
+        while f"{name} (Imported {suffix})".casefold() in used:
+            suffix += 1
+        return f"{name} (Imported {suffix})"
+
+    def _merge_character(
+        self,
+        document: Dict[str, Any],
+        raw_character: Dict[str, Any],
+        *,
+        deduplicate_content: bool,
+    ) -> Tuple[Dict[str, Any], Dict[str, str], Dict[str, str], bool]:
+        normalized = self._normalize_characters([raw_character], require_uuids=False)[0]
+        old_character_id = str(normalized.get("id", ""))
+        old_prompt_ids = [str(prompt.get("id", "")) for prompt in normalized.get("prompts", [])]
+        content_key = _canonical(self._without_ids(normalized))
+        if deduplicate_content:
+            existing = next(
+                (
+                    character for character in document["characters"]
+                    if _canonical(self._without_ids(character)) == content_key
+                ),
+                None,
+            )
+            if existing is not None:
+                prompt_map = {
+                    old_id: existing["prompts"][index]["id"]
+                    for index, old_id in enumerate(old_prompt_ids)
+                    if index < len(existing.get("prompts", []))
+                }
+                return existing, {old_character_id: existing["id"]}, prompt_map, False
+
+        used_character_ids = {character["id"] for character in document["characters"]}
+        used_prompt_ids = {
+            prompt["id"]
+            for character in document["characters"]
+            for prompt in character.get("prompts", [])
+        }
+        character_id = old_character_id if _is_uuid(old_character_id) and old_character_id not in used_character_ids else _new_uuid()
+        normalized["id"] = character_id
+        normalized["name"] = self._unique_name(str(normalized.get("name") or "Imported Character"), document["characters"])
+        prompt_map = {}
+        for prompt, old_prompt_id in zip(normalized.get("prompts", []), old_prompt_ids):
+            prompt_id = old_prompt_id if _is_uuid(old_prompt_id) and old_prompt_id not in used_prompt_ids else _new_uuid()
+            used_prompt_ids.add(prompt_id)
+            prompt["id"] = prompt_id
+            prompt_map[old_prompt_id] = prompt_id
+        document["characters"].append(normalized)
+        return normalized, {old_character_id: character_id}, prompt_map, True
+
+    def migrate_legacy(
+        self,
+        legacy_state: Any,
+        selected_character_id: Any = "",
+        selected_prompt_id: Any = "",
+    ) -> Dict[str, Any]:
+        if not isinstance(legacy_state, dict) or not isinstance(legacy_state.get("characters"), list):
+            raise InvalidStateLibrary("Legacy State Manager data is malformed.")
+        normalized = self._normalize_state(legacy_state)
+        fingerprint = hashlib.sha256(_canonical(normalized).encode("utf-8")).hexdigest()
+        with self._lock:
+            document = self._load_unlocked()
+            self._require_recovery_acknowledgement()
+            existing_migration = next(
+                (entry for entry in document["migrations"] if entry["fingerprint"] == fingerprint),
+                None,
+            )
+            if existing_migration is not None:
+                return {
+                    "snapshot": self._public(document),
+                    "fingerprint": fingerprint,
+                    "already_migrated": True,
+                    "selected_character_id": existing_migration["character_ids"].get(str(selected_character_id), ""),
+                    "selected_prompt_id": existing_migration["prompt_ids"].get(str(selected_prompt_id), ""),
+                    "character_ids": _json_copy(existing_migration["character_ids"]),
+                    "prompt_ids": _json_copy(existing_migration["prompt_ids"]),
+                }
+
+            character_map: Dict[str, str] = {}
+            prompt_map: Dict[str, str] = {}
+            changed = False
+            for character in normalized.get("characters", []):
+                _, mapped_characters, mapped_prompts, inserted = self._merge_character(
+                    document,
+                    character,
+                    deduplicate_content=True,
+                )
+                character_map.update(mapped_characters)
+                prompt_map.update(mapped_prompts)
+                changed = changed or inserted
+            document["migrations"].append({
+                "fingerprint": fingerprint,
+                "character_ids": character_map,
+                "prompt_ids": prompt_map,
+                "imported_at": int(time.time() * 1000),
+            })
+            document["migrations"] = document["migrations"][-self.MAX_MIGRATIONS :]
+            document["revision"] += 1
+            self._write_unlocked(document)
+            return {
+                "snapshot": self._public(document),
+                "fingerprint": fingerprint,
+                "already_migrated": False,
+                "changed": changed,
+                "selected_character_id": character_map.get(str(selected_character_id), ""),
+                "selected_prompt_id": prompt_map.get(str(selected_prompt_id), ""),
+                "character_ids": character_map,
+                "prompt_ids": prompt_map,
+            }
+
+    def import_character(self, raw_character: Any) -> Dict[str, Any]:
+        if not isinstance(raw_character, dict):
+            raise InvalidStateLibrary("The character import is malformed.")
+        with self._lock:
+            document = self._load_unlocked()
+            self._require_recovery_acknowledgement()
+            character, _, _, _ = self._merge_character(document, raw_character, deduplicate_content=False)
+            document["revision"] += 1
+            self._write_unlocked(document)
+            return {"snapshot": self._public(document), "character": _json_copy(character)}
+
+    def merge_library(self, characters: Any) -> Dict[str, Any]:
+        if not isinstance(characters, list):
+            raise InvalidStateLibrary("The State Manager library import is malformed.")
+        with self._lock:
+            document = self._load_unlocked()
+            self._require_recovery_acknowledgement()
+            imported_ids = []
+            for character in characters:
+                imported, _, _, _ = self._merge_character(document, character, deduplicate_content=True)
+                imported_ids.append(imported["id"])
+            document["revision"] += 1
+            self._write_unlocked(document)
+            return {"snapshot": self._public(document), "character_ids": imported_ids}
+
+    def export_character(self, character_id: Any) -> Dict[str, Any]:
+        character_id = str(character_id or "").strip()
+        with self._lock:
+            document = self._load_unlocked()
+            character = next((entry for entry in document["characters"] if entry["id"] == character_id), None)
+            if character is None:
+                raise StatePresetNotFound(character_id)
+            return {
+                "version": 1,
+                "kind": "dora_state_manager_character_export",
+                "exported_at": int(time.time() * 1000),
+                "character": _json_copy(character),
+            }
+
+    def export_library(self) -> Dict[str, Any]:
+        snapshot = self.snapshot()
+        return {
+            "version": 1,
+            "kind": "dora_state_manager_library_export",
+            "exported_at": int(time.time() * 1000),
+            "characters": snapshot["characters"],
+        }
+
+    def resolve(self, character_id: Any, prompt_id: Any) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+        character_id = str(character_id or "").strip()
+        prompt_id = str(prompt_id or "").strip()
+        if character_id in {"", "default_character"} and prompt_id in {"", "default_prompt"}:
+            character = self._default_state()["characters"][0]
+            return _json_copy(character), _json_copy(character["prompts"][0])
+        with self._lock:
+            document = self._load_unlocked()
+            character = next((entry for entry in document["characters"] if entry["id"] == character_id), None)
+            if character is None:
+                raise StatePresetNotFound(
+                    "Selected character preset is not available locally. Select or create a character."
+                )
+            prompt = next((entry for entry in character.get("prompts", []) if entry["id"] == prompt_id), None)
+            if prompt is None:
+                raise StatePresetNotFound(
+                    "Selected prompt preset is not available locally for this character. Select or create a prompt."
+                )
+            return _json_copy(character), _json_copy(prompt)
+
+
+_STORE: Optional[StateLibraryStore] = None
+_STORE_LOCK = threading.Lock()
+
+
+def get_state_manager_store(
+    *,
+    path: Optional[str] = None,
+    normalize_state: Optional[Callable[[Any], Dict[str, Any]]] = None,
+    default_state: Optional[Callable[[], Dict[str, Any]]] = None,
+) -> StateLibraryStore:
+    global _STORE
+    with _STORE_LOCK:
+        if _STORE is None:
+            if path is None or normalize_state is None or default_state is None:
+                raise RuntimeError("State Manager store has not been configured.")
+            _STORE = StateLibraryStore(path, normalize_state, default_state)
+        return _STORE
+
+
+def reset_state_manager_store_for_tests() -> None:
+    global _STORE
+    with _STORE_LOCK:
+        _STORE = None

--- a/state_manager_store.py
+++ b/state_manager_store.py
@@ -52,6 +52,27 @@ def _canonical(value: Any) -> str:
     return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
 
 
+def state_manager_library_path(folder_paths_module: Any, user_id: Any = "default") -> str:
+    user = str(user_id or "default").strip() or "default"
+    if user in {".", ".."} or "\x00" in user or "/" in user or "\\" in user:
+        raise InvalidStateLibrary("The ComfyUI user id is invalid.")
+    get_public_directory = getattr(folder_paths_module, "get_public_user_directory", None)
+    if callable(get_public_directory):
+        user_directory = get_public_directory(user)
+    else:  # Compatibility with ComfyUI revisions predating public-user helpers.
+        user_directory = os.path.join(folder_paths_module.get_user_directory(), user)
+    if not user_directory:
+        raise InvalidStateLibrary("The active ComfyUI user directory is unavailable.")
+    base_directory = os.path.realpath(folder_paths_module.get_user_directory())
+    resolved_directory = os.path.realpath(user_directory)
+    try:
+        if os.path.commonpath((base_directory, resolved_directory)) != base_directory:
+            raise InvalidStateLibrary("The ComfyUI user directory is outside the configured user root.")
+    except ValueError as exc:
+        raise InvalidStateLibrary("The ComfyUI user directory is invalid.") from exc
+    return os.path.join(resolved_directory, "dora_state_manager", "state-library.json")
+
+
 def _normalize_relative_component(value: Any, label: str) -> str:
     raw = str(value or "").strip().replace("\\", "/")
     if not raw:
@@ -115,10 +136,14 @@ class StateLibraryStore:
             raise InvalidStateLibrary("The State Manager library must contain a character list.")
         if not characters:
             return []
+        if any(not isinstance(character, dict) for character in characters):
+            raise InvalidStateLibrary("One or more State Manager characters are malformed.")
         normalized = self._normalize_state({"version": 3, "characters": characters})
         result = normalized.get("characters") if isinstance(normalized, dict) else None
         if not isinstance(result, list):
             raise InvalidStateLibrary("The State Manager character library is malformed.")
+        if len(result) != len(characters):
+            raise InvalidStateLibrary("One or more State Manager characters are malformed.")
         character_ids = set()
         prompt_ids = set()
         for character in result:
@@ -478,7 +503,7 @@ class StateLibraryStore:
             return _json_copy(character), _json_copy(prompt)
 
 
-_STORE: Optional[StateLibraryStore] = None
+_STORES: Dict[str, StateLibraryStore] = {}
 _STORE_LOCK = threading.Lock()
 
 
@@ -488,16 +513,19 @@ def get_state_manager_store(
     normalize_state: Optional[Callable[[Any], Dict[str, Any]]] = None,
     default_state: Optional[Callable[[], Dict[str, Any]]] = None,
 ) -> StateLibraryStore:
-    global _STORE
     with _STORE_LOCK:
-        if _STORE is None:
-            if path is None or normalize_state is None or default_state is None:
-                raise RuntimeError("State Manager store has not been configured.")
-            _STORE = StateLibraryStore(path, normalize_state, default_state)
-        return _STORE
+        if path is None:
+            raise RuntimeError("A State Manager library path is required.")
+        normalized_path = os.path.realpath(path)
+        store = _STORES.get(normalized_path)
+        if store is None:
+            if normalize_state is None or default_state is None:
+                raise RuntimeError("State Manager store has not been configured for this user.")
+            store = StateLibraryStore(normalized_path, normalize_state, default_state)
+            _STORES[normalized_path] = store
+        return store
 
 
 def reset_state_manager_store_for_tests() -> None:
-    global _STORE
     with _STORE_LOCK:
-        _STORE = None
+        _STORES.clear()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,26 +16,6 @@ ROOT = pathlib.Path(
 COMFYUI_PATH = pathlib.Path(os.environ.get("COMFYUI_PATH", ROOT / "ComfyUI")).resolve()
 
 comfy_cli_args_path = COMFYUI_PATH / "comfy" / "cli_args.py"
-if not comfy_cli_args_path.is_file():
-    pytest.skip(
-        f"ComfyUI checkout not found at {COMFYUI_PATH}; set COMFYUI_PATH to a valid checkout.",
-        allow_module_level=True,
-    )
-
-if str(COMFYUI_PATH) not in sys.path:
-    sys.path.insert(0, str(COMFYUI_PATH))
-
-# GitHub's hosted runners use the CPU-only PyTorch wheel. ComfyUI's CLI parser
-# intentionally parses an empty argv when imported as a library, so its default
-# device remains CUDA unless a caller changes the parsed args before importing
-# comfy.model_management. Force CPU mode for these pure adapter tests; this is
-# the same supported ComfyUI --cpu execution mode, without letting ComfyUI parse
-# pytest's own command-line arguments.
-comfy_cli_args = pytest.importorskip(
-    "comfy.cli_args",
-    reason=f"Could not import comfy.cli_args from ComfyUI checkout at {COMFYUI_PATH}.",
-)
-comfy_cli_args.args.cpu = True
 
 
 @pytest.fixture(scope="session")
@@ -45,6 +25,21 @@ def dora_modules():
     The custom-node __init__ registers HTTP routes against a live PromptServer,
     which is correct inside ComfyUI but unnecessary for these pure loader tests.
     """
+    if not comfy_cli_args_path.is_file():
+        pytest.skip(
+            f"ComfyUI checkout not found at {COMFYUI_PATH}; set COMFYUI_PATH to a valid checkout."
+        )
+    if str(COMFYUI_PATH) not in sys.path:
+        sys.path.insert(0, str(COMFYUI_PATH))
+
+    # GitHub's hosted runners use the CPU-only PyTorch wheel. Force the supported
+    # ComfyUI CPU mode before importing comfy.model_management.
+    comfy_cli_args = pytest.importorskip(
+        "comfy.cli_args",
+        reason=f"Could not import comfy.cli_args from ComfyUI checkout at {COMFYUI_PATH}.",
+    )
+    comfy_cli_args.args.cpu = True
+
     package_name = "dora_loader_testpkg"
     package = types.ModuleType(package_name)
     package.__path__ = [str(ROOT)]

--- a/tests/test_runtime_bypass_error_deferral.py
+++ b/tests/test_runtime_bypass_error_deferral.py
@@ -1,0 +1,169 @@
+import pytest
+import torch
+
+
+def make_dora_adapter(comfy_weight_adapter):
+    return comfy_weight_adapter.LoRAAdapter(
+        set(),
+        (
+            torch.tensor([[1.0], [0.5]], dtype=torch.float32),
+            torch.tensor([[0.25, -0.5, 1.0]], dtype=torch.float32),
+            1.0,
+            None,
+            torch.ones(2, dtype=torch.float32),
+            None,
+        ),
+    )
+
+
+def make_lora_adapter(comfy_weight_adapter):
+    return comfy_weight_adapter.LoRAAdapter(
+        set(),
+        (
+            torch.tensor([[1.0], [0.5]], dtype=torch.float32),
+            torch.tensor([[0.25, -0.5, 1.0]], dtype=torch.float32),
+            1.0,
+            None,
+            None,
+            None,
+        ),
+    )
+
+
+def test_runtime_validation_error_is_deferred_only_once(dora_modules):
+    _, runtime = dora_modules
+    loader = runtime.RuntimeBypassDoraPowerLoraLoader()
+    loader._runtime_bypass_capture = {"model": [], "clip": []}
+    adapter = make_dora_adapter(runtime.comfy.weight_adapter)
+    deferred = []
+
+    capture_add = loader._capture_add_patches(
+        "model",
+        {"layer.weight"},
+        lambda patches, *args, **kwargs: list(patches),
+        "dora.safetensors",
+        deferred,
+    )
+
+    assert capture_add({"layer.weight": adapter}, 1.0) == []
+    assert len(deferred) == 1
+    assert isinstance(deferred[0], runtime.RuntimeBypassUnsupportedError)
+
+    # nodes.py currently retries add_patches() after a raised exception. Once a
+    # runtime validation failure has been deferred, a second invocation becomes a
+    # no-op and cannot generate another copy of the same exception.
+    assert capture_add({"layer.weight": adapter}, 1.0) == []
+    assert len(deferred) == 1
+    assert loader._runtime_bypass_capture["model"] == []
+
+
+def test_runtime_capture_is_transactional_across_base_retry(dora_modules):
+    _, runtime = dora_modules
+    loader = runtime.RuntimeBypassDoraPowerLoraLoader()
+    loader._runtime_bypass_capture = {"model": [], "clip": []}
+    adapter = make_lora_adapter(runtime.comfy.weight_adapter)
+    attempts = []
+
+    def materialize_regular(patches, *args, **kwargs):
+        attempts.append(dict(patches))
+        if len(attempts) == 1:
+            raise RuntimeError("transient materialization failure")
+        return list(patches)
+
+    capture_add = loader._capture_add_patches(
+        "model",
+        {"layer.weight", "layer.bias"},
+        materialize_regular,
+        "mixed.safetensors",
+    )
+    patches = {
+        "layer.weight": adapter,
+        "layer.bias": torch.tensor([0.25, -0.5], dtype=torch.float32),
+    }
+
+    with pytest.raises(RuntimeError, match="transient materialization failure"):
+        capture_add(patches, 0.75)
+    assert loader._runtime_bypass_capture["model"] == []
+
+    assert capture_add(patches, 0.75) == ["layer.weight", "layer.bias"]
+    assert len(attempts) == 2
+    assert len(loader._runtime_bypass_capture["model"]) == 1
+    assert loader._runtime_bypass_capture["model"][0]["adapter"] is adapter
+
+
+def test_deferred_validation_does_not_commit_partial_capture(dora_modules):
+    _, runtime = dora_modules
+    loader = runtime.RuntimeBypassDoraPowerLoraLoader()
+    loader._runtime_bypass_capture = {"model": [], "clip": []}
+    deferred = []
+    patches = {
+        "first.weight": make_lora_adapter(runtime.comfy.weight_adapter),
+        "second.weight": make_dora_adapter(runtime.comfy.weight_adapter),
+    }
+
+    capture_add = loader._capture_add_patches(
+        "model",
+        set(patches),
+        lambda regular, *args, **kwargs: list(regular),
+        "partially-supported.safetensors",
+        deferred,
+    )
+
+    assert capture_add(patches, 1.0) == []
+    assert len(deferred) == 1
+    assert isinstance(deferred[0], runtime.RuntimeBypassUnsupportedError)
+    assert loader._runtime_bypass_capture["model"] == []
+
+
+def test_runtime_load_one_raises_deferred_validation_after_base_retry_boundary(
+    dora_modules,
+    monkeypatch,
+):
+    _, runtime = dora_modules
+    adapter = make_dora_adapter(runtime.comfy.weight_adapter)
+    base_cls = runtime._base.DoraPowerLoraLoader
+    add_attempts = []
+
+    class TinyModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.layer = torch.nn.Linear(3, 2, bias=False)
+
+    class FakePatcher:
+        def __init__(self):
+            self.model = TinyModel()
+
+        def add_patches(self, patches, strength_patch=1.0, strength_model=1.0):
+            raise AssertionError("runtime adapter validation should intercept before materialization")
+
+    def fake_base_load_one(self, model, clip, *args, **kwargs):
+        # Mirror the current base loader's try/retry shape. With deferral, the first
+        # call returns normally, so this retry path is never entered.
+        try:
+            add_attempts.append("first")
+            model.add_patches({"layer.weight": adapter}, 1.0)
+        except Exception:
+            add_attempts.append("retry")
+            model.add_patches({"layer.weight": adapter}, 1.0)
+        return model, clip, {}
+
+    monkeypatch.setattr(base_cls, "_load_one", fake_base_load_one)
+    monkeypatch.setattr(
+        runtime.RuntimeBypassDoraPowerLoraLoader,
+        "_runtime_preflight",
+        lambda self, lora_name: None,
+    )
+
+    loader = runtime.RuntimeBypassDoraPowerLoraLoader()
+    loader._runtime_bypass_active = True
+    loader._runtime_bypass_capture = {"model": [], "clip": []}
+
+    with pytest.raises(runtime.RuntimeBypassUnsupportedError, match="DoRA magnitude scaling"):
+        loader._load_one(
+            FakePatcher(),
+            None,
+            lora_name="dora.safetensors",
+        )
+
+    assert add_attempts == ["first"]
+    assert loader._runtime_bypass_capture["model"] == []

--- a/tests/test_runtime_bypass_lokr.py
+++ b/tests/test_runtime_bypass_lokr.py
@@ -1,0 +1,379 @@
+import pytest
+import torch
+import torch.nn.functional as F
+
+
+def make_lora_adapter(comfy_weight_adapter, up, down, *, alpha=1.0):
+    return comfy_weight_adapter.LoRAAdapter(
+        set(),
+        (
+            torch.tensor(up, dtype=torch.float32),
+            torch.tensor(down, dtype=torch.float32),
+            alpha,
+            None,
+            None,
+            None,
+        ),
+    )
+
+
+def make_lokr_adapter(
+    comfy_weight_adapter,
+    w1,
+    w2,
+    *,
+    alpha=1.0,
+    dora_scale=None,
+    require_bypass=True,
+):
+    lokr_type = getattr(comfy_weight_adapter, "LoKrAdapter", None)
+    if lokr_type is None:
+        pytest.skip("This ComfyUI revision does not expose LoKrAdapter")
+    if require_bypass:
+        base_h = getattr(comfy_weight_adapter.WeightAdapterBase, "h", None)
+        lokr_h = getattr(lokr_type, "h", None)
+        if not callable(lokr_h) or lokr_h is base_h:
+            pytest.skip("This ComfyUI revision does not implement LoKr bypass math")
+    return lokr_type(
+        set(),
+        (
+            torch.tensor(w1, dtype=torch.float32),
+            torch.tensor(w2, dtype=torch.float32),
+            alpha,
+            None,
+            None,
+            None,
+            None,
+            None,
+            dora_scale,
+        ),
+    )
+
+
+def test_plain_lokr_adapter_is_accepted_when_comfy_has_native_bypass(dora_modules):
+    _, runtime = dora_modules
+    adapter = make_lokr_adapter(
+        runtime.comfy.weight_adapter,
+        [[1.0, -0.25], [0.5, 0.75]],
+        [[0.3, -0.2, 0.1], [0.4, 0.6, -0.5]],
+    )
+
+    runtime._validate_lora_adapter(adapter, "plain_lokr.safetensors", "layer.weight")
+
+
+def test_lokr_dora_scale_is_refused(dora_modules):
+    _, runtime = dora_modules
+    adapter = make_lokr_adapter(
+        runtime.comfy.weight_adapter,
+        [[1.0]],
+        [[0.3, -0.2, 0.1], [0.4, 0.6, -0.5]],
+        dora_scale=torch.ones(2, dtype=torch.float32),
+    )
+
+    with pytest.raises(runtime.RuntimeBypassUnsupportedError, match="LoKr DoRA magnitude scaling"):
+        runtime._validate_lora_adapter(adapter, "dora_lokr.safetensors", "layer.weight")
+
+
+def test_lokr_without_real_comfy_bypass_math_is_refused(dora_modules, monkeypatch):
+    _, runtime = dora_modules
+    comfy_weight_adapter = runtime.comfy.weight_adapter
+    adapter = make_lokr_adapter(
+        comfy_weight_adapter,
+        [[1.0]],
+        [[0.3, -0.2, 0.1], [0.4, 0.6, -0.5]],
+        require_bypass=False,
+    )
+
+    monkeypatch.setattr(
+        type(adapter),
+        "h",
+        comfy_weight_adapter.WeightAdapterBase.h,
+    )
+
+    with pytest.raises(runtime.RuntimeBypassUnsupportedError, match="does not implement LoKr bypass math"):
+        runtime._validate_lora_adapter(adapter, "old_comfy_lokr.safetensors", "layer.weight")
+
+
+def test_lokr_is_captured_without_materializing_patch(dora_modules):
+    _, runtime = dora_modules
+    loader = runtime.RuntimeBypassDoraPowerLoraLoader()
+    loader._runtime_bypass_capture = {"model": [], "clip": []}
+    adapter = make_lokr_adapter(
+        runtime.comfy.weight_adapter,
+        [[1.0, -0.25], [0.5, 0.75]],
+        [[0.3, -0.2, 0.1], [0.4, 0.6, -0.5]],
+    )
+    materialized_calls = []
+
+    def original_add_patches(patches, *args, **kwargs):
+        materialized_calls.append((patches, args, kwargs))
+        return list(patches)
+
+    capture_add = loader._capture_add_patches(
+        "model",
+        {"layer.weight"},
+        original_add_patches,
+        "plain_lokr.safetensors",
+    )
+    applied = capture_add({"layer.weight": adapter}, 0.65)
+
+    assert applied == ["layer.weight"]
+    assert materialized_calls == []
+    captured = loader._runtime_bypass_capture["model"]
+    assert len(captured) == 1
+    assert captured[0]["key"] == "layer.weight"
+    assert captured[0]["adapter"] is not adapter
+    assert captured[0]["adapter"].weights[2] == pytest.approx(1.0)
+    assert captured[0]["strength"] == pytest.approx(0.65)
+    assert captured[0]["lora_name"] == "plain_lokr.safetensors"
+
+
+def test_direct_lokr_nonfinite_alpha_is_normalized_to_materialized_semantics(dora_modules):
+    _, runtime = dora_modules
+    comfy_weight_adapter = runtime.comfy.weight_adapter
+    loader = runtime.RuntimeBypassDoraPowerLoraLoader()
+    loader._runtime_bypass_capture = {"model": [], "clip": []}
+
+    w1 = torch.tensor([[0.5, -0.25], [0.75, 0.2]], dtype=torch.float32)
+    w2 = torch.tensor([[0.3, -0.2, 0.1], [0.4, 0.6, -0.5]], dtype=torch.float32)
+    adapter = make_lokr_adapter(
+        comfy_weight_adapter,
+        w1.tolist(),
+        w2.tolist(),
+        alpha=float("inf"),
+    )
+
+    capture_add = loader._capture_add_patches(
+        "model",
+        {"layer.weight"},
+        lambda patches, *args, **kwargs: list(patches),
+        "inf_alpha_lokr.safetensors",
+    )
+    capture_add({"layer.weight": adapter}, 0.7)
+    captured_adapter = loader._runtime_bypass_capture["model"][0]["adapter"]
+
+    assert captured_adapter is not adapter
+    assert adapter.weights[2] == float("inf")
+    assert captured_adapter.weights[2] == pytest.approx(1.0)
+
+    class TinyModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.layer = torch.nn.Linear(6, 4, bias=False)
+
+    model = TinyModel()
+    x = torch.tensor([[0.2, -0.7, 1.1, 0.3, -0.4, 0.9]], dtype=torch.float32)
+    base = model.layer(x).detach().clone()
+    expected_delta = F.linear(x, torch.kron(w1, w2)) * 0.7
+
+    injections, _ = runtime._make_stacked_injection(
+        model,
+        [{"key": "layer.weight", "adapter": captured_adapter, "strength": 0.7, "lora_name": "inf_alpha"}],
+    )
+    injections[0].inject(None)
+    try:
+        actual = model.layer(x)
+        assert torch.isfinite(actual).all()
+        torch.testing.assert_close(actual, base + expected_delta)
+    finally:
+        injections[0].eject(None)
+
+
+def test_unequal_decomposed_lokr_ranks_are_normalized_to_materialized_scale(dora_modules):
+    _, runtime = dora_modules
+    comfy_weight_adapter = runtime.comfy.weight_adapter
+    lokr_type = getattr(comfy_weight_adapter, "LoKrAdapter", None)
+    if lokr_type is None:
+        pytest.skip("This ComfyUI revision does not expose LoKrAdapter")
+    base_h = getattr(comfy_weight_adapter.WeightAdapterBase, "h", None)
+    lokr_h = getattr(lokr_type, "h", None)
+    if not callable(lokr_h) or lokr_h is base_h:
+        pytest.skip("This ComfyUI revision does not implement LoKr bypass math")
+
+    w1_a = torch.tensor([[0.5], [0.3]], dtype=torch.float32)
+    w1_b = torch.tensor([[0.8, -0.4]], dtype=torch.float32)  # rank_w1 = 1
+    w2_a = torch.tensor([[0.4, -0.3], [0.2, 0.9]], dtype=torch.float32)
+    w2_b = torch.tensor([[0.5, -0.1, 0.7], [-0.6, 0.8, 0.2]], dtype=torch.float32)  # rank_w2 = 2
+    alpha = 1.5
+    adapter = lokr_type(
+        set(),
+        (None, None, alpha, w1_a, w1_b, w2_a, w2_b, None, None),
+    )
+
+    runtime_adapter = runtime._runtime_adapter_for_bypass(
+        adapter,
+        "unequal_rank_lokr.safetensors",
+        "layer.weight",
+    )
+    assert runtime_adapter is not adapter
+    assert adapter.weights[2] == pytest.approx(alpha)
+    assert runtime_adapter.weights[2] == pytest.approx(alpha * 1.0 / 2.0)
+
+    class TinyModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.layer = torch.nn.Linear(6, 4, bias=False)
+
+    model = TinyModel()
+    x = torch.tensor([[0.2, -0.7, 1.1, 0.3, -0.4, 0.9]], dtype=torch.float32)
+    base = model.layer(x).detach().clone()
+    materialized_delta = torch.kron(w1_a @ w1_b, w2_a @ w2_b) * (alpha / w2_b.shape[0])
+    strength = 0.45
+
+    injections, _ = runtime._make_stacked_injection(
+        model,
+        [{"key": "layer.weight", "adapter": runtime_adapter, "strength": strength, "lora_name": "unequal"}],
+    )
+    injections[0].inject(None)
+    try:
+        torch.testing.assert_close(
+            model.layer(x),
+            base + F.linear(x, materialized_delta) * strength,
+        )
+    finally:
+        injections[0].eject(None)
+
+
+def test_runtime_lokr_matches_materialized_kronecker_math_and_restores_forward(dora_modules):
+    _, runtime = dora_modules
+    comfy_weight_adapter = runtime.comfy.weight_adapter
+
+    class TinyModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.layer = torch.nn.Linear(6, 4, bias=False)
+
+    model = TinyModel()
+    with torch.no_grad():
+        model.layer.weight.copy_(torch.arange(24, dtype=torch.float32).reshape(4, 6) / 50.0)
+
+    w1 = torch.tensor([[0.5, -0.25], [0.75, 0.2]], dtype=torch.float32)
+    w2 = torch.tensor([[0.3, -0.2, 0.1], [0.4, 0.6, -0.5]], dtype=torch.float32)
+    adapter = make_lokr_adapter(comfy_weight_adapter, w1.tolist(), w2.tolist())
+    strength = 0.7
+    x = torch.tensor(
+        [
+            [0.2, -0.7, 1.1, 0.3, -0.4, 0.9],
+            [1.3, 0.4, -0.2, 0.8, -0.6, 0.1],
+        ],
+        dtype=torch.float32,
+    )
+
+    base = model.layer(x).detach().clone()
+    expected_delta = F.linear(x, torch.kron(w1, w2)) * strength
+
+    injections, hook_count = runtime._make_stacked_injection(
+        model,
+        [
+            {
+                "key": "layer.weight",
+                "adapter": adapter,
+                "strength": strength,
+                "lora_name": "plain_lokr.safetensors",
+            }
+        ],
+    )
+    assert hook_count == 1
+
+    injections[0].inject(None)
+    try:
+        torch.testing.assert_close(model.layer(x), base + expected_delta)
+    finally:
+        injections[0].eject(None)
+
+    torch.testing.assert_close(model.layer(x), base)
+
+
+def test_decomposed_lokr_bypass_matches_materialized_scale(dora_modules):
+    _, runtime = dora_modules
+    comfy_weight_adapter = runtime.comfy.weight_adapter
+    lokr_type = getattr(comfy_weight_adapter, "LoKrAdapter", None)
+    if lokr_type is None:
+        pytest.skip("This ComfyUI revision does not expose LoKrAdapter")
+    base_h = getattr(comfy_weight_adapter.WeightAdapterBase, "h", None)
+    lokr_h = getattr(lokr_type, "h", None)
+    if not callable(lokr_h) or lokr_h is base_h:
+        pytest.skip("This ComfyUI revision does not implement LoKr bypass math")
+
+    class TinyModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.layer = torch.nn.Linear(6, 4, bias=False)
+
+    w1_a = torch.tensor([[0.5, -0.2], [0.3, 0.7]], dtype=torch.float32)
+    w1_b = torch.tensor([[0.8, -0.4], [0.1, 0.6]], dtype=torch.float32)
+    w2_a = torch.tensor([[0.4, -0.3], [0.2, 0.9]], dtype=torch.float32)
+    w2_b = torch.tensor([[0.5, -0.1, 0.7], [-0.6, 0.8, 0.2]], dtype=torch.float32)
+    alpha = 1.5
+    rank = w2_b.shape[0]
+    adapter = lokr_type(
+        set(),
+        (None, None, alpha, w1_a, w1_b, w2_a, w2_b, None, None),
+    )
+
+    model = TinyModel()
+    x = torch.tensor([[0.2, -0.7, 1.1, 0.3, -0.4, 0.9]], dtype=torch.float32)
+    base = model.layer(x).detach().clone()
+    materialized_delta = torch.kron(w1_a @ w1_b, w2_a @ w2_b) * (alpha / rank)
+    strength = 0.45
+
+    injections, _ = runtime._make_stacked_injection(
+        model,
+        [{"key": "layer.weight", "adapter": adapter, "strength": strength, "lora_name": "factorized"}],
+    )
+    injections[0].inject(None)
+    try:
+        torch.testing.assert_close(
+            model.layer(x),
+            base + F.linear(x, materialized_delta) * strength,
+        )
+    finally:
+        injections[0].eject(None)
+
+    torch.testing.assert_close(model.layer(x), base)
+
+
+def test_mixed_lora_and_lokr_stack_matches_materialized_math(dora_modules):
+    _, runtime = dora_modules
+    comfy_weight_adapter = runtime.comfy.weight_adapter
+
+    class TinyModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.layer = torch.nn.Linear(6, 4, bias=False)
+
+    model = TinyModel()
+    with torch.no_grad():
+        model.layer.weight.copy_(torch.arange(24, dtype=torch.float32).reshape(4, 6) / 40.0)
+
+    lora_up = torch.tensor([[0.8], [-0.3], [0.25], [0.6]], dtype=torch.float32)
+    lora_down = torch.tensor([[0.4, -0.2, 0.6, 0.1, -0.5, 0.3]], dtype=torch.float32)
+    lora = make_lora_adapter(comfy_weight_adapter, lora_up.tolist(), lora_down.tolist())
+
+    lokr_w1 = torch.tensor([[0.5, -0.25], [0.75, 0.2]], dtype=torch.float32)
+    lokr_w2 = torch.tensor([[0.3, -0.2, 0.1], [0.4, 0.6, -0.5]], dtype=torch.float32)
+    lokr = make_lokr_adapter(comfy_weight_adapter, lokr_w1.tolist(), lokr_w2.tolist())
+
+    lora_strength = 0.55
+    lokr_strength = -0.35
+    x = torch.tensor([[0.2, -0.7, 1.1, 0.3, -0.4, 0.9]], dtype=torch.float32)
+    base = model.layer(x).detach().clone()
+    expected_lora = F.linear(F.linear(x, lora_down), lora_up) * lora_strength
+    expected_lokr = F.linear(x, torch.kron(lokr_w1, lokr_w2)) * lokr_strength
+
+    injections, hook_count = runtime._make_stacked_injection(
+        model,
+        [
+            {"key": "layer.weight", "adapter": lora, "strength": lora_strength, "lora_name": "a"},
+            {"key": "layer.weight", "adapter": lokr, "strength": lokr_strength, "lora_name": "b"},
+        ],
+    )
+    assert hook_count == 2
+
+    injections[0].inject(None)
+    try:
+        torch.testing.assert_close(model.layer(x), base + expected_lora + expected_lokr)
+    finally:
+        injections[0].eject(None)
+
+    torch.testing.assert_close(model.layer(x), base)

--- a/tests/test_state_manager_frontend.mjs
+++ b/tests/test_state_manager_frontend.mjs
@@ -1,0 +1,217 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+
+async function loadStateManagerHelpers() {
+  const sourceUrl = new URL("../web/dora_state_manager.js", import.meta.url);
+  let source = await readFile(sourceUrl, "utf8");
+  source = source
+    .replace('import { app } from "../../scripts/app.js";', "let capturedExtension = null; const app = { registerExtension(value) { capturedExtension = value; }, graph: { extra: {} } };")
+    .replace('import { api } from "../../scripts/api.js";', "const api = { fetchApi() { throw new Error('not used'); }, apiURL(value) { return value; } };")
+    .replace('import "../../scripts/domWidget.js";', "");
+  source += `\nexport { capturedExtension, defaultBinding, defaultState, makeId, materializeEditedDefault, mergeScheduledLibraryUpdate, serializeBinding, serializeWorkflowUiState, serializeQueuedUiStateOverride, parseLegacyEmbeddedState };\n`;
+  const encoded = Buffer.from(source, "utf8").toString("base64");
+  return import(`data:text/javascript;base64,${encoded}#${Date.now()}-${Math.random()}`);
+}
+
+
+function privateCharacter(id, name, promptText) {
+  return {
+    id,
+    name,
+    prompts: [{ id: `${id}-prompt`, name: "Private preset", positive: promptText }],
+  };
+}
+
+
+test("workflow binding contains IDs/configuration only and no private library payload", async () => {
+  const helpers = await loadStateManagerHelpers();
+  const binding = JSON.parse(helpers.serializeBinding());
+  assert.deepEqual(binding, { version: 1, kind: "dora_state_manager_binding" });
+  const serialized = JSON.stringify(binding);
+  for (const secret of ["Private Character", "private prompt", "private.safetensors", "thumbnail", "reference_image", "loader_stacks"]) {
+    assert.equal(serialized.includes(secret), false);
+  }
+});
+
+
+test("the installed onSerialize hook scrubs private widget and property payloads", async () => {
+  const helpers = await loadStateManagerHelpers();
+  class StateManagerNode {
+    onSerialize(output) {
+      output.widgets_values = this.widgets.map((widget) => widget.value);
+      output.widgets_values_named = Object.fromEntries(this.widgets.map((widget) => [widget.name, widget.value]));
+      output.properties = { ...this.properties };
+    }
+  }
+  StateManagerNode.comfyClass = "State Manager";
+  await helpers.capturedExtension.beforeRegisterNodeDef(StateManagerNode, {
+    name: "State Manager",
+    input: { required: {} },
+  });
+  const privateState = {
+    version: 3,
+    characters: [privateCharacter("private-character", "Private Character", "private prompt text")],
+  };
+  const node = new StateManagerNode();
+  node.properties = {
+    dora_state_manager: privateState,
+    dora_state_manager_backup_node_uid: "private-backup-id",
+  };
+  node.widgets = [
+    { name: "state_json", value: JSON.stringify(privateState) },
+    { name: "ui_state_json", value: JSON.stringify({ status: "Private Character", panel: "character" }) },
+    { name: "selected_character_id", value: "private-character" },
+    { name: "selected_prompt_id", value: "private-character-prompt" },
+  ];
+  node.__dsm = { state: privateState, uiState: { status: "Private Character", panel: "character" } };
+
+  const output = {};
+  node.onSerialize(output);
+  const serialized = JSON.stringify(output);
+  assert.equal(serialized.includes("Private Character"), false);
+  assert.equal(serialized.includes("private prompt text"), false);
+  assert.equal(Object.prototype.hasOwnProperty.call(output.properties, "dora_state_manager"), false);
+  assert.deepEqual(JSON.parse(output.widgets_values[0]), helpers.defaultBinding());
+  assert.deepEqual(JSON.parse(output.widgets_values[1]), {
+    version: 2,
+    queue_prompt_wildcard: false,
+    queue_character_wildcard: false,
+    queue_randomize_saved_seed: false,
+    queue_character_ids: [],
+  });
+});
+
+
+test("an untouched ephemeral default is never materialized by selection or queue UI updates", async () => {
+  const helpers = await loadStateManagerHelpers();
+  const result = helpers.materializeEditedDefault(
+    helpers.defaultState(),
+    "default_character",
+    "default_prompt",
+  );
+  assert.equal(result.characterId, "default_character");
+  assert.equal(result.promptId, "default_prompt");
+  assert.equal(result.state.characters[0].id, "default_character");
+});
+
+
+test("materializing an edited default preserves the selected newly-created prompt", async () => {
+  const helpers = await loadStateManagerHelpers();
+  const state = helpers.defaultState();
+  state.characters[0].prompts.push({
+    ...structuredClone(state.characters[0].prompts[0]),
+    id: "draft_prompt",
+    name: "New preset",
+  });
+  const result = helpers.materializeEditedDefault(state, "default_character", "draft_prompt");
+  assert.notEqual(result.characterId, "default_character");
+  assert.equal(result.promptId, result.state.characters[0].prompts[1].id);
+});
+
+
+test("new and duplicated presets receive collision-resistant UUID bindings", async () => {
+  const helpers = await loadStateManagerHelpers();
+  const ids = new Set(Array.from({ length: 100 }, () => helpers.makeId("prompt")));
+  assert.equal(ids.size, 100);
+  for (const id of ids) assert.match(id, /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
+});
+
+
+test("disjoint character edits rebase without losing either manager's change", async () => {
+  const helpers = await loadStateManagerHelpers();
+  const base = [
+    privateCharacter("character-a", "A", "A0"),
+    privateCharacter("character-b", "B", "B0"),
+  ];
+  const desired = structuredClone(base);
+  desired[1].prompts[0].positive = "B1";
+  const current = structuredClone(base);
+  current[0].prompts[0].positive = "A1";
+  const merged = helpers.mergeScheduledLibraryUpdate(base, desired, current);
+  assert.equal(merged.conflict, null);
+  assert.equal(merged.characters[0].prompts[0].positive, "A1");
+  assert.equal(merged.characters[1].prompts[0].positive, "B1");
+});
+
+
+test("same-character concurrent edits are surfaced instead of overwritten", async () => {
+  const helpers = await loadStateManagerHelpers();
+  const base = [privateCharacter("character-a", "A", "A0")];
+  const desired = structuredClone(base);
+  desired[0].prompts[0].positive = "A from manager two";
+  const current = structuredClone(base);
+  current[0].prompts[0].positive = "A from manager one";
+  const merged = helpers.mergeScheduledLibraryUpdate(base, desired, current);
+  assert.equal(merged.conflict, "character-a");
+  assert.equal(merged.characters[0].prompts[0].positive, "A from manager one");
+});
+
+
+test("workflow UI serialization drops disposable status and panel state", async () => {
+  const helpers = await loadStateManagerHelpers();
+  const serialized = helpers.serializeWorkflowUiState({
+    panel: "character",
+    status: "Editing Private Character",
+    queue_prompt_wildcard: true,
+    queue_character_wildcard: true,
+    queue_randomize_saved_seed: false,
+    queue_character_ids: ["9aa1ddfd-a018-4f42-9ca5-e8c05d558729"],
+  });
+  const parsed = JSON.parse(serialized);
+  assert.equal(Object.prototype.hasOwnProperty.call(parsed, "status"), false);
+  assert.equal(Object.prototype.hasOwnProperty.call(parsed, "panel"), false);
+  assert.deepEqual(parsed.queue_character_ids, ["9aa1ddfd-a018-4f42-9ca5-e8c05d558729"]);
+});
+
+
+test("queued manager override carries a runtime seed and selection metadata only", async () => {
+  const helpers = await loadStateManagerHelpers();
+  const serialized = helpers.serializeQueuedUiStateOverride(
+    { status: "Private Character", queue_randomize_saved_seed: true },
+    "8e7dd506-439d-4040-b5ba-d9e258259abc",
+    "0a4f988a-4f17-4df6-9d2f-5f0042e9306b",
+    1234,
+    0,
+    2,
+  );
+  const parsed = JSON.parse(serialized);
+  assert.equal(parsed.__dsm_runtime_seed, 1234);
+  assert.equal(parsed.__dsm_queued_runtime_character_id, "8e7dd506-439d-4040-b5ba-d9e258259abc");
+  assert.equal(parsed.__dsm_queued_runtime_prompt_id, "0a4f988a-4f17-4df6-9d2f-5f0042e9306b");
+  assert.equal(Object.prototype.hasOwnProperty.call(parsed, "__dsm_queued_runtime_state"), false);
+  assert.equal(serialized.includes("Private Character"), false);
+});
+
+
+test("legacy embedded state remains detectable for controlled migration", async () => {
+  const helpers = await loadStateManagerHelpers();
+  const legacy = { version: 3, characters: [{ id: "legacy", name: "Legacy" }] };
+  assert.deepEqual(helpers.parseLegacyEmbeddedState(JSON.stringify(legacy)), legacy);
+  assert.equal(helpers.parseLegacyEmbeddedState(helpers.serializeBinding()), null);
+});
+
+
+test("browser persistence code cannot resurrect a private library", async () => {
+  const source = await readFile(new URL("../web/dora_state_manager.js", import.meta.url), "utf8");
+  assert.equal(source.includes("localStorage"), false);
+  assert.equal(source.includes("tryRestoreStateBackup"), false);
+  assert.equal(source.includes("writeStateBackup"), false);
+  assert.equal(source.includes("dora_state_manager_backup_workflow_id"), true, "legacy metadata should only appear in the serialization scrubber");
+  assert.match(source, /delete app\.graph\.extra\.dora_state_manager_backup_workflow_id/);
+  assert.equal(source.includes("setWidgetValue(widgets.uiStateWidget, serializeUiState"), false);
+  assert.match(source, /setWidgetValue\(currentWidgets\.stateWidget, serializeBinding\(\)\)/);
+});
+
+
+test("queued library values never synchronize into the workflow copy", async () => {
+  const source = await readFile(new URL("../web/dora_state_manager.js", import.meta.url), "utf8");
+  const stateManagerCalls = source.match(/setQueuedInput\([^;]+\);/gs) || [];
+  for (const call of stateManagerCalls) {
+    if (/function setQueuedInput/.test(call)) continue;
+    if (/mutatePromptForStateSeedNode/.test(call)) continue;
+    assert.equal(/syncWidget:\s*true/.test(call), false, call);
+  }
+  assert.equal(source.includes("__dsm_queued_runtime_state"), false);
+});

--- a/tests/test_state_manager_frontend.mjs
+++ b/tests/test_state_manager_frontend.mjs
@@ -10,7 +10,7 @@ async function loadStateManagerHelpers() {
     .replace('import { app } from "../../scripts/app.js";', "let capturedExtension = null; const app = { registerExtension(value) { capturedExtension = value; }, graph: { extra: {} } };")
     .replace('import { api } from "../../scripts/api.js";', "const api = { fetchApi() { throw new Error('not used'); }, apiURL(value) { return value; } };")
     .replace('import "../../scripts/domWidget.js";', "");
-  source += `\nexport { capturedExtension, defaultBinding, defaultState, makeId, materializeEditedDefault, mergeScheduledLibraryUpdate, serializeBinding, serializeWorkflowUiState, serializeQueuedUiStateOverride, parseLegacyEmbeddedState };\n`;
+  source += `\nexport { capturedExtension, defaultBinding, defaultState, makeId, materializeEditedDefault, mergeScheduledLibraryUpdate, persistentCharacters, serializeBinding, serializeWorkflowUiState, serializeQueuedUiStateOverride, parseLegacyEmbeddedState, stateLibraryClient, stateViewForSelection };\n`;
   const encoded = Buffer.from(source, "utf8").toString("base64");
   return import(`data:text/javascript;base64,${encoded}#${Date.now()}-${Math.random()}`);
 }
@@ -84,6 +84,40 @@ test("the installed onSerialize hook scrubs private widget and property payloads
 });
 
 
+test("failed legacy migration remains serialized for a lossless retry", async () => {
+  const helpers = await loadStateManagerHelpers();
+  class StateManagerNode {
+    onSerialize(output) {
+      output.widgets_values = this.widgets.map((widget) => widget.value);
+      output.widgets_values_named = Object.fromEntries(this.widgets.map((widget) => [widget.name, widget.value]));
+      output.properties = {};
+    }
+  }
+  StateManagerNode.comfyClass = "State Manager";
+  await helpers.capturedExtension.beforeRegisterNodeDef(StateManagerNode, {
+    name: "State Manager",
+    input: { required: {} },
+  });
+  const legacy = { version: 3, characters: [privateCharacter("legacy", "Legacy", "recover me")] };
+  const node = new StateManagerNode();
+  node.properties = {};
+  node.widgets = [
+    { name: "state_json", value: helpers.serializeBinding() },
+    { name: "ui_state_json", value: helpers.serializeWorkflowUiState({}) },
+    { name: "selected_character_id", value: "legacy" },
+    { name: "selected_prompt_id", value: "legacy-prompt" },
+  ];
+  node.__dsm = { state: helpers.defaultState(), uiState: {} };
+  node.__dsmPendingLegacyState = legacy;
+  const output = {};
+  node.onSerialize(output);
+  const preserved = JSON.parse(output.widgets_values[0]);
+  assert.equal(preserved.characters[0].id, "legacy");
+  assert.equal(preserved.characters[0].prompts[0].positive, "recover me");
+  assert.deepEqual(JSON.parse(node.widgets[0].value), helpers.defaultBinding());
+});
+
+
 test("an untouched ephemeral default is never materialized by selection or queue UI updates", async () => {
   const helpers = await loadStateManagerHelpers();
   const result = helpers.materializeEditedDefault(
@@ -149,6 +183,18 @@ test("same-character concurrent edits are surfaced instead of overwritten", asyn
 });
 
 
+test("a stale prompt binding creates one ephemeral prompt without duplicating its character", async () => {
+  const helpers = await loadStateManagerHelpers();
+  const character = privateCharacter("character-a", "A", "A0");
+  helpers.stateLibraryClient.state = { version: 2, characters: [character] };
+  const state = helpers.stateViewForSelection("character-a", "deleted-prompt");
+  assert.equal(state.characters.filter((entry) => entry.id === "character-a").length, 1);
+  const missing = state.characters[0].prompts.find((prompt) => prompt.id === "deleted-prompt");
+  assert.equal(missing.__dsm_ephemeral, true);
+  assert.equal(helpers.persistentCharacters(state)[0].prompts.some((prompt) => prompt.id === "deleted-prompt"), false);
+});
+
+
 test("workflow UI serialization drops disposable status and panel state", async () => {
   const helpers = await loadStateManagerHelpers();
   const serialized = helpers.serializeWorkflowUiState({
@@ -162,6 +208,7 @@ test("workflow UI serialization drops disposable status and panel state", async 
   const parsed = JSON.parse(serialized);
   assert.equal(Object.prototype.hasOwnProperty.call(parsed, "status"), false);
   assert.equal(Object.prototype.hasOwnProperty.call(parsed, "panel"), false);
+  assert.equal(Object.prototype.hasOwnProperty.call(parsed, "__dsm_library_user_id"), false);
   assert.deepEqual(parsed.queue_character_ids, ["9aa1ddfd-a018-4f42-9ca5-e8c05d558729"]);
 });
 
@@ -178,6 +225,7 @@ test("queued manager override carries a runtime seed and selection metadata only
   );
   const parsed = JSON.parse(serialized);
   assert.equal(parsed.__dsm_runtime_seed, 1234);
+  assert.equal(parsed.__dsm_library_user_id, "default");
   assert.equal(parsed.__dsm_queued_runtime_character_id, "8e7dd506-439d-4040-b5ba-d9e258259abc");
   assert.equal(parsed.__dsm_queued_runtime_prompt_id, "0a4f988a-4f17-4df6-9d2f-5f0042e9306b");
   assert.equal(Object.prototype.hasOwnProperty.call(parsed, "__dsm_queued_runtime_state"), false);
@@ -201,17 +249,24 @@ test("browser persistence code cannot resurrect a private library", async () => 
   assert.equal(source.includes("dora_state_manager_backup_workflow_id"), true, "legacy metadata should only appear in the serialization scrubber");
   assert.match(source, /delete app\.graph\.extra\.dora_state_manager_backup_workflow_id/);
   assert.equal(source.includes("setWidgetValue(widgets.uiStateWidget, serializeUiState"), false);
-  assert.match(source, /setWidgetValue\(currentWidgets\.stateWidget, serializeBinding\(\)\)/);
+  const stashIndex = source.indexOf("node.__dsmPendingLegacyState = structuredCloneCompat(embeddedLegacy)");
+  const scrubIndex = source.indexOf("setWidgetValue(currentWidgets.stateWidget, serializeBinding())");
+  const successIndex = source.indexOf("if (loaded) delete node.__dsmPendingLegacyState");
+  assert.ok(stashIndex >= 0 && scrubIndex > stashIndex && successIndex > scrubIndex);
+  assert.match(source, /this\.__dsmPendingLegacyState\s*\?\s*serializeState\(this\.__dsmPendingLegacyState\)/);
 });
 
 
 test("queued library values never synchronize into the workflow copy", async () => {
   const source = await readFile(new URL("../web/dora_state_manager.js", import.meta.url), "utf8");
-  const stateManagerCalls = source.match(/setQueuedInput\([^;]+\);/gs) || [];
-  for (const call of stateManagerCalls) {
-    if (/function setQueuedInput/.test(call)) continue;
-    if (/mutatePromptForStateSeedNode/.test(call)) continue;
-    assert.equal(/syncWidget:\s*true/.test(call), false, call);
-  }
+  assert.equal(/syncWidget:\s*true/.test(source), false);
+  assert.equal((source.match(/syncWidget\s*=\s*true/g) || []).length, 1);
   assert.equal(source.includes("__dsm_queued_runtime_state"), false);
+});
+
+
+test("blocked writes clear pending work and restore the persisted view", async () => {
+  const source = await readFile(new URL("../web/dora_state_manager.js", import.meta.url), "utf8");
+  assert.match(source, /function blockLibraryWrites[\s\S]*stateLibraryClient\.pending = \[\]/);
+  assert.match(source, /if \(stateLibraryClient\.blocked\) \{[\s\S]*refreshNodeFromLibrary\(node/);
 });

--- a/tests/test_state_manager_runtime.py
+++ b/tests/test_state_manager_runtime.py
@@ -1,0 +1,126 @@
+import json
+import uuid
+
+import pytest
+
+
+def persistent_character():
+    return {
+        "id": str(uuid.uuid4()),
+        "name": "Shared Group",
+        "thumbnail": {},
+        "loader_stacks": [{
+            "slot": "default",
+            "label": "Default loader",
+            "loras": [{
+                "enabled": True,
+                "name": "runtime.safetensors",
+                "strength_model": 0.75,
+                "strength_clip": 0.5,
+            }],
+            "loader_globals": {"auto_strength_enabled": True},
+        }],
+        "loras": [],
+        "loader_globals": {},
+        "prompts": [{
+            "id": str(uuid.uuid4()),
+            "name": "Runtime Character",
+            "positive": "runtime positive",
+            "negative": "runtime negative",
+            "text_boxes": [
+                {"role": "positive", "slot": "default", "label": "Positive", "text": "runtime positive"},
+                {"role": "negative", "slot": "default", "label": "Negative", "text": "runtime negative"},
+            ],
+            "settings": {"seed": 42},
+            "reference_image": {},
+            "fileimage_prefix": "runtime/output",
+        }],
+    }
+
+
+@pytest.fixture
+def configured_nodes(dora_modules, tmp_path, monkeypatch):
+    nodes, _ = dora_modules
+    import dora_loader_testpkg.state_manager_store as store_module
+
+    store_module.reset_state_manager_store_for_tests()
+    monkeypatch.setattr(nodes.folder_paths, "get_user_directory", lambda: str(tmp_path))
+    yield nodes
+    store_module.reset_state_manager_store_for_tests()
+
+
+def test_runtime_resolves_persistent_library_payload(configured_nodes):
+    nodes = configured_nodes
+    character = persistent_character()
+    store = nodes._get_state_manager_store()
+    store.replace([character], 0)
+    payload = nodes._resolve_dora_state_payload(
+        json.dumps(nodes._state_manager_default_binding()),
+        character["id"],
+        character["prompts"][0]["id"],
+    )
+    assert payload["positive_prompt"] == "runtime positive"
+    assert payload["negative_prompt"] == "runtime negative"
+    assert payload["loras"][0]["name"] == "runtime.safetensors"
+    assert payload["settings"]["seed"] == 42
+    assert payload["fileimage_prefix"] == "runtime/output"
+
+
+def test_runtime_missing_uuid_is_explicit(configured_nodes):
+    nodes = configured_nodes
+    character = persistent_character()
+    nodes._get_state_manager_store().replace([character], 0)
+    result = nodes.StateManager.VALIDATE_INPUTS(
+        json.dumps(nodes._state_manager_default_binding()),
+        "",
+        str(uuid.uuid4()),
+        character["prompts"][0]["id"],
+    )
+    assert isinstance(result, str)
+    assert "not available locally" in result
+
+
+def test_queued_runtime_seed_changes_seed_without_embedded_payload(configured_nodes):
+    nodes = configured_nodes
+    character = persistent_character()
+    nodes._get_state_manager_store().replace([character], 0)
+    manager = nodes.StateManager()
+    result = manager.resolve_state(
+        json.dumps(nodes._state_manager_default_binding()),
+        json.dumps({"__dsm_runtime_seed": 987654, "__dsm_queued_runtime_nonce": "queue-1"}),
+        character["id"],
+        character["prompts"][0]["id"],
+    )
+    assert result[6] == 987654
+    assert result[0]["positive_prompt"] == "runtime positive"
+
+
+@pytest.mark.parametrize("special_seed", [-1, -2, -3])
+def test_special_seed_semantics_remain_randomized(configured_nodes, special_seed):
+    nodes = configured_nodes
+    character = persistent_character()
+    character["prompts"][0]["settings"]["seed"] = special_seed
+    nodes._get_state_manager_store().replace([character], 0)
+    result = nodes.StateManager().resolve_state(
+        json.dumps(nodes._state_manager_default_binding()),
+        "",
+        character["id"],
+        character["prompts"][0]["id"],
+    )
+    assert 1 <= result[6] <= nodes._STATE_SEED_MAX
+
+
+def test_two_managers_can_resolve_same_library_selection(configured_nodes):
+    nodes = configured_nodes
+    character = persistent_character()
+    nodes._get_state_manager_store().replace([character], 0)
+    args = (
+        json.dumps(nodes._state_manager_default_binding()),
+        "",
+        character["id"],
+        character["prompts"][0]["id"],
+    )
+    first = nodes.StateManager().resolve_state(*args)
+    second = nodes.StateManager().resolve_state(*args)
+    assert first[0] == second[0]
+    assert first[1:4] == second[1:4]

--- a/tests/test_state_manager_runtime.py
+++ b/tests/test_state_manager_runtime.py
@@ -124,3 +124,84 @@ def test_two_managers_can_resolve_same_library_selection(configured_nodes):
     second = nodes.StateManager().resolve_state(*args)
     assert first[0] == second[0]
     assert first[1:4] == second[1:4]
+
+
+def test_legacy_migration_keeps_an_existing_persistent_uuid_selection(configured_nodes):
+    nodes = configured_nodes
+    selected = persistent_character()
+    legacy = persistent_character()
+    nodes._get_state_manager_store().replace([selected], 0)
+    character, prompt = nodes._resolve_state_manager_selection(
+        json.dumps({"version": 3, "characters": [legacy]}),
+        selected["id"],
+        selected["prompts"][0]["id"],
+    )
+    assert character["id"] == selected["id"]
+    assert prompt["id"] == selected["prompts"][0]["id"]
+
+
+def test_is_changed_returns_stable_marker_for_missing_preset(configured_nodes):
+    nodes = configured_nodes
+    marker = json.loads(nodes.StateManager.IS_CHANGED(
+        json.dumps(nodes._state_manager_default_binding()),
+        "",
+        str(uuid.uuid4()),
+        str(uuid.uuid4()),
+    ))
+    assert marker["library_error"] == "StatePresetNotFound"
+
+
+def test_is_changed_returns_stable_marker_for_library_io_error(configured_nodes, monkeypatch):
+    nodes = configured_nodes
+    store = nodes._get_state_manager_store()
+
+    def fail_resolve(*_args, **_kwargs):
+        raise OSError("sharing violation")
+
+    monkeypatch.setattr(store, "resolve", fail_resolve)
+    marker = json.loads(nodes.StateManager.IS_CHANGED(
+        json.dumps(nodes._state_manager_default_binding()),
+        "",
+        "default_character",
+        "default_prompt",
+    ))
+    assert marker["library_error"] == "OSError"
+
+
+def test_queued_user_id_selects_an_isolated_library(configured_nodes):
+    nodes = configured_nodes
+    first = persistent_character()
+    second = persistent_character()
+    nodes._get_state_manager_store("first-user").replace([first], 0)
+    nodes._get_state_manager_store("second-user").replace([second], 0)
+    result = nodes.StateManager().resolve_state(
+        json.dumps(nodes._state_manager_default_binding()),
+        json.dumps({"__dsm_library_user_id": "first-user"}),
+        first["id"],
+        first["prompts"][0]["id"],
+    )
+    assert result[0]["character"]["id"] == first["id"]
+
+
+def test_explicit_library_import_kind_wins_over_stray_character_field(dora_modules):
+    import dora_loader_testpkg.state_manager_api as api
+
+    calls = []
+
+    class Store:
+        def merge_library(self, characters):
+            calls.append(("library", characters))
+            return {"characters": characters}
+
+        def import_character(self, character):
+            calls.append(("character", character))
+            return {"character": character}
+
+    characters = [persistent_character()]
+    result = api._import_payload(Store(), {
+        "kind": "dora_state_manager_library_export",
+        "characters": characters,
+        "character": {"id": "stray"},
+    })
+    assert calls == [("library", characters)]
+    assert result["characters"] == characters

--- a/tests/test_state_manager_store.py
+++ b/tests/test_state_manager_store.py
@@ -1,0 +1,256 @@
+import json
+import os
+import sys
+import threading
+import uuid
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from state_manager_store import (
+    InvalidStateLibrary,
+    StateLibraryRevisionConflict,
+    StateLibraryStore,
+    StatePresetNotFound,
+    UnsupportedStateLibraryVersion,
+)
+
+
+def normalize_state(raw):
+    characters = []
+    for character in raw.get("characters", []):
+        value = json.loads(json.dumps(character))
+        value.setdefault("thumbnail", {})
+        value.setdefault("loader_stacks", [])
+        value.setdefault("loras", [])
+        value.setdefault("loader_globals", {})
+        value.setdefault("prompts", [])
+        for prompt in value["prompts"]:
+            prompt.setdefault("positive", "")
+            prompt.setdefault("negative", "")
+            prompt.setdefault("text_boxes", [])
+            prompt.setdefault("settings", {})
+            prompt.setdefault("reference_image", {})
+            prompt.setdefault("fileimage_prefix", "")
+        characters.append(value)
+    return {"version": 3, "characters": characters}
+
+
+def default_state():
+    return {
+        "version": 3,
+        "characters": [{
+            "id": "default_character",
+            "name": "Default Character",
+            "thumbnail": {},
+            "loader_stacks": [],
+            "loras": [],
+            "loader_globals": {},
+            "prompts": [{
+                "id": "default_prompt",
+                "name": "Default Prompt",
+                "positive": "",
+                "negative": "",
+                "text_boxes": [],
+                "settings": {},
+                "reference_image": {},
+                "fileimage_prefix": "",
+            }],
+        }],
+    }
+
+
+def make_character(name="Private Character", *, character_id=None, prompt_id=None):
+    return {
+        "id": character_id or str(uuid.uuid4()),
+        "name": name,
+        "thumbnail": {"filename": "private.png", "subfolder": "dora_state_manager", "type": "input"},
+        "loader_stacks": [{
+            "slot": "default",
+            "label": "Default loader",
+            "loras": [{"enabled": True, "name": "private.safetensors", "strength_model": 0.8, "strength_clip": 0.7}],
+            "loader_globals": {"auto_strength_enabled": True},
+        }],
+        "loras": [],
+        "loader_globals": {},
+        "prompts": [{
+            "id": prompt_id or str(uuid.uuid4()),
+            "name": f"{name} Prompt",
+            "positive": "private positive prompt",
+            "negative": "private negative prompt",
+            "text_boxes": [{"role": "positive", "slot": "default", "label": "Main", "text": "private positive prompt"}],
+            "settings": {"seed": -2, "nodes": [{"key": "sampler", "widgets": {"steps": 20}}]},
+            "reference_image": {"filename": "reference.png", "subfolder": "dora_state_manager", "type": "input"},
+            "fileimage_prefix": "private/output",
+        }],
+    }
+
+
+@pytest.fixture
+def store(tmp_path):
+    return StateLibraryStore(str(tmp_path / "dora_state_manager" / "state-library.json"), normalize_state, default_state)
+
+
+def test_persistence_survives_reinitialization_and_delete(store):
+    character = make_character()
+    first = store.replace([character], 0)
+    assert first["revision"] == 1
+    reloaded = StateLibraryStore(store.path, normalize_state, default_state)
+    assert reloaded.snapshot()["characters"] == first["characters"]
+
+    second = reloaded.replace([], 1)
+    assert second == {"version": 1, "revision": 2, "characters": []}
+    assert StateLibraryStore(store.path, normalize_state, default_state).snapshot() == second
+
+
+def test_atomic_write_fsyncs_and_leaves_no_temporary_file(store):
+    store.replace([make_character()], 0)
+    parent = Path(store.path).parent
+    assert list(parent.glob("*.tmp")) == []
+    assert json.loads(Path(store.path).read_text(encoding="utf-8"))["revision"] == 1
+
+
+def test_failed_atomic_replace_preserves_previous_document(store):
+    first = store.replace([make_character("First")], 0)
+    original = Path(store.path).read_bytes()
+    with mock.patch("state_manager_store.os.replace", side_effect=OSError("disk full")):
+        with pytest.raises(OSError, match="disk full"):
+            store.replace([make_character("Second")], first["revision"])
+    assert Path(store.path).read_bytes() == original
+    assert list(Path(store.path).parent.glob("*.tmp")) == []
+
+
+def test_malformed_file_is_quarantined_without_overwrite(store):
+    path = Path(store.path)
+    path.parent.mkdir(parents=True)
+    path.write_text("{broken", encoding="utf-8")
+    assert store.snapshot() == {"version": 1, "revision": 0, "characters": []}
+    assert not path.exists()
+    quarantined = list(path.parent.glob("state-library.json.corrupt-*"))
+    assert len(quarantined) == 1
+    assert quarantined[0].read_text(encoding="utf-8") == "{broken"
+    with pytest.raises(InvalidStateLibrary, match="quarantined"):
+        store.replace([], 0)
+    assert store.snapshot()["characters"] == []
+    assert store.replace([], 0)["revision"] == 1
+
+
+def test_transient_read_error_does_not_quarantine(store):
+    store.replace([make_character()], 0)
+    with mock.patch("builtins.open", side_effect=PermissionError("sharing violation")):
+        with pytest.raises(PermissionError, match="sharing violation"):
+            store.snapshot()
+    assert Path(store.path).exists()
+    assert list(Path(store.path).parent.glob("*.corrupt-*")) == []
+
+
+def test_future_library_version_is_left_untouched(store):
+    path = Path(store.path)
+    path.parent.mkdir(parents=True)
+    raw = '{"version":999,"revision":1,"characters":[],"migrations":[]}'
+    path.write_text(raw, encoding="utf-8")
+    with pytest.raises(UnsupportedStateLibraryVersion, match="expected 1"):
+        store.snapshot()
+    assert path.read_text(encoding="utf-8") == raw
+    assert list(path.parent.glob("*.corrupt-*")) == []
+
+
+def test_revision_conflict_prevents_stale_update_loss(store):
+    first = store.replace([make_character("First")], 0)
+    current = store.replace([make_character("Current")], first["revision"])
+    with pytest.raises(StateLibraryRevisionConflict) as caught:
+        store.replace([make_character("Stale")], first["revision"])
+    assert caught.value.current == current
+    assert store.snapshot() == current
+
+
+def test_concurrent_writers_have_one_winner(store):
+    barrier = threading.Barrier(2)
+    results = []
+
+    def writer(name):
+        barrier.wait()
+        try:
+            results.append(("ok", store.replace([make_character(name)], 0)))
+        except StateLibraryRevisionConflict as exc:
+            results.append(("conflict", exc.current))
+
+    threads = [threading.Thread(target=writer, args=(name,)) for name in ("A", "B")]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+    assert sorted(kind for kind, _ in results) == ["conflict", "ok"]
+    assert store.snapshot()["revision"] == 1
+
+
+def test_legacy_migration_is_complete_and_idempotent(store):
+    legacy = {"version": 3, "characters": [make_character(
+        character_id="legacy character",
+        prompt_id="legacy prompt",
+    )]}
+    first = store.migrate_legacy(legacy, "legacy character", "legacy prompt")
+    second = store.migrate_legacy(legacy, "legacy character", "legacy prompt")
+    assert not first["already_migrated"]
+    assert second["already_migrated"]
+    assert first["snapshot"] == second["snapshot"]
+    assert len(second["snapshot"]["characters"]) == 1
+    assert uuid.UUID(first["selected_character_id"])
+    assert uuid.UUID(first["selected_prompt_id"])
+    migrated = second["snapshot"]["characters"][0]
+    assert migrated["loader_stacks"][0]["loras"][0]["name"] == "private.safetensors"
+    assert migrated["prompts"][0]["settings"]["nodes"][0]["widgets"]["steps"] == 20
+    assert migrated["prompts"][0]["reference_image"]["filename"] == "reference.png"
+
+
+def test_distinct_legacy_import_does_not_overwrite_colliding_uuid(store):
+    shared_id = str(uuid.uuid4())
+    shared_prompt_id = str(uuid.uuid4())
+    store.replace([make_character("Existing", character_id=shared_id, prompt_id=shared_prompt_id)], 0)
+    legacy = {"version": 3, "characters": [make_character(
+        "Different",
+        character_id=shared_id,
+        prompt_id=shared_prompt_id,
+    )]}
+    result = store.migrate_legacy(legacy, shared_id, shared_prompt_id)
+    assert len(result["snapshot"]["characters"]) == 2
+    assert result["selected_character_id"] != shared_id
+    assert result["selected_prompt_id"] != shared_prompt_id
+    assert store.snapshot()["characters"][0]["name"] == "Existing"
+
+
+def test_missing_selection_never_falls_back_to_unrelated_preset(store):
+    character = make_character("Unrelated")
+    store.replace([character], 0)
+    with pytest.raises(StatePresetNotFound, match="not available locally"):
+        store.resolve(str(uuid.uuid4()), character["prompts"][0]["id"])
+    default_character, default_prompt = store.resolve("default_character", "default_prompt")
+    assert default_character["id"] == "default_character"
+    assert default_prompt["id"] == "default_prompt"
+
+
+def test_character_export_import_round_trip_does_not_copy_other_characters(store):
+    first = make_character("First")
+    unrelated = make_character("Unrelated")
+    snapshot = store.replace([first, unrelated], 0)
+    exported = store.export_character(first["id"])
+
+    target = StateLibraryStore(str(Path(store.path).parent / "target.json"), normalize_state, default_state)
+    imported = target.import_character(exported["character"])
+    assert len(imported["snapshot"]["characters"]) == 1
+    assert imported["character"]["name"] == "First"
+    assert "Unrelated" not in json.dumps(imported)
+    assert snapshot["characters"][0]["prompts"][0]["positive"] == imported["character"]["prompts"][0]["positive"]
+
+
+@pytest.mark.parametrize("subfolder", ["../escape", "/tmp/escape", "C:\\escape"])
+def test_image_references_reject_unsafe_paths(store, subfolder):
+    character = make_character()
+    character["thumbnail"]["subfolder"] = subfolder
+    with pytest.raises(InvalidStateLibrary, match="relative|unsafe"):
+        store.replace([character], 0)

--- a/tests/test_state_manager_store.py
+++ b/tests/test_state_manager_store.py
@@ -8,7 +8,7 @@ from unittest import mock
 
 import pytest
 
-ROOT = Path(__file__).resolve().parents[1]
+ROOT = Path(os.environ.get("DORA_REPO_ROOT", Path(__file__).resolve().parents[1])).resolve()
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 

--- a/tests/test_state_manager_store.py
+++ b/tests/test_state_manager_store.py
@@ -18,6 +18,9 @@ from state_manager_store import (
     StateLibraryStore,
     StatePresetNotFound,
     UnsupportedStateLibraryVersion,
+    get_state_manager_store,
+    reset_state_manager_store_for_tests,
+    state_manager_library_path,
 )
 
 
@@ -254,3 +257,35 @@ def test_image_references_reject_unsafe_paths(store, subfolder):
     character["thumbnail"]["subfolder"] = subfolder
     with pytest.raises(InvalidStateLibrary, match="relative|unsafe"):
         store.replace([character], 0)
+
+
+def test_malformed_character_cannot_normalize_into_default(store):
+    with pytest.raises(InvalidStateLibrary, match="characters are malformed"):
+        store.merge_library([None])
+
+
+def test_store_cache_and_paths_are_isolated_per_comfy_user(tmp_path):
+    class FolderPaths:
+        @staticmethod
+        def get_user_directory():
+            return str(tmp_path)
+
+        @staticmethod
+        def get_public_user_directory(user_id):
+            return str(tmp_path / user_id)
+
+    reset_state_manager_store_for_tests()
+    try:
+        first_path = state_manager_library_path(FolderPaths, "first")
+        second_path = state_manager_library_path(FolderPaths, "second")
+        first = get_state_manager_store(path=first_path, normalize_state=normalize_state, default_state=default_state)
+        first_again = get_state_manager_store(path=first_path, normalize_state=normalize_state, default_state=default_state)
+        second = get_state_manager_store(path=second_path, normalize_state=normalize_state, default_state=default_state)
+        assert first is first_again
+        assert first is not second
+        first.replace([make_character("First user")], 0)
+        assert second.snapshot()["characters"] == []
+        with pytest.raises(InvalidStateLibrary, match="user id is invalid"):
+            state_manager_library_path(FolderPaths, "../second")
+    finally:
+        reset_state_manager_store_for_tests()

--- a/web/dora_state_manager.js
+++ b/web/dora_state_manager.js
@@ -53,13 +53,9 @@ const STATE_SEED_INCREMENT = -2;
 const STATE_SEED_DECREMENT = -3;
 const STATE_SEED_SPECIALS = [STATE_SEED_RANDOM, STATE_SEED_INCREMENT, STATE_SEED_DECREMENT];
 const LAST_SEED_BUTTON_LABEL = "♻️ (Use Last Queued Seed)";
-const BACKUP_STORAGE_PREFIX = "comfyui_dora_state_manager_backup_v2";
-const LEGACY_BACKUP_STORAGE_PREFIX = "comfyui_dora_state_manager_backup_v1";
-const BACKUP_WORKFLOW_ID_EXTRA_KEY = "dora_state_manager_backup_workflow_id";
-const BACKUP_NODE_UID_PROPERTY = "dora_state_manager_backup_node_uid";
-const BACKUP_INDEX_STORAGE_SUFFIX = "workflow_index";
-const BACKUP_EXPORT_KIND = "dora_state_manager_export";
-const BACKUP_RESTORE_STATUS_PREFIX = "Warning: this node loaded with default/empty state";
+const LIBRARY_API = "/dora_dynamic_lora/state-library";
+const BINDING_KIND = "dora_state_manager_binding";
+const BINDING_VERSION = 1;
 const QUEUE_SESSION_MAX_AGE_MS = 30000;
 
 const dsmQueueSession = {
@@ -68,6 +64,17 @@ const dsmQueueSession = {
   nextIndex: 0,
   startedAt: 0,
   promptPools: new Map(),
+};
+
+const stateLibraryClient = {
+  revision: 0,
+  state: { version: STATE_SCHEMA_VERSION, characters: [] },
+  canonical: "[]",
+  pending: [],
+  writing: false,
+  blocked: false,
+  lastAppliedNode: null,
+  nodes: new Set(),
 };
 
 
@@ -87,9 +94,17 @@ function safeJsonParse(raw, fallback) {
   }
 }
 
-function makeId(prefix) {
-  if (globalThis.crypto?.randomUUID) return `${prefix}_${globalThis.crypto.randomUUID()}`;
-  return `${prefix}_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`;
+function makeId(_prefix) {
+  if (globalThis.crypto?.randomUUID) return globalThis.crypto.randomUUID();
+  const bytes = new Uint8Array(16);
+  globalThis.crypto?.getRandomValues?.(bytes);
+  if (!bytes.some(Boolean)) {
+    for (let index = 0; index < bytes.length; index++) bytes[index] = Math.floor(Math.random() * 256);
+  }
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex = [...bytes].map((value) => value.toString(16).padStart(2, "0")).join("");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
 }
 
 function cleanId(value, fallback) {
@@ -292,26 +307,8 @@ function defaultUiState() {
   return { version: 1, panel: "prompts", status: "", queue_randomize_saved_seed: false };
 }
 
-function isBackupRestoreStatus(value) {
-  return String(value ?? "").trim().startsWith(BACKUP_RESTORE_STATUS_PREFIX);
-}
-
 function stripBackupRestoreStatus(uiState) {
-  const normalized = normalizeUiState(uiState || defaultUiState());
-  return isBackupRestoreStatus(normalized.status) ? { ...normalized, status: "" } : normalized;
-}
-
-function setBackupWarning(node, text) {
-  if (!node) return;
-  const warning = String(text ?? "").trim();
-  if (warning) node.__dsmBackupWarning = warning;
-  else delete node.__dsmBackupWarning;
-}
-
-function clearBackupWarning(node) {
-  if (!node?.__dsmBackupWarning) return false;
-  delete node.__dsmBackupWarning;
-  return true;
+  return normalizeUiState(uiState || defaultUiState());
 }
 
 function normalizeNumber(value, fallback = 1.0) {
@@ -572,6 +569,7 @@ function normalizeCharacter(character, index, { migrateLegacyPresetNames = false
     loader_stacks: normalizeLoaderStacks(c),
     prompts: prompts.length ? prompts : [defaultPrompt(name)],
   };
+  if (c.__dsm_ephemeral) normalized.__dsm_ephemeral = true;
   return syncLegacyLoaderMirror(normalized);
 }
 
@@ -627,8 +625,39 @@ function serializeUiState(uiState) {
   return JSON.stringify(stripBackupRestoreStatus(uiState), null, 0);
 }
 
+function serializeWorkflowUiState(uiState) {
+  const normalized = normalizeUiState(uiState);
+  return JSON.stringify({
+    version: 2,
+    queue_prompt_wildcard: normalized.queue_prompt_wildcard,
+    queue_character_wildcard: normalized.queue_character_wildcard,
+    queue_randomize_saved_seed: normalized.queue_randomize_saved_seed,
+    queue_character_ids: normalized.queue_character_ids,
+  });
+}
+
 function canonicalJson(value) {
-  return JSON.stringify(value);
+  const canonicalize = (item) => {
+    if (Array.isArray(item)) return item.map(canonicalize);
+    if (!item || typeof item !== "object") return item;
+    return Object.fromEntries(
+      Object.keys(item).sort().map((key) => [key, canonicalize(item[key])])
+    );
+  };
+  return JSON.stringify(canonicalize(value));
+}
+
+function defaultBinding() {
+  return { version: BINDING_VERSION, kind: BINDING_KIND };
+}
+
+function serializeBinding() {
+  return JSON.stringify(defaultBinding());
+}
+
+function parseLegacyEmbeddedState(raw) {
+  const parsed = safeJsonParse(raw, null);
+  return parsed && Array.isArray(parsed.characters) ? parsed : null;
 }
 
 function isDefaultStateValue(value) {
@@ -639,327 +668,269 @@ function isDefaultStateValue(value) {
   }
 }
 
-function isStateJsonDefaultOrEmpty(raw) {
-  if (raw == null) return true;
-  if (typeof raw === "string" && !raw.trim()) return true;
-  return isDefaultStateValue(raw);
+function persistentCharacters(state) {
+  return normalizeState(state).characters.filter(
+    (character) => character.id !== "default_character" && !character.__dsm_ephemeral
+  );
 }
 
-function graphForBackup(node) {
-  return getGraph(node) || app?.graph || null;
-}
-
-function workflowBackupId(node, { create = true } = {}) {
-  const graph = graphForBackup(node);
-  if (!graph) return "unknown_workflow";
-  graph.extra = graph.extra || {};
-  const existing = String(graph.extra[BACKUP_WORKFLOW_ID_EXTRA_KEY] ?? "").trim();
-  if (existing) return existing;
-  if (!create) return "";
-  const id = makeId("workflow");
-  graph.extra[BACKUP_WORKFLOW_ID_EXTRA_KEY] = id;
-  return id;
-}
-
-function nodeBackupId(node) {
-  const id = node?.id ?? node?.__id ?? "unknown_node";
-  return String(id).trim() || "unknown_node";
-}
-
-function nodeBackupUid(node, { create = true } = {}) {
-  const props = node?.properties || {};
-  const nested = props.dora_state_manager && typeof props.dora_state_manager === "object" ? props.dora_state_manager : {};
-  const existing = String(props[BACKUP_NODE_UID_PROPERTY] ?? nested.backup_node_uid ?? "").trim();
-  if (existing) return existing;
-  if (!create || !node) return "";
-  node.properties = node.properties || {};
-  const uid = makeId("state_manager_node");
-  node.properties[BACKUP_NODE_UID_PROPERTY] = uid;
-  return uid;
-}
-
-function stateBackupNodeKey(node, { createNodeUid = true } = {}) {
-  return nodeBackupUid(node, { create: createNodeUid }) || `node_id_${nodeBackupId(node)}`;
-}
-
-function stateBackupStorageKey(prefix, workflowId, nodeKey) {
-  return `${prefix}:${workflowId || "unknown_workflow"}:node:${nodeKey || "unknown_node"}`;
-}
-
-function stateBackupKey(node, { createWorkflowId = true, createNodeUid = true } = {}) {
-  const workflowId = workflowBackupId(node, { create: createWorkflowId }) || "unknown_workflow";
-  return stateBackupStorageKey(BACKUP_STORAGE_PREFIX, workflowId, stateBackupNodeKey(node, { createNodeUid }));
-}
-
-function legacyStateBackupKey(node, { createWorkflowId = false } = {}) {
-  const workflowId = workflowBackupId(node, { create: createWorkflowId }) || "unknown_workflow";
-  return stateBackupStorageKey(LEGACY_BACKUP_STORAGE_PREFIX, workflowId, `node_id_${nodeBackupId(node)}`);
-}
-
-function stateBackupIndexKey(workflowId, prefix = BACKUP_STORAGE_PREFIX) {
-  return `${prefix}:${workflowId || "unknown_workflow"}:${BACKUP_INDEX_STORAGE_SUFFIX}`;
-}
-
-function nodeBackupSignature(node) {
-  const pos = Array.isArray(node?.pos) ? node.pos : [];
-  const size = Array.isArray(node?.size) ? node.size : [];
-  return {
-    type: String(node?.type ?? node?.constructor?.type ?? "").trim(),
-    title: String(node?.title ?? "").trim(),
-    comfyClass: String(node?.comfyClass ?? node?.constructor?.comfyClass ?? "").trim(),
-    pos: [Number(pos[0]) || 0, Number(pos[1]) || 0],
-    size: [Number(size[0]) || 0, Number(size[1]) || 0],
-  };
-}
-
-function backupStateSummary(state) {
+function materializeEditedDefault(state, characterId, promptId) {
   const normalized = normalizeState(state);
-  const characterCount = normalized.characters.length;
-  const promptCount = normalized.characters.reduce((sum, character) => sum + (character.prompts?.length || 0), 0);
-  const loaderCount = normalized.characters.reduce((sum, character) => sum + normalizeLoaderStacks(character).length, 0);
-  return { characterCount, promptCount, loaderCount };
-}
-
-function normalizeBackupRecord(raw, storageKey = "") {
-  const parsed = safeJsonParse(raw, null);
-  if (!parsed || typeof parsed !== "object") return null;
-  const stateRaw = parsed.state ?? parsed.state_json ?? parsed.stateJson;
-  if (stateRaw == null) return null;
-  const state = normalizeState(stateRaw);
-  const uiState = stripBackupRestoreStatus(parsed.ui_state ?? parsed.uiState ?? parsed.ui_state_json ?? parsed.uiStateJson ?? defaultUiState());
-  const characterId = String(parsed.selected_character_id ?? parsed.selectedCharacterId ?? "").trim();
-  const promptId = String(parsed.selected_prompt_id ?? parsed.selectedPromptId ?? "").trim();
-  const nodeMeta = parsed.node && typeof parsed.node === "object" ? parsed.node : {};
+  const defaultIndex = normalized.characters.findIndex((character) => character.id === "default_character");
+  if (defaultIndex < 0) return { state: normalized, characterId, promptId };
+  const character = normalized.characters[defaultIndex];
+  if (canonicalJson(character) === canonicalJson(defaultCharacter())) return { state: normalized, characterId, promptId };
+  const oldPromptId = String(promptId || "");
+  character.id = makeId("character");
+  const promptIds = new Map();
+  character.prompts = character.prompts.map((prompt) => {
+    const id = makeId("prompt");
+    promptIds.set(String(prompt.id || ""), id);
+    return { ...prompt, id };
+  });
   return {
-    version: 2,
-    kind: "dora_state_manager_backup",
-    storageKey,
-    workflowId: String(parsed.workflow_id ?? parsed.workflowId ?? "").trim(),
-    nodeId: String(parsed.node_id ?? parsed.nodeId ?? "").trim(),
-    nodeKey: String(parsed.node_key ?? parsed.nodeKey ?? "").trim(),
-    backupNodeUid: String(parsed.backup_node_uid ?? parsed.backupNodeUid ?? parsed.node_uid ?? parsed.nodeUid ?? "").trim(),
-    updatedAt: String(parsed.updated_at ?? parsed.updatedAt ?? "").trim(),
-    state,
-    uiState,
-    selectedCharacterId: characterId,
-    selectedPromptId: promptId,
-    node: {
-      type: String(nodeMeta.type ?? "").trim(),
-      title: String(nodeMeta.title ?? "").trim(),
-      comfyClass: String(nodeMeta.comfyClass ?? nodeMeta.comfy_class ?? "").trim(),
-      pos: Array.isArray(nodeMeta.pos) ? [Number(nodeMeta.pos[0]) || 0, Number(nodeMeta.pos[1]) || 0] : [0, 0],
-      size: Array.isArray(nodeMeta.size) ? [Number(nodeMeta.size[0]) || 0, Number(nodeMeta.size[1]) || 0] : [0, 0],
-    },
+    state: normalized,
+    characterId: String(characterId || "") === "default_character" ? character.id : characterId,
+    promptId: promptIds.get(oldPromptId) || character.prompts[0]?.id || "",
   };
 }
 
-function readStorageJson(key, fallback) {
+async function stateLibraryRequest(path = "", options = {}) {
+  const response = await api.fetchApi(`${LIBRARY_API}${path}`, options);
+  let payload = null;
   try {
-    const raw = globalThis.localStorage?.getItem(key);
-    if (raw == null) return structuredCloneCompat(fallback);
-    return safeJsonParse(raw, fallback);
-  } catch (err) {
-    console.warn(`[${EXT_NAME}] failed to read localStorage key ${key}`, err);
-    return structuredCloneCompat(fallback);
+    payload = await response.json();
+  } catch {
+    payload = null;
   }
-}
-
-function writeStorageJson(key, value) {
-  try {
-    globalThis.localStorage?.setItem(key, JSON.stringify(value));
-    return true;
-  } catch (err) {
-    console.warn(`[${EXT_NAME}] failed to write localStorage key ${key}`, err);
-    return false;
+  if (!response.ok) {
+    const error = new Error(payload?.error || `State Manager library request failed (${response.status}).`);
+    error.status = response.status;
+    error.payload = payload;
+    throw error;
   }
+  return payload;
 }
 
-function readBackupRecordAtKey(key) {
-  try {
-    const raw = globalThis.localStorage?.getItem(key);
-    return normalizeBackupRecord(raw, key);
-  } catch (err) {
-    console.warn(`[${EXT_NAME}] failed to read State Manager browser backup`, err);
-    return null;
+function installLibrarySnapshot(snapshot, { force = false } = {}) {
+  const characters = Array.isArray(snapshot?.characters) ? snapshot.characters : [];
+  const revision = Math.max(0, Number(snapshot?.revision) || 0);
+  if (!force && revision < stateLibraryClient.revision) return false;
+  stateLibraryClient.revision = revision;
+  stateLibraryClient.state = { version: STATE_SCHEMA_VERSION, characters: structuredCloneCompat(characters) };
+  stateLibraryClient.canonical = canonicalJson(characters);
+  stateLibraryClient.blocked = false;
+  return true;
+}
+
+function selectionIsDefault(characterId, promptId) {
+  return ["", "default_character"].includes(String(characterId || ""))
+    && ["", "default_prompt"].includes(String(promptId || ""));
+}
+
+function stateViewForSelection(characterId, promptId) {
+  const characters = Array.isArray(stateLibraryClient.state?.characters)
+    ? stateLibraryClient.state.characters.map((character, index) => normalizeCharacter(character, index)).filter(Boolean)
+    : [];
+  const state = { version: STATE_SCHEMA_VERSION, characters };
+  if (selectionIsDefault(characterId, promptId)) {
+    return normalizeState({ version: STATE_SCHEMA_VERSION, characters: [defaultCharacter(), ...state.characters] });
   }
+  const character = state.characters.find((item) => item.id === characterId);
+  const prompt = character?.prompts?.find((item) => item.id === promptId);
+  if (character && prompt) return state;
+  const missing = defaultCharacter();
+  missing.__dsm_ephemeral = true;
+  missing.id = String(characterId || "missing_character");
+  missing.name = "Selected character preset is not available locally";
+  missing.prompts[0].id = String(promptId || "missing_prompt");
+  missing.prompts[0].name = "Select or create a local character";
+  return normalizeState({ version: STATE_SCHEMA_VERSION, characters: [missing, ...state.characters] });
 }
 
-function readStateBackup(node) {
-  const keys = [
-    stateBackupKey(node, { createWorkflowId: false, createNodeUid: false }),
-    legacyStateBackupKey(node, { createWorkflowId: false }),
-  ];
-  for (const key of keys) {
-    const backup = readBackupRecordAtKey(key);
-    if (backup) return backup;
+function refreshNodeFromLibrary(node, { status = "" } = {}) {
+  if (!node?.__dsm) return;
+  const widgets = getWidgets(node);
+  const characterId = String(widgetValue(widgets.characterWidget, "") || "");
+  const promptId = String(widgetValue(widgets.promptWidget, "") || "");
+  const state = stateViewForSelection(characterId, promptId);
+  const uiState = normalizeUiState(
+    node.__dsm?.uiState || widgetValue(widgets.uiStateWidget, serializeWorkflowUiState(defaultUiState()))
+  );
+  cacheRenderableState(node, state, status ? { ...uiState, status } : uiState);
+  scheduleRender(node);
+}
+
+function refreshAllNodesFromLibrary() {
+  for (const node of stateLibraryClient.nodes) refreshNodeFromLibrary(node);
+}
+
+function mergeScheduledLibraryUpdate(baseCharacters, desiredCharacters, currentCharacters, { allowOverwrite = false } = {}) {
+  const base = new Map((baseCharacters || []).map((character) => [character.id, character]));
+  const desired = new Map((desiredCharacters || []).map((character) => [character.id, character]));
+  const current = new Map((currentCharacters || []).map((character) => [character.id, character]));
+  const changedIds = new Set();
+  for (const id of new Set([...base.keys(), ...desired.keys()])) {
+    if (canonicalJson(base.get(id)) !== canonicalJson(desired.get(id))) changedIds.add(id);
   }
-  return null;
-}
-
-function backupIndexEntry(record, key) {
-  return {
-    key,
-    workflow_id: record.workflow_id,
-    node_id: record.node_id,
-    node_key: record.node_key,
-    backup_node_uid: record.backup_node_uid,
-    updated_at: record.updated_at,
-    summary: record.summary,
-    node: record.node,
-  };
-}
-
-function updateBackupIndex(record, key) {
-  const workflowId = String(record.workflow_id || "").trim();
-  if (!workflowId) return;
-  const indexKey = stateBackupIndexKey(workflowId);
-  const index = readStorageJson(indexKey, []);
-  const entries = Array.isArray(index) ? index.filter((entry) => entry && entry.key !== key) : [];
-  entries.unshift(backupIndexEntry(record, key));
-  writeStorageJson(indexKey, entries.slice(0, 100));
-}
-
-function scanBackupKeysForWorkflow(workflowId) {
-  const out = new Set();
-  const prefixes = [
-    `${BACKUP_STORAGE_PREFIX}:${workflowId}:node:`,
-    `${LEGACY_BACKUP_STORAGE_PREFIX}:${workflowId}:node:`,
-  ];
-  try {
-    const storage = globalThis.localStorage;
-    if (!storage) return [];
-    for (let i = 0; i < storage.length; i++) {
-      const key = storage.key(i);
-      if (prefixes.some((prefix) => String(key || "").startsWith(prefix))) out.add(key);
+  for (const id of changedIds) {
+    const baseValue = base.get(id);
+    const desiredValue = desired.get(id);
+    const currentValue = current.get(id);
+    const currentMatchesBase = canonicalJson(currentValue) === canonicalJson(baseValue);
+    const currentMatchesDesired = canonicalJson(currentValue) === canonicalJson(desiredValue);
+    if (!currentMatchesBase && !currentMatchesDesired && !allowOverwrite) {
+      return { conflict: id, characters: currentCharacters };
     }
-  } catch (err) {
-    console.warn(`[${EXT_NAME}] failed to scan State Manager browser backups`, err);
+    if (desiredValue === undefined) current.delete(id);
+    else current.set(id, structuredCloneCompat(desiredValue));
   }
-  return [...out];
-}
-
-function readWorkflowBackupCandidates(node) {
-  const workflowId = workflowBackupId(node, { create: false });
-  if (!workflowId) return [];
-  const keys = new Set();
-  const index = readStorageJson(stateBackupIndexKey(workflowId), []);
-  if (Array.isArray(index)) {
-    for (const entry of index) {
-      if (entry?.key) keys.add(String(entry.key));
+  const order = [];
+  for (const character of currentCharacters || []) {
+    if (current.has(character.id)) order.push(current.get(character.id));
+  }
+  for (const character of desiredCharacters || []) {
+    if (!order.some((entry) => entry.id === character.id) && current.has(character.id)) {
+      order.push(current.get(character.id));
     }
   }
-  for (const key of scanBackupKeysForWorkflow(workflowId)) keys.add(key);
-  const records = [];
-  for (const key of keys) {
-    const record = readBackupRecordAtKey(key);
-    if (record && !isDefaultStateValue(record.state)) records.push(record);
-  }
-  records.sort((a, b) => Date.parse(b.updatedAt || 0) - Date.parse(a.updatedAt || 0));
-  return records;
+  return { conflict: null, characters: order };
 }
 
-function backupDistanceScore(nodeSignature, backupSignature) {
-  const a = Array.isArray(nodeSignature?.pos) ? nodeSignature.pos : [0, 0];
-  const b = Array.isArray(backupSignature?.pos) ? backupSignature.pos : [0, 0];
-  const dx = (Number(a[0]) || 0) - (Number(b[0]) || 0);
-  const dy = (Number(a[1]) || 0) - (Number(b[1]) || 0);
-  return Math.sqrt(dx * dx + dy * dy);
-}
-
-function scoreBackupForNode(node, record) {
-  const currentUid = nodeBackupUid(node, { create: false });
-  const currentId = nodeBackupId(node);
-  const current = nodeBackupSignature(node);
-  const backup = record?.node || {};
-  let score = 0;
-  let exact = false;
-
-  if (currentUid && record.backupNodeUid && currentUid === record.backupNodeUid) {
-    score += 10000;
-    exact = true;
-  }
-  if (currentId && record.nodeId && currentId === record.nodeId) {
-    score += 5000;
-    exact = true;
-  }
-
-  const sameTitle = current.title && backup.title && current.title === backup.title;
-  const sameType = current.type && backup.type && current.type === backup.type;
-  const sameClass = current.comfyClass && backup.comfyClass && current.comfyClass === backup.comfyClass;
-  const distance = backupDistanceScore(current, backup);
-
-  if (sameTitle) score += 80;
-  if (sameType) score += 40;
-  if (sameClass) score += 40;
-  if (Number.isFinite(distance)) {
-    if (distance <= 4) score += 160;
-    else if (distance <= 32) score += 120;
-    else if (distance <= 96) score += 60;
-  }
-
-  return { score, exact, sameTitle, sameType, sameClass, distance };
-}
-
-function findBestStateBackup(node) {
-  const exact = readStateBackup(node);
-  if (exact && !isDefaultStateValue(exact.state)) return { record: exact, reason: "exact", ambiguous: false };
-
-  const candidates = readWorkflowBackupCandidates(node);
-  if (!candidates.length) return { record: null, reason: "none", ambiguous: false };
-
-  const scored = candidates
-    .map((record) => ({ record, match: scoreBackupForNode(node, record) }))
-    .sort((a, b) => b.match.score - a.match.score || Date.parse(b.record.updatedAt || 0) - Date.parse(a.record.updatedAt || 0));
-
-  const best = scored[0];
-  const second = scored[1];
-  if (best.match.exact) return { record: best.record, reason: "stable-node-id", ambiguous: false };
-
-  const strongPositionalMatch = best.match.score >= 180 && (best.match.sameTitle || best.match.sameType || best.match.sameClass) && best.match.distance <= 96;
-  if (strongPositionalMatch && (!second || best.match.score - second.match.score >= 40)) {
-    return { record: best.record, reason: "position-title", ambiguous: false };
-  }
-
-  if (candidates.length === 1) return { record: best.record, reason: "only-workflow-backup", ambiguous: false };
-
-  return { record: null, reason: "ambiguous", ambiguous: true, candidates: scored };
-}
-
-function makeBackupRecord(node, state, uiState, widgets = getWidgets(node)) {
-  const normalizedState = normalizeState(state);
-  const normalizedUiState = stripBackupRestoreStatus(uiState || defaultUiState());
-  const workflowId = workflowBackupId(node, { create: true });
-  const backupUid = nodeBackupUid(node, { create: true });
-  const nodeKey = stateBackupNodeKey(node, { createNodeUid: true });
-  return {
-    version: 2,
-    kind: "dora_state_manager_backup",
-    workflow_id: workflowId,
-    node_id: nodeBackupId(node),
-    node_key: nodeKey,
-    backup_node_uid: backupUid,
-    updated_at: new Date().toISOString(),
-    summary: backupStateSummary(normalizedState),
-    node: nodeBackupSignature(node),
-    state: normalizedState,
-    ui_state: normalizedUiState,
-    selected_character_id: String(widgetValue(widgets.characterWidget, "") || ""),
-    selected_prompt_id: String(widgetValue(widgets.promptWidget, "") || ""),
-  };
-}
-
-function writeStateBackup(node, state, uiState, widgets = getWidgets(node)) {
-  if (!node) return;
+async function writePendingLibrary() {
+  if (stateLibraryClient.writing || stateLibraryClient.blocked) return;
+  stateLibraryClient.writing = true;
   try {
-    const normalizedState = normalizeState(state);
-    if (isDefaultStateValue(normalizedState)) return;
-    const record = makeBackupRecord(node, normalizedState, uiState, widgets);
-    const key = stateBackupKey(node, { createWorkflowId: true, createNodeUid: true });
-    globalThis.localStorage?.setItem(key, JSON.stringify(record));
-    updateBackupIndex(record, key);
-  } catch (err) {
-    console.warn(`[${EXT_NAME}] failed to write State Manager browser backup`, err);
+    while (stateLibraryClient.pending.length && !stateLibraryClient.blocked) {
+      const pending = stateLibraryClient.pending.shift();
+      const merged = mergeScheduledLibraryUpdate(
+        pending.baseCharacters,
+        pending.desiredCharacters,
+        stateLibraryClient.state.characters,
+        { allowOverwrite: pending.node === stateLibraryClient.lastAppliedNode },
+      );
+      if (merged.conflict) {
+        stateLibraryClient.blocked = true;
+        for (const node of stateLibraryClient.nodes) {
+          const current = getRenderableState(node);
+          cacheRenderableState(node, current.state, {
+            ...current.uiState,
+            status: "Two local State Manager instances edited the same character concurrently. Reload the library; no conflicting write was sent.",
+          });
+          scheduleRender(node);
+        }
+        break;
+      }
+      if (canonicalJson(merged.characters) === stateLibraryClient.canonical) {
+        stateLibraryClient.lastAppliedNode = pending.node;
+        continue;
+      }
+      try {
+        const snapshot = await stateLibraryRequest("", {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            expected_revision: stateLibraryClient.revision,
+            characters: merged.characters,
+          }),
+        });
+        installLibrarySnapshot(snapshot);
+        stateLibraryClient.lastAppliedNode = pending.node;
+        refreshAllNodesFromLibrary();
+      } catch (error) {
+        if (error.status === 409) {
+          stateLibraryClient.blocked = true;
+          for (const node of stateLibraryClient.nodes) {
+            const current = getRenderableState(node);
+            cacheRenderableState(node, current.state, {
+              ...current.uiState,
+              status: "Library changed in another tab or State Manager. Reload the library before editing again; the stale write was rejected.",
+            });
+            scheduleRender(node);
+          }
+          break;
+        }
+        stateLibraryClient.blocked = true;
+        for (const node of stateLibraryClient.nodes) {
+          const current = getRenderableState(node);
+          cacheRenderableState(node, current.state, {
+            ...current.uiState,
+            status: `Library save failed: ${error?.message || error}`,
+          });
+          scheduleRender(node);
+        }
+        break;
+      }
+    }
+  } finally {
+    stateLibraryClient.writing = false;
   }
+}
+
+function scheduleLibraryPersist(node, state) {
+  const desiredCharacters = persistentCharacters(state);
+  const canonical = canonicalJson(desiredCharacters);
+  if (canonical === stateLibraryClient.canonical || stateLibraryClient.blocked) return;
+  const last = stateLibraryClient.pending[stateLibraryClient.pending.length - 1];
+  const scheduled = {
+    node,
+    baseCharacters: structuredCloneCompat(last?.node === node ? last.baseCharacters : stateLibraryClient.state.characters),
+    desiredCharacters: structuredCloneCompat(desiredCharacters),
+  };
+  if (last?.node === node) stateLibraryClient.pending[stateLibraryClient.pending.length - 1] = scheduled;
+  else stateLibraryClient.pending.push(scheduled);
+  void writePendingLibrary();
+}
+
+async function reloadStateLibrary(node, { status = "Reloaded State Manager library." } = {}) {
+  stateLibraryClient.blocked = false;
+  stateLibraryClient.pending = [];
+  stateLibraryClient.lastAppliedNode = null;
+  const snapshot = await stateLibraryRequest();
+  installLibrarySnapshot(snapshot, { force: true });
+  refreshAllNodesFromLibrary();
+  refreshNodeFromLibrary(node, { status });
+}
+
+async function initializeStateLibrary(node, legacyState, selectedCharacterId, selectedPromptId, token = null) {
+  let snapshot;
+  let characterId = String(selectedCharacterId || "");
+  let promptId = String(selectedPromptId || "");
+  let status = "";
+  if (legacyState && !isDefaultStateValue(legacyState)) {
+    const migration = await stateLibraryRequest("/migrate", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        state: legacyState,
+        selected_character_id: characterId,
+        selected_prompt_id: promptId,
+      }),
+    });
+    snapshot = migration.snapshot;
+    characterId = migration.selected_character_id || "";
+    promptId = migration.selected_prompt_id || "";
+    status = migration.already_migrated
+      ? "Legacy embedded library was already migrated; restored its local UUID binding."
+      : "Migrated the legacy embedded State Manager library into persistent user storage.";
+  } else {
+    snapshot = await stateLibraryRequest();
+  }
+  if (token != null && node.__dsmLibraryLoadToken !== token) return;
+  installLibrarySnapshot(snapshot);
+  const widgets = getWidgets(node);
+  setWidgetValue(widgets.stateWidget, serializeBinding());
+  setWidgetValue(widgets.characterWidget, characterId || "default_character");
+  setWidgetValue(widgets.promptWidget, promptId || "default_prompt");
+  const state = stateViewForSelection(
+    widgetValue(widgets.characterWidget, ""),
+    widgetValue(widgets.promptWidget, ""),
+  );
+  const uiState = normalizeUiState(widgetValue(widgets.uiStateWidget, serializeUiState(defaultUiState())));
+  setWidgetValue(widgets.uiStateWidget, serializeWorkflowUiState(uiState));
+  refreshAllNodesFromLibrary();
+  cacheRenderableState(node, state, status ? { ...uiState, status } : uiState);
+  scheduleRender(node);
 }
 
 function selectionIdsForState(state, characterId = "", promptId = "") {
@@ -967,77 +938,6 @@ function selectionIdsForState(state, characterId = "", promptId = "") {
   const character = normalizedState.characters.find((item) => item.id === characterId) || normalizedState.characters[0];
   const prompt = character?.prompts?.find((item) => item.id === promptId) || character?.prompts?.[0];
   return { characterId: character?.id || "", promptId: prompt?.id || "" };
-}
-
-function backupRestoredStatus(record, reason = "") {
-  const summary = record?.state ? backupStateSummary(record.state) : null;
-  const suffix = summary ? ` (${summary.characterCount} character${summary.characterCount === 1 ? "" : "s"}, ${summary.promptCount} prompt${summary.promptCount === 1 ? "" : "s"}).` : ".";
-  const source = reason && reason !== "exact" ? ` Matched backup by ${reason}.` : "";
-  return `Warning: this node loaded with default/empty state while a browser backup existed. Restored backup${suffix}${source} Save the workflow to persist the recovered state.`;
-}
-
-function backupAmbiguousStatus(match) {
-  const count = match?.candidates?.length || 0;
-  return `Warning: this node loaded with default/empty state and ${count} browser backups exist for this workflow, but none matched this recreated node safely. Use Import State JSON or move/rename the node to match the original location before retrying.`;
-}
-
-function tryRestoreStateBackup(node, { force = false } = {}) {
-  const widgets = getWidgets(node);
-  const rawState = widgetValue(widgets.stateWidget, "");
-  const result = { restored: false, preserveBackupWarning: false };
-  if (!force && !isStateJsonDefaultOrEmpty(rawState)) return result;
-  const match = findBestStateBackup(node);
-  const backup = match.record;
-  if (!backup || isDefaultStateValue(backup.state)) {
-    if (match.ambiguous) {
-      const status = backupAmbiguousStatus(match);
-      setWidgetValue(widgets.uiStateWidget, serializeUiState(stripBackupRestoreStatus(widgetValue(widgets.uiStateWidget, ""))));
-      setBackupWarning(node, status);
-      markNodeDirty(node);
-      return { restored: false, preserveBackupWarning: true };
-    }
-    return result;
-  }
-  const selection = selectionIdsForState(backup.state, backup.selectedCharacterId, backup.selectedPromptId);
-  const status = backupRestoredStatus(backup, match.reason);
-  const restoredUiState = stripBackupRestoreStatus(backup.uiState);
-  setWidgetValue(widgets.stateWidget, serializeState(backup.state));
-  setWidgetValue(widgets.uiStateWidget, serializeUiState(restoredUiState));
-  setWidgetValue(widgets.characterWidget, selection.characterId);
-  setWidgetValue(widgets.promptWidget, selection.promptId);
-  node.properties = node.properties || {};
-  if (backup.backupNodeUid) node.properties[BACKUP_NODE_UID_PROPERTY] = backup.backupNodeUid;
-  node.properties.dora_state_manager = {
-    state: normalizeState(backup.state),
-    selected_character_id: selection.characterId,
-    selected_prompt_id: selection.promptId,
-    backup_node_uid: nodeBackupUid(node, { create: true }),
-  };
-  setBackupWarning(node, status);
-  cacheRenderableState(node, backup.state, restoredUiState);
-  writeStateBackup(node, backup.state, restoredUiState, widgets);
-  markNodeDirty(node);
-  return { restored: true, preserveBackupWarning: true };
-}
-
-function buildStateExportPayload(node, state, uiState, characterId, promptId) {
-  const normalizedState = normalizeState(state);
-  const normalizedUiState = stripBackupRestoreStatus(uiState || defaultUiState());
-  const selection = selectionIdsForState(normalizedState, characterId, promptId);
-  return {
-    version: 2,
-    kind: BACKUP_EXPORT_KIND,
-    exported_at: new Date().toISOString(),
-    workflow_id: workflowBackupId(node, { create: true }),
-    node_id: nodeBackupId(node),
-    node_key: stateBackupNodeKey(node, { createNodeUid: true }),
-    backup_node_uid: nodeBackupUid(node, { create: true }),
-    node: nodeBackupSignature(node),
-    state: normalizedState,
-    ui_state: normalizedUiState,
-    selected_character_id: selection.characterId,
-    selected_prompt_id: selection.promptId,
-  };
 }
 
 function downloadJsonFile(filename, payload) {
@@ -1056,36 +956,35 @@ function downloadJsonFile(filename, payload) {
   }
 }
 
-function exportStateJson(node, state, uiState, characterId, promptId) {
-  const payload = buildStateExportPayload(node, state, uiState, characterId, promptId);
-  const timestamp = payload.exported_at.replace(/[:.]/g, "-");
-  downloadJsonFile(`dora-state-manager-node-${nodeBackupId(node)}-${timestamp}.json`, payload);
+async function exportCharacterJson(characterId) {
+  const payload = await stateLibraryRequest(`/characters/${encodeURIComponent(characterId)}/export`);
+  downloadJsonFile(`dora-state-manager-character-${characterId}.json`, payload);
 }
 
-function parseImportedStateJson(text) {
-  const parsed = JSON.parse(String(text ?? ""));
-  const stateRaw = parsed.state ?? parsed.state_json ?? parsed.stateJson ?? (Array.isArray(parsed.characters) ? parsed : null);
-  if (stateRaw == null) throw new Error("JSON does not contain a State Manager state.");
-  const state = normalizeState(stateRaw);
-  if (isDefaultStateValue(state) && !isDefaultStateValue(stateRaw)) throw new Error("Imported state normalized to the default state.");
-  const uiState = stripBackupRestoreStatus(parsed.ui_state ?? parsed.uiState ?? parsed.ui_state_json ?? parsed.uiStateJson ?? defaultUiState());
-  const selection = selectionIdsForState(
-    state,
-    String(parsed.selected_character_id ?? parsed.selectedCharacterId ?? ""),
-    String(parsed.selected_prompt_id ?? parsed.selectedPromptId ?? "")
-  );
-  return { state, uiState, ...selection };
+async function exportLibraryJson() {
+  const payload = await stateLibraryRequest("/export");
+  downloadJsonFile("dora-state-manager-library.json", payload);
 }
 
-async function importStateJsonFile(node, file, currentUiState = defaultUiState()) {
+async function importStateJsonFile(node, file) {
   if (!file) return;
   const text = await file.text();
-  const imported = parseImportedStateJson(text);
-  updateState(node, imported.state, { ...currentUiState, ...imported.uiState }, {
-    characterId: imported.characterId,
-    promptId: imported.promptId,
-    status: `Imported State Manager JSON from ${file.name || "file"}.`,
+  const parsed = JSON.parse(String(text || ""));
+  const result = await stateLibraryRequest("/import", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(parsed),
   });
+  installLibrarySnapshot(result.snapshot);
+  refreshAllNodesFromLibrary();
+  const characterId = result.character?.id || result.character_ids?.[0] || "";
+  if (characterId) {
+    const character = stateLibraryClient.state.characters.find((item) => item.id === characterId);
+    const widgets = getWidgets(node);
+    setWidgetValue(widgets.characterWidget, characterId);
+    setWidgetValue(widgets.promptWidget, character?.prompts?.[0]?.id || "");
+  }
+  refreshNodeFromLibrary(node, { status: `Imported ${file.name || "State Manager JSON"}.` });
 }
 
 function getWidgets(node) {
@@ -1121,8 +1020,14 @@ function hideWidget(widget) {
 }
 
 function getCurrentState(node) {
+  if (node?.__dsm?.state && node?.__dsm?.uiState) {
+    return { state: node.__dsm.state, uiState: node.__dsm.uiState };
+  }
   const widgets = getWidgets(node);
-  const state = normalizeState(widgetValue(widgets.stateWidget, serializeState(defaultState())));
+  const state = stateViewForSelection(
+    String(widgetValue(widgets.characterWidget, "") || ""),
+    String(widgetValue(widgets.promptWidget, "") || ""),
+  );
   const uiState = normalizeUiState(widgetValue(widgets.uiStateWidget, serializeUiState(defaultUiState())));
   return { state, uiState };
 }
@@ -1184,28 +1089,29 @@ function markDownstreamDirty(node) {
 
 function updateState(node, state, uiState, opts = {}) {
   const widgets = getWidgets(node);
-  const normalizedState = normalizeState(state);
+  const currentCharacterId = opts.characterId ?? String(widgetValue(widgets.characterWidget, "") || "");
+  const currentPromptId = opts.promptId ?? String(widgetValue(widgets.promptWidget, "") || "");
+  const materialized = materializeEditedDefault(state, currentCharacterId, currentPromptId);
+  const normalizedState = materialized.state;
   const normalizedUiState = stripBackupRestoreStatus(uiState || defaultUiState());
-  const warningCleared = opts.preserveBackupWarning ? false : clearBackupWarning(node);
+  const nextUiState = normalizeUiState({
+    ...normalizedUiState,
+    status: opts.status ?? normalizedUiState.status,
+  });
+  setWidgetValue(widgets.characterWidget, materialized.characterId || "default_character");
+  setWidgetValue(widgets.promptWidget, materialized.promptId || "default_prompt");
   const { character, prompt } = ensureSelection(node, normalizedState);
-  setWidgetValue(widgets.stateWidget, serializeState(normalizedState));
-  setWidgetValue(widgets.uiStateWidget, serializeUiState({ ...normalizedUiState, status: opts.status ?? normalizedUiState.status }));
-  setWidgetValue(widgets.characterWidget, opts.characterId ?? character.id);
-  setWidgetValue(widgets.promptWidget, opts.promptId ?? prompt.id);
+  setWidgetValue(widgets.stateWidget, serializeBinding());
+  setWidgetValue(widgets.uiStateWidget, serializeWorkflowUiState(nextUiState));
+  setWidgetValue(widgets.characterWidget, materialized.characterId || character.id);
+  setWidgetValue(widgets.promptWidget, materialized.promptId || prompt.id);
   node.properties = node.properties || {};
-  const backupUid = nodeBackupUid(node, { create: !isDefaultStateValue(normalizedState) });
-  if (backupUid) node.properties[BACKUP_NODE_UID_PROPERTY] = backupUid;
-  node.properties.dora_state_manager = {
-    state: normalizedState,
-    selected_character_id: widgetValue(widgets.characterWidget, ""),
-    selected_prompt_id: widgetValue(widgets.promptWidget, ""),
-    backup_node_uid: backupUid,
-  };
-  const cachedUiState = normalizeUiState(widgetValue(widgets.uiStateWidget, ""));
-  cacheRenderableState(node, normalizedState, cachedUiState);
-  writeStateBackup(node, normalizedState, cachedUiState, widgets);
+  delete node.properties.dora_state_manager;
+  delete node.properties.dora_state_manager_backup_node_uid;
+  cacheRenderableState(node, normalizedState, nextUiState);
+  if (opts.persist !== false) scheduleLibraryPersist(node, normalizedState);
   if (opts.dirty !== false) markNodeDirty(node);
-  if (opts.render !== false || warningCleared) scheduleRender(node);
+  if (opts.render !== false) scheduleRender(node);
 }
 
 function cacheRenderableState(node, state, uiState) {
@@ -1418,13 +1324,6 @@ function extractLoraStackFromNode(sourceNode, fallbackIndex = 0) {
   if (sourceNode.properties?.dora_power_lora) return normalizeDoraLoaderState(sourceNode.properties.dora_power_lora, sourceNode, fallbackIndex);
   if (sourceNode._doraRows || sourceNode._doraGlobals) {
     return normalizeDoraLoaderState({ rows: sourceNode._doraRows || [], globals: sourceNode._doraGlobals || {} }, sourceNode, fallbackIndex);
-  }
-  if (sourceNode.properties?.dora_state_manager?.state) {
-    const state = normalizeState(sourceNode.properties.dora_state_manager.state);
-    const charId = sourceNode.properties.dora_state_manager.selected_character_id;
-    const character = selectedCharacter(state, charId);
-    const stack = findCharacterLoaderStack(character, getDoraLoaderSlot(sourceNode, fallbackIndex));
-    return stack ? structuredCloneCompat(stack) : null;
   }
   return null;
 }
@@ -2470,7 +2369,7 @@ function renderHeader(node, state, uiState, character, prompt) {
     const file = importInput.files?.[0];
     if (!file) return;
     try {
-      await importStateJsonFile(node, file, uiState);
+      await importStateJsonFile(node, file);
     } catch (err) {
       setStatus(node, `Import failed: ${err?.message || err}`);
     } finally {
@@ -2518,25 +2417,36 @@ function renderHeader(node, state, uiState, character, prompt) {
         status: changes.length ? `Applied ${changes.join(", ")} to selected nodes.` : "Selected nodes did not match this state.",
       });
     }, "Apply the current character/preset to selected graph nodes"),
-    makeButton("Export", () => {
-      exportStateJson(node, state, uiState, character.id, prompt.id);
-      setStatus(node, "Exported State Manager JSON.");
-    }, "Download the complete State Manager data as JSON"),
-    makeButton("Import", () => importInput.click(), "Import a State Manager JSON backup")
+    makeButton("Export character", async () => {
+      try {
+        if (character.id === "default_character" || character.__dsm_ephemeral) {
+          throw new Error("The built-in or missing placeholder is not a persistent character.");
+        }
+        await exportCharacterJson(character.id);
+        setStatus(node, "Exported the selected character.");
+      } catch (err) {
+        setStatus(node, `Character export failed: ${err?.message || err}`);
+      }
+    }, "Download only the selected character and its prompts"),
+    makeButton("Export library", async () => {
+      try {
+        await exportLibraryJson();
+        setStatus(node, "Exported the complete State Manager library.");
+      } catch (err) {
+        setStatus(node, `Library export failed: ${err?.message || err}`);
+      }
+    }, "Download the complete persistent State Manager library"),
+    makeButton("Import", () => importInput.click(), "Import a character or State Manager library JSON"),
+    makeButton("Reload library", async () => {
+      try {
+        await reloadStateLibrary(node);
+      } catch (err) {
+        setStatus(node, `Library reload failed: ${err?.message || err}`);
+      }
+    }, "Discard unsaved stale edits and reload persistent storage")
   );
 
   section.append(toolbar, importInput);
-  if (node.__dsmBackupWarning) {
-    const warning = document.createElement("div");
-    warning.className = "dsm-warning";
-    const warningText = document.createElement("span");
-    warningText.textContent = node.__dsmBackupWarning;
-    warning.append(warningText, makeButton("Dismiss", () => {
-      clearBackupWarning(node);
-      scheduleRender(node);
-    }));
-    section.appendChild(warning);
-  }
   return section;
 }
 
@@ -3383,8 +3293,7 @@ function renderSettingsPanelContent(section, node, state, uiState, character, pr
 }
 
 function libraryRenderKey(node, state, uiState, mode) {
-  const rawState = widgetValue(getWidgets(node).stateWidget, "");
-  const stateKey = typeof rawState === "string" && rawState ? rawState : serializeState(state);
+  const stateKey = canonicalJson(state);
   return [
     mode,
     stateKey,
@@ -3652,17 +3561,35 @@ function initializeNode(node, widget) {
   node.min_size = [MIN_NODE_WIDTH, MIN_NODE_HEIGHT];
   node.setSize?.([Math.max(oldSize[0], MIN_NODE_WIDTH), Math.max(oldSize[1], MIN_NODE_HEIGHT)]);
 
-  const restoreResult = tryRestoreStateBackup(node);
-  const snapshot = getCurrentState(node);
-  const { character, prompt } = ensureSelection(node, snapshot.state);
-  updateState(node, snapshot.state, snapshot.uiState, { characterId: character.id, promptId: prompt.id, dirty: false, render: false, preserveBackupWarning: restoreResult.preserveBackupWarning });
+  stateLibraryClient.nodes.add(node);
+  const load = async () => {
+    const token = (node.__dsmLibraryLoadToken || 0) + 1;
+    node.__dsmLibraryLoadToken = token;
+    const currentWidgets = getWidgets(node);
+    const legacy = parseLegacyEmbeddedState(widgetValue(currentWidgets.stateWidget, ""));
+    setWidgetValue(currentWidgets.stateWidget, serializeBinding());
+    node.properties = node.properties || {};
+    delete node.properties.dora_state_manager;
+    delete node.properties.dora_state_manager_backup_node_uid;
+    const characterId = String(widgetValue(currentWidgets.characterWidget, "") || "");
+    const promptId = String(widgetValue(currentWidgets.promptWidget, "") || "");
+    try {
+      await initializeStateLibrary(node, legacy, characterId, promptId, token);
+    } catch (err) {
+      if (node.__dsmLibraryLoadToken !== token) return;
+      const fallback = stateViewForSelection(characterId, promptId);
+      const uiState = normalizeUiState(widgetValue(currentWidgets.uiStateWidget, serializeUiState(defaultUiState())));
+      cacheRenderableState(node, fallback, {
+        ...uiState,
+        status: `State Manager library load failed: ${err?.message || err}`,
+      });
+      scheduleRender(node);
+    }
+  };
+  void load();
 
   chainNodeCallback(node, "onConfigure", function () {
-    const restoreOnConfigureResult = tryRestoreStateBackup(node);
-    const next = getCurrentState(node);
-    const selection = ensureSelection(node, next.state);
-    updateState(node, next.state, next.uiState, { characterId: selection.character.id, promptId: selection.prompt.id, dirty: false, render: false, preserveBackupWarning: restoreOnConfigureResult.preserveBackupWarning });
-    scheduleRender(node);
+    void Promise.resolve().then(load);
   });
 
   chainNodeCallback(node, "onResize", function () {
@@ -3671,6 +3598,7 @@ function initializeNode(node, widget) {
   });
 
   chainNodeCallback(node, "onRemoved", function () {
+    stateLibraryClient.nodes.delete(node);
     const ctx = node.__dsm;
     if (!ctx?.renderFrame) return;
     cancelAnimationFrame(ctx.renderFrame);
@@ -3764,7 +3692,7 @@ function setQueuedInput(promptPayload, node, inputName, value, { addIfMissing = 
 }
 
 function setQueuedWidgetInput(promptPayload, node, widgetName, value) {
-  return setQueuedInput(promptPayload, node, widgetName, value, { addIfMissing: false, syncWidget: true });
+  return setQueuedInput(promptPayload, node, widgetName, value, { addIfMissing: false, syncWidget: false });
 }
 
 function readQueuedInput(promptPayload, node, inputName) {
@@ -3792,12 +3720,12 @@ function firstControlledStateSeed(managerNode, promptPayload) {
   return null;
 }
 
-function serializeQueuedUiStateOverride(uiState, payload, queueIndex, total) {
+function serializeQueuedUiStateOverride(uiState, characterId, promptId, runtimeSeed, queueIndex, total) {
   return JSON.stringify({
-    ...stripBackupRestoreStatus(uiState || defaultUiState()),
-    __dsm_queued_runtime_state: structuredCloneCompat(payload),
-    __dsm_queued_runtime_character_id: String(payload?.character?.id ?? ""),
-    __dsm_queued_runtime_prompt_id: String(payload?.prompt?.id ?? ""),
+    ...safeJsonParse(serializeWorkflowUiState(uiState), {}),
+    ...(runtimeSeed == null ? {} : { __dsm_runtime_seed: runtimeSeed }),
+    __dsm_queued_runtime_character_id: String(characterId ?? ""),
+    __dsm_queued_runtime_prompt_id: String(promptId ?? ""),
     __dsm_queued_runtime_queue_index: Math.max(0, Number(queueIndex) || 0),
     __dsm_queued_runtime_queue_total: Math.max(1, Number(total) || 1),
     // The runtime override must differ per queued prompt even if the same prompt
@@ -3807,20 +3735,20 @@ function serializeQueuedUiStateOverride(uiState, payload, queueIndex, total) {
   }, null, 0);
 }
 
-function setQueuedStateManagerRuntimeState(promptPayload, node, uiState, payload, queueIndex, total) {
+function setQueuedStateManagerRuntimeState(promptPayload, node, uiState, characterId, promptId, runtimeSeed, queueIndex, total) {
   return setQueuedInput(
     promptPayload,
     node,
     UI_STATE_WIDGET,
-    serializeQueuedUiStateOverride(uiState, payload, queueIndex, total),
-    { addIfMissing: true, syncWidget: true }
+    serializeQueuedUiStateOverride(uiState, characterId, promptId, runtimeSeed, queueIndex, total),
+    { addIfMissing: true, syncWidget: false }
   );
 }
 
 function setQueuedStateManagerSelection(promptPayload, node, characterId, promptId) {
   let changed = 0;
-  changed += setQueuedInput(promptPayload, node, SELECTED_CHARACTER_WIDGET, characterId, { addIfMissing: false, syncWidget: true });
-  changed += setQueuedInput(promptPayload, node, SELECTED_PROMPT_WIDGET, promptId, { addIfMissing: false, syncWidget: true });
+  changed += setQueuedInput(promptPayload, node, SELECTED_CHARACTER_WIDGET, characterId, { addIfMissing: false, syncWidget: false });
+  changed += setQueuedInput(promptPayload, node, SELECTED_PROMPT_WIDGET, promptId, { addIfMissing: false, syncWidget: false });
   return changed;
 }
 
@@ -4034,10 +3962,10 @@ function mutateQueuedLegacyTextTargets(promptPayload, managerNode, prompt) {
   for (const group of legacyTargets) {
     for (const target of group.targets) {
       const inputName = target.inputName || (group.role === "negative" ? "negative" : "text");
-      changed += setQueuedInput(promptPayload, target.node, inputName, String(group.text ?? ""), { addIfMissing: true, syncWidget: true });
+      changed += setQueuedInput(promptPayload, target.node, inputName, String(group.text ?? ""), { addIfMissing: true, syncWidget: false });
       if (isImpactWildcardNode(target.node)) {
-        changed += setQueuedInput(promptPayload, target.node, "wildcard_text", String(group.text ?? ""), { addIfMissing: true, syncWidget: true });
-        changed += setQueuedInput(promptPayload, target.node, "populated_text", String(group.text ?? ""), { addIfMissing: true, syncWidget: true });
+        changed += setQueuedInput(promptPayload, target.node, "wildcard_text", String(group.text ?? ""), { addIfMissing: true, syncWidget: false });
+        changed += setQueuedInput(promptPayload, target.node, "populated_text", String(group.text ?? ""), { addIfMissing: true, syncWidget: false });
       }
     }
   }
@@ -4060,7 +3988,7 @@ function mutateQueuedSettingsNodes(promptPayload, managerNode, settingsSource) {
     if (snapshot?.widgets) {
       for (const [name, value] of Object.entries(snapshot.widgets)) {
         if (preserveLiveStateSeed && String(name) === "seed") continue;
-        changed += setQueuedInput(promptPayload, node, String(name), value, { addIfMissing: false, syncWidget: true });
+        changed += setQueuedInput(promptPayload, node, String(name), value, { addIfMissing: false, syncWidget: false });
       }
     }
     if (isSeedNode(node) && !preserveLiveStateSeed) {
@@ -4068,7 +3996,7 @@ function mutateQueuedSettingsNodes(promptPayload, managerNode, settingsSource) {
       if (seed != null) {
         for (const name of ["seed", "noise_seed", "value"]) {
           const before = changed;
-          changed += setQueuedInput(promptPayload, node, name, seed, { addIfMissing: false, syncWidget: true });
+          changed += setQueuedInput(promptPayload, node, name, seed, { addIfMissing: false, syncWidget: false });
           if (changed !== before) break;
         }
       }
@@ -4091,14 +4019,26 @@ function mutatePromptForStateManagers(promptPayload, queueIndex, total) {
     const { character, prompt } = selectQueuedCharacterAndPrompt(node, state, uiState, currentCharacterId, currentPromptId, queueIndex, total);
     if (!character || !prompt) continue;
     let payload = buildQueuedDoraStatePayload(character, prompt);
+    let runtimeSeed = null;
     const liveStateSeed = firstControlledStateSeed(node, promptPayload);
     if (liveStateSeed) {
-      payload = withRuntimeSeed(payload, liveStateSeed.seed);
+      runtimeSeed = liveStateSeed.seed;
+      payload = withRuntimeSeed(payload, runtimeSeed);
     } else if (uiState.queue_randomize_saved_seed) {
-      payload = withRuntimeSeed(payload, generateStateManagerRuntimeSeed());
+      runtimeSeed = generateStateManagerRuntimeSeed();
+      payload = withRuntimeSeed(payload, runtimeSeed);
     }
     changed += setQueuedStateManagerSelection(promptPayload, node, character.id, prompt.id);
-    changed += setQueuedStateManagerRuntimeState(promptPayload, node, uiState, payload, queueIndex, total);
+    changed += setQueuedStateManagerRuntimeState(
+      promptPayload,
+      node,
+      uiState,
+      character.id,
+      prompt.id,
+      runtimeSeed,
+      queueIndex,
+      total,
+    );
     changed += mutateQueuedDoraLoaders(promptPayload, node, character);
     changed += mutateQueuedStateTextBoxes(promptPayload, node, prompt);
     changed += mutateQueuedLegacyTextTargets(promptPayload, node, prompt);
@@ -4425,16 +4365,31 @@ app.registerExtension({
     nodeType.prototype.onSerialize = function (o) {
       const result = originalOnSerialize?.apply(this, arguments);
       try {
+        const widgets = getWidgets(this);
         const snapshot = getCurrentState(this);
-        const selection = ensureSelection(this, snapshot.state);
-        updateState(this, snapshot.state, snapshot.uiState, {
-          characterId: selection.character.id,
-          promptId: selection.prompt.id,
-          dirty: false,
-          render: false,
-        });
+        const binding = serializeBinding();
+        const workflowUiState = serializeWorkflowUiState(snapshot.uiState);
+        setWidgetValue(widgets.stateWidget, binding);
         o.properties = o.properties || {};
-        o.properties.dora_state_manager = this.properties?.dora_state_manager;
+        delete o.properties.dora_state_manager;
+        delete o.properties.dora_state_manager_backup_node_uid;
+        if (this.properties) {
+          delete this.properties.dora_state_manager;
+          delete this.properties.dora_state_manager_backup_node_uid;
+        }
+        if (app?.graph?.extra) delete app.graph.extra.dora_state_manager_backup_workflow_id;
+        const values = Array.isArray(o.widgets_values) ? o.widgets_values : null;
+        const named = o.widgets_values_named && typeof o.widgets_values_named === "object"
+          ? o.widgets_values_named
+          : null;
+        for (const [widget, value] of [
+          [widgets.stateWidget, binding],
+          [widgets.uiStateWidget, workflowUiState],
+        ]) {
+          const index = (this.widgets || []).indexOf(widget);
+          if (values && index >= 0) values[index] = value;
+          if (named && widget?.name) named[widget.name] = value;
+        }
       } catch (err) {
         console.warn(`[${EXT_NAME}] serialize sync failed`, err);
       }

--- a/web/dora_state_manager.js
+++ b/web/dora_state_manager.js
@@ -67,6 +67,7 @@ const dsmQueueSession = {
 };
 
 const stateLibraryClient = {
+  userId: "default",
   revision: 0,
   state: { version: STATE_SCHEMA_VERSION, characters: [] },
   canonical: "[]",
@@ -544,7 +545,7 @@ function normalizeLoraRow(row) {
 function normalizePrompt(prompt, index, nameOverride = "") {
   const p = prompt && typeof prompt === "object" ? prompt : {};
   const fallbackName = `Character ${index + 1}`;
-  return syncPromptTextMirror({
+  const normalized = syncPromptTextMirror({
     id: cleanId(p.id, `prompt_${index + 1}`),
     name: String(nameOverride || p.name || fallbackName).trim() || fallbackName,
     positive: String(p.positive ?? p.positive_prompt ?? ""),
@@ -554,6 +555,8 @@ function normalizePrompt(prompt, index, nameOverride = "") {
     reference_image: normalizeThumbnail(p.reference_image ?? p.referenceImage ?? p.prompt_image ?? p.image),
     fileimage_prefix: String(p.fileimage_prefix ?? p.filename_prefix ?? p.file_image_prefix ?? "").trim(),
   });
+  if (p.__dsm_ephemeral) normalized.__dsm_ephemeral = true;
+  return normalized;
 }
 
 function normalizeCharacter(character, index, { migrateLegacyPresetNames = false } = {}) {
@@ -669,9 +672,13 @@ function isDefaultStateValue(value) {
 }
 
 function persistentCharacters(state) {
-  return normalizeState(state).characters.filter(
-    (character) => character.id !== "default_character" && !character.__dsm_ephemeral
-  );
+  return normalizeState(state).characters
+    .filter((character) => character.id !== "default_character" && !character.__dsm_ephemeral)
+    .map((character) => ({
+      ...character,
+      prompts: character.prompts.filter((prompt) => !prompt.__dsm_ephemeral),
+    }))
+    .filter((character) => character.prompts.length);
 }
 
 function materializeEditedDefault(state, characterId, promptId) {
@@ -716,6 +723,7 @@ function installLibrarySnapshot(snapshot, { force = false } = {}) {
   const characters = Array.isArray(snapshot?.characters) ? snapshot.characters : [];
   const revision = Math.max(0, Number(snapshot?.revision) || 0);
   if (!force && revision < stateLibraryClient.revision) return false;
+  stateLibraryClient.userId = String(snapshot?.user_id || stateLibraryClient.userId || "default");
   stateLibraryClient.revision = revision;
   stateLibraryClient.state = { version: STATE_SCHEMA_VERSION, characters: structuredCloneCompat(characters) };
   stateLibraryClient.canonical = canonicalJson(characters);
@@ -739,6 +747,14 @@ function stateViewForSelection(characterId, promptId) {
   const character = state.characters.find((item) => item.id === characterId);
   const prompt = character?.prompts?.find((item) => item.id === promptId);
   if (character && prompt) return state;
+  if (character) {
+    character.prompts.unshift({
+      ...defaultPrompt("Selected prompt preset is not available locally"),
+      id: String(promptId || "missing_prompt"),
+      __dsm_ephemeral: true,
+    });
+    return normalizeState(state);
+  }
   const missing = defaultCharacter();
   missing.__dsm_ephemeral = true;
   missing.id = String(characterId || "missing_character");
@@ -797,6 +813,16 @@ function mergeScheduledLibraryUpdate(baseCharacters, desiredCharacters, currentC
   return { conflict: null, characters: order };
 }
 
+function blockLibraryWrites(status) {
+  stateLibraryClient.blocked = true;
+  stateLibraryClient.pending = [];
+  for (const node of stateLibraryClient.nodes) {
+    const current = getRenderableState(node);
+    cacheRenderableState(node, current.state, { ...current.uiState, status });
+    scheduleRender(node);
+  }
+}
+
 async function writePendingLibrary() {
   if (stateLibraryClient.writing || stateLibraryClient.blocked) return;
   stateLibraryClient.writing = true;
@@ -810,15 +836,7 @@ async function writePendingLibrary() {
         { allowOverwrite: pending.node === stateLibraryClient.lastAppliedNode },
       );
       if (merged.conflict) {
-        stateLibraryClient.blocked = true;
-        for (const node of stateLibraryClient.nodes) {
-          const current = getRenderableState(node);
-          cacheRenderableState(node, current.state, {
-            ...current.uiState,
-            status: "Two local State Manager instances edited the same character concurrently. Reload the library; no conflicting write was sent.",
-          });
-          scheduleRender(node);
-        }
+        blockLibraryWrites("Two local State Manager instances edited the same character concurrently. Reload the library; no conflicting write was sent.");
         break;
       }
       if (canonicalJson(merged.characters) === stateLibraryClient.canonical) {
@@ -839,26 +857,10 @@ async function writePendingLibrary() {
         refreshAllNodesFromLibrary();
       } catch (error) {
         if (error.status === 409) {
-          stateLibraryClient.blocked = true;
-          for (const node of stateLibraryClient.nodes) {
-            const current = getRenderableState(node);
-            cacheRenderableState(node, current.state, {
-              ...current.uiState,
-              status: "Library changed in another tab or State Manager. Reload the library before editing again; the stale write was rejected.",
-            });
-            scheduleRender(node);
-          }
+          blockLibraryWrites("Library changed in another tab or State Manager. Reload the library before editing again; the stale write was rejected.");
           break;
         }
-        stateLibraryClient.blocked = true;
-        for (const node of stateLibraryClient.nodes) {
-          const current = getRenderableState(node);
-          cacheRenderableState(node, current.state, {
-            ...current.uiState,
-            status: `Library save failed: ${error?.message || error}`,
-          });
-          scheduleRender(node);
-        }
+        blockLibraryWrites(`Library save failed: ${error?.message || error}`);
         break;
       }
     }
@@ -870,7 +872,13 @@ async function writePendingLibrary() {
 function scheduleLibraryPersist(node, state) {
   const desiredCharacters = persistentCharacters(state);
   const canonical = canonicalJson(desiredCharacters);
-  if (canonical === stateLibraryClient.canonical || stateLibraryClient.blocked) return;
+  if (stateLibraryClient.blocked) {
+    refreshNodeFromLibrary(node, {
+      status: "This edit was not applied. Reload the State Manager library before editing again.",
+    });
+    return;
+  }
+  if (canonical === stateLibraryClient.canonical) return;
   const last = stateLibraryClient.pending[stateLibraryClient.pending.length - 1];
   const scheduled = {
     node,
@@ -916,7 +924,7 @@ async function initializeStateLibrary(node, legacyState, selectedCharacterId, se
   } else {
     snapshot = await stateLibraryRequest();
   }
-  if (token != null && node.__dsmLibraryLoadToken !== token) return;
+  if (token != null && node.__dsmLibraryLoadToken !== token) return false;
   installLibrarySnapshot(snapshot);
   const widgets = getWidgets(node);
   setWidgetValue(widgets.stateWidget, serializeBinding());
@@ -931,6 +939,7 @@ async function initializeStateLibrary(node, legacyState, selectedCharacterId, se
   refreshAllNodesFromLibrary();
   cacheRenderableState(node, state, status ? { ...uiState, status } : uiState);
   scheduleRender(node);
+  return true;
 }
 
 function selectionIdsForState(state, characterId = "", promptId = "") {
@@ -3566,7 +3575,14 @@ function initializeNode(node, widget) {
     const token = (node.__dsmLibraryLoadToken || 0) + 1;
     node.__dsmLibraryLoadToken = token;
     const currentWidgets = getWidgets(node);
-    const legacy = parseLegacyEmbeddedState(widgetValue(currentWidgets.stateWidget, ""));
+    const embeddedLegacy = parseLegacyEmbeddedState(widgetValue(currentWidgets.stateWidget, ""));
+    if (embeddedLegacy && !isDefaultStateValue(embeddedLegacy)) {
+      node.__dsmPendingLegacyState = structuredCloneCompat(embeddedLegacy);
+    }
+    const legacy = node.__dsmPendingLegacyState || embeddedLegacy;
+    // Keep queued prompt generation free of the embedded payload. Until the
+    // migration succeeds, onSerialize writes the stashed legacy state back to
+    // workflow JSON so a transient server failure cannot destroy it.
     setWidgetValue(currentWidgets.stateWidget, serializeBinding());
     node.properties = node.properties || {};
     delete node.properties.dora_state_manager;
@@ -3574,7 +3590,8 @@ function initializeNode(node, widget) {
     const characterId = String(widgetValue(currentWidgets.characterWidget, "") || "");
     const promptId = String(widgetValue(currentWidgets.promptWidget, "") || "");
     try {
-      await initializeStateLibrary(node, legacy, characterId, promptId, token);
+      const loaded = await initializeStateLibrary(node, legacy, characterId, promptId, token);
+      if (loaded) delete node.__dsmPendingLegacyState;
     } catch (err) {
       if (node.__dsmLibraryLoadToken !== token) return;
       const fallback = stateViewForSelection(characterId, promptId);
@@ -3723,6 +3740,7 @@ function firstControlledStateSeed(managerNode, promptPayload) {
 function serializeQueuedUiStateOverride(uiState, characterId, promptId, runtimeSeed, queueIndex, total) {
   return JSON.stringify({
     ...safeJsonParse(serializeWorkflowUiState(uiState), {}),
+    __dsm_library_user_id: stateLibraryClient.userId,
     ...(runtimeSeed == null ? {} : { __dsm_runtime_seed: runtimeSeed }),
     __dsm_queued_runtime_character_id: String(characterId ?? ""),
     __dsm_queued_runtime_prompt_id: String(promptId ?? ""),
@@ -4368,6 +4386,9 @@ app.registerExtension({
         const widgets = getWidgets(this);
         const snapshot = getCurrentState(this);
         const binding = serializeBinding();
+        const serializedState = this.__dsmPendingLegacyState
+          ? serializeState(this.__dsmPendingLegacyState)
+          : binding;
         const workflowUiState = serializeWorkflowUiState(snapshot.uiState);
         setWidgetValue(widgets.stateWidget, binding);
         o.properties = o.properties || {};
@@ -4383,7 +4404,7 @@ app.registerExtension({
           ? o.widgets_values_named
           : null;
         for (const [widget, value] of [
-          [widgets.stateWidget, binding],
+          [widgets.stateWidget, serializedState],
           [widgets.uiStateWidget, workflowUiState],
         ]) {
           const index = (this.widgets || []).indexOf(widget);


### PR DESCRIPTION
## Summary

- move reusable State Manager characters and presets into a backend-authoritative, revisioned library under the active ComfyUI user directory
- serialize only UUID bindings and workflow-specific queue configuration; remove browser backup restoration and keep queue-time values transient
- add idempotent legacy embedded-library migration, explicit import/export, missing-preset handling, atomic writes, corruption quarantine, optimistic revisions, and conflict-safe multi-manager updates
- preserve runtime outputs, connected Save/Load, loader stacks, text/settings/image metadata, special seeds, wildcard queues, and the legacy node alias

## Root cause

The full preset library was duplicated into the hidden `state_json` widget, node properties, workflow JSON, queued workflow copies, and workflow/node-keyed `localStorage` backups. A sanitized or fresh workflow could therefore be repopulated from unrelated browser state.

## Validation

- `node --test tests/test_frontend_state_persistence.mjs tests/test_state_manager_frontend.mjs` — 22 passed
- staged `pytest tests/test_state_manager_store.py` — 15 passed
- Python compilation and frontend syntax checks passed
- offline package wheel build passed
- GitHub Actions runs the pinned ComfyUI v0.29.2, v0.30.2, and v0.31.1 compatibility/runtime matrix


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * State Manager data is now stored persistently in the ComfyUI user directory.
  * Added character and full-library import/export, reload, and migration support.
  * Workflows now retain lightweight UUID bindings while runtime values are resolved from the selected library.
  * Added safer storage with atomic updates, conflict handling, corruption recovery, and clear missing-preset errors.

* **Bug Fixes**
  * Fixed DoRA Power LoRA settings resetting when switching workflows in newer ComfyUI frontends.

* **Compatibility**
  * Existing workflows, seeds, loaders, text inputs, and queue behavior remain supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Plain LoKr runtime bypass

- Adds exact runtime bypass for plain direct-factor and decomposed LoKr adapters on ComfyUI revisions with native LoKr forward math.
- Preserves materialized alpha/rank semantics through runtime-only adapter copies and supports mixed LoRA + LoKr stacks.
- Keeps DoRA-LoKr and unsupported target forms fail-closed.
- Makes adapter capture transactional across the base loader's retry boundary.
- Extends CI with a pinned 2026-08-21 ComfyUI revision that executes the LoKr path.

## Release

- Bumps the package and Comfy Registry version to `1.0.41`.
- Promotes the release notes to `v1.0.41` and covers both feature sets.
- Verifies the GitHub release ZIP contains `state_manager_api.py`, `state_manager_store.py`, and `web/dora_state_manager.js`.
- Keeps the explicit Comfy Registry include list for both backend modules and `web`.