### PR TITLE
Fix persistent State Manager preset deletion

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,16 @@
+# DoRA Dynamic LoRA Loader v1.0.42
+
+This hotfix makes State Manager prompt-preset and character deletion persist correctly when removing the final stored entry.
+
+## State Manager deletion fix
+
+- Removes the selected prompt and selects its adjacent preset when the character has other prompts.
+- Removes a character when its sole prompt is deleted, matching the persisted character schema's requirement that a stored character contain at least one prompt.
+- Allows the final stored character to be deleted and shows the existing non-persistent default placeholder for an empty library.
+- Treats ephemeral missing-selection placeholders as already unavailable, repairs the workflow binding to the nearest durable selection, and sends no storage write for that repair.
+- Uses the same tested deletion helpers from the preset library, prompt editor, and character library controls.
+- Adds regression coverage for multi-preset deletion, sole-preset deletion, final-character deletion, and stale prompt/character placeholders.
+
 # DoRA Dynamic LoRA Loader v1.0.41
 
 This release moves State Manager presets into a backend-authoritative per-user library and adds mathematically equivalent runtime bypass support for plain LoKr adapters on compatible ComfyUI revisions.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "dora-dynamic-lora-loader"
 description = "A ComfyUI custom node that loads and stacks regular LoRAs and DoRA LoRAs with Flux/Flux2 and OneTrainer compatibility fixes."
-version = "1.0.41"
+version = "1.0.42"
 license = { file = "LICENSE" }
 
 [project.urls]

--- a/tests/test_state_manager_frontend.mjs
+++ b/tests/test_state_manager_frontend.mjs
@@ -10,7 +10,7 @@ async function loadStateManagerHelpers() {
     .replace('import { app } from "../../scripts/app.js";', "let capturedExtension = null; const app = { registerExtension(value) { capturedExtension = value; }, graph: { extra: {} } };")
     .replace('import { api } from "../../scripts/api.js";', "const api = { fetchApi() { throw new Error('not used'); }, apiURL(value) { return value; } };")
     .replace('import "../../scripts/domWidget.js";', "");
-  source += `\nexport { capturedExtension, defaultBinding, defaultState, makeId, materializeEditedDefault, mergeScheduledLibraryUpdate, persistentCharacters, serializeBinding, serializeWorkflowUiState, serializeQueuedUiStateOverride, parseLegacyEmbeddedState, stateLibraryClient, stateViewForSelection };\n`;
+  source += `\nexport { capturedExtension, defaultBinding, defaultState, deletePromptPreset, deleteStateCharacter, makeId, materializeEditedDefault, mergeScheduledLibraryUpdate, persistentCharacters, serializeBinding, serializeWorkflowUiState, serializeQueuedUiStateOverride, parseLegacyEmbeddedState, stateLibraryClient, stateViewForSelection };\n`;
   const encoded = Buffer.from(source, "utf8").toString("base64");
   return import(`data:text/javascript;base64,${encoded}#${Date.now()}-${Math.random()}`);
 }
@@ -150,6 +150,59 @@ test("new and duplicated presets receive collision-resistant UUID bindings", asy
   const ids = new Set(Array.from({ length: 100 }, () => helpers.makeId("prompt")));
   assert.equal(ids.size, 100);
   for (const id of ids) assert.match(id, /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
+});
+
+
+test("deleting the sole preset removes its character from persistent storage", async () => {
+  const helpers = await loadStateManagerHelpers();
+  const state = {
+    version: 3,
+    characters: [privateCharacter("character-a", "A", "A0")],
+  };
+  const result = helpers.deletePromptPreset(state, "character-a", "character-a-prompt");
+  assert.equal(result.deleted, true);
+  assert.equal(result.removedCharacter, true);
+  assert.equal(result.characterId, "default_character");
+  assert.equal(result.promptId, "default_prompt");
+  assert.deepEqual(helpers.persistentCharacters(result.state), []);
+});
+
+
+test("deleting one of several presets keeps the character and selects its neighbor", async () => {
+  const helpers = await loadStateManagerHelpers();
+  const character = privateCharacter("character-a", "A", "A0");
+  character.prompts.push({
+    ...structuredClone(character.prompts[0]),
+    id: "character-a-prompt-2",
+    name: "Second preset",
+    positive: "A1",
+  });
+  const result = helpers.deletePromptPreset(
+    { version: 3, characters: [character] },
+    "character-a",
+    "character-a-prompt",
+  );
+  assert.equal(result.deleted, true);
+  assert.equal(result.removedCharacter, false);
+  assert.equal(result.characterId, "character-a");
+  assert.equal(result.promptId, "character-a-prompt-2");
+  assert.deepEqual(
+    helpers.persistentCharacters(result.state)[0].prompts.map((prompt) => prompt.id),
+    ["character-a-prompt-2"],
+  );
+});
+
+
+test("deleting the final character leaves an empty persistent library", async () => {
+  const helpers = await loadStateManagerHelpers();
+  const result = helpers.deleteStateCharacter(
+    { version: 3, characters: [privateCharacter("character-a", "A", "A0")] },
+    "character-a",
+  );
+  assert.equal(result.deleted, true);
+  assert.equal(result.characterId, "default_character");
+  assert.equal(result.promptId, "default_prompt");
+  assert.deepEqual(helpers.persistentCharacters(result.state), []);
 });
 
 

--- a/tests/test_state_manager_frontend.mjs
+++ b/tests/test_state_manager_frontend.mjs
@@ -206,18 +206,28 @@ test("deleting the final character leaves an empty persistent library", async ()
 });
 
 
-test("deleting an ephemeral stale preset repairs selection without reporting a stored deletion", async () => {
+test("deleting ephemeral stale selections repairs bindings without reporting stored deletions", async () => {
   const helpers = await loadStateManagerHelpers();
   const character = privateCharacter("character-a", "A", "A0");
   helpers.stateLibraryClient.state = { version: 2, characters: [character] };
-  const state = helpers.stateViewForSelection("character-a", "deleted-prompt");
-  const result = helpers.deletePromptPreset(state, "character-a", "deleted-prompt");
-  assert.equal(result.deleted, false);
-  assert.equal(result.characterId, "character-a");
-  assert.equal(result.promptId, "character-a-prompt");
+  const promptState = helpers.stateViewForSelection("character-a", "deleted-prompt");
+  const promptResult = helpers.deletePromptPreset(promptState, "character-a", "deleted-prompt");
+  assert.equal(promptResult.deleted, false);
+  assert.equal(promptResult.characterId, "character-a");
+  assert.equal(promptResult.promptId, "character-a-prompt");
   assert.deepEqual(
-    helpers.persistentCharacters(result.state)[0].prompts.map((prompt) => prompt.id),
+    helpers.persistentCharacters(promptResult.state)[0].prompts.map((prompt) => prompt.id),
     ["character-a-prompt"],
+  );
+
+  const characterState = helpers.stateViewForSelection("deleted-character", "deleted-prompt");
+  const characterResult = helpers.deleteStateCharacter(characterState, "deleted-character");
+  assert.equal(characterResult.deleted, false);
+  assert.equal(characterResult.characterId, "character-a");
+  assert.equal(characterResult.promptId, "character-a-prompt");
+  assert.deepEqual(
+    helpers.persistentCharacters(characterResult.state).map((item) => item.id),
+    ["character-a"],
   );
 });
 

--- a/tests/test_state_manager_frontend.mjs
+++ b/tests/test_state_manager_frontend.mjs
@@ -206,6 +206,22 @@ test("deleting the final character leaves an empty persistent library", async ()
 });
 
 
+test("deleting an ephemeral stale preset repairs selection without reporting a stored deletion", async () => {
+  const helpers = await loadStateManagerHelpers();
+  const character = privateCharacter("character-a", "A", "A0");
+  helpers.stateLibraryClient.state = { version: 2, characters: [character] };
+  const state = helpers.stateViewForSelection("character-a", "deleted-prompt");
+  const result = helpers.deletePromptPreset(state, "character-a", "deleted-prompt");
+  assert.equal(result.deleted, false);
+  assert.equal(result.characterId, "character-a");
+  assert.equal(result.promptId, "character-a-prompt");
+  assert.deepEqual(
+    helpers.persistentCharacters(result.state)[0].prompts.map((prompt) => prompt.id),
+    ["character-a-prompt"],
+  );
+});
+
+
 test("disjoint character edits rebase without losing either manager's change", async () => {
   const helpers = await loadStateManagerHelpers();
   const base = [

--- a/web/dora_state_manager.js
+++ b/web/dora_state_manager.js
@@ -602,9 +602,11 @@ function updatePromptName(state, characterId, promptId, value) {
 function deleteStateCharacter(state, characterId) {
   const nextState = normalizeState(state);
   const characterIndex = nextState.characters.findIndex((item) => item.id === characterId);
-  if (characterIndex < 0) {
-    const selection = selectionIdsForState(nextState, characterId, "");
-    return { state: nextState, ...selection, deleted: false };
+  const character = nextState.characters[characterIndex];
+  if (!character || character.__dsm_ephemeral) {
+    const durableState = normalizeState({ version: STATE_SCHEMA_VERSION, characters: persistentCharacters(nextState) });
+    const selection = selectionIdsForState(durableState);
+    return { state: durableState, ...selection, deleted: false };
   }
   nextState.characters.splice(characterIndex, 1);
   if (!nextState.characters.length) {
@@ -629,9 +631,11 @@ function deletePromptPreset(state, characterId, promptId) {
   const characterIndex = nextState.characters.findIndex((item) => item.id === characterId);
   const character = nextState.characters[characterIndex];
   const promptIndex = character?.prompts.findIndex((item) => item.id === promptId) ?? -1;
-  if (!character || promptIndex < 0) {
-    const selection = selectionIdsForState(nextState, characterId, promptId);
-    return { state: nextState, ...selection, deleted: false };
+  const prompt = character?.prompts[promptIndex];
+  if (!character || character.__dsm_ephemeral || !prompt || prompt.__dsm_ephemeral) {
+    const durableState = normalizeState({ version: STATE_SCHEMA_VERSION, characters: persistentCharacters(nextState) });
+    const selection = selectionIdsForState(durableState, character?.__dsm_ephemeral ? "" : characterId, "");
+    return { state: durableState, ...selection, deleted: false };
   }
 
   if (character.prompts.length > 1) {
@@ -2610,7 +2614,12 @@ function renderLibrary(node, state, uiState, character, prompt) {
         const current = currentLibrarySelection();
         const result = deletePromptPreset(current.state, current.character.id, current.prompt.id);
         if (!result.deleted) {
-          setStatus(node, "The selected prompt preset is no longer available.");
+          updateState(node, result.state, current.uiState, {
+            characterId: result.characterId,
+            promptId: result.promptId,
+            status: "The selected prompt preset was already unavailable; selected the nearest saved preset.",
+            persist: false,
+          });
           return;
         }
         const status = result.removedCharacter
@@ -2646,7 +2655,12 @@ function renderLibrary(node, state, uiState, character, prompt) {
         const current = currentLibrarySelection();
         const result = deleteStateCharacter(current.state, current.character.id);
         if (!result.deleted) {
-          setStatus(node, "The selected character is no longer available.");
+          updateState(node, result.state, current.uiState, {
+            characterId: result.characterId,
+            promptId: result.promptId,
+            status: "The selected character was already unavailable; selected the nearest saved character.",
+            persist: false,
+          });
           return;
         }
         updateState(node, result.state, current.uiState, { characterId: result.characterId, promptId: result.promptId, status: "Deleted character." });
@@ -2908,7 +2922,12 @@ function renderPromptPanelContent(section, node, state, uiState, character, prom
     makeButton("Delete", () => {
       const result = deletePromptPreset(state, character.id, prompt.id);
       if (!result.deleted) {
-        setStatus(node, "The selected prompt preset is no longer available.");
+        updateState(node, result.state, uiState, {
+          characterId: result.characterId,
+          promptId: result.promptId,
+          status: "The selected prompt preset was already unavailable; selected the nearest saved preset.",
+          persist: false,
+        });
         return;
       }
       const status = result.removedCharacter

--- a/web/dora_state_manager.js
+++ b/web/dora_state_manager.js
@@ -599,6 +599,56 @@ function updatePromptName(state, characterId, promptId, value) {
   return nextState;
 }
 
+function deleteStateCharacter(state, characterId) {
+  const nextState = normalizeState(state);
+  const characterIndex = nextState.characters.findIndex((item) => item.id === characterId);
+  if (characterIndex < 0) {
+    const selection = selectionIdsForState(nextState, characterId, "");
+    return { state: nextState, ...selection, deleted: false };
+  }
+  nextState.characters.splice(characterIndex, 1);
+  if (!nextState.characters.length) {
+    return {
+      state: defaultState(),
+      characterId: "default_character",
+      promptId: "default_prompt",
+      deleted: true,
+    };
+  }
+  const nextCharacter = nextState.characters[Math.min(characterIndex, nextState.characters.length - 1)];
+  return {
+    state: nextState,
+    characterId: nextCharacter.id,
+    promptId: nextCharacter.prompts[0].id,
+    deleted: true,
+  };
+}
+
+function deletePromptPreset(state, characterId, promptId) {
+  const nextState = normalizeState(state);
+  const characterIndex = nextState.characters.findIndex((item) => item.id === characterId);
+  const character = nextState.characters[characterIndex];
+  const promptIndex = character?.prompts.findIndex((item) => item.id === promptId) ?? -1;
+  if (!character || promptIndex < 0) {
+    const selection = selectionIdsForState(nextState, characterId, promptId);
+    return { state: nextState, ...selection, deleted: false };
+  }
+
+  if (character.prompts.length > 1) {
+    character.prompts.splice(promptIndex, 1);
+    const nextPrompt = character.prompts[Math.min(promptIndex, character.prompts.length - 1)];
+    return {
+      state: nextState,
+      characterId: character.id,
+      promptId: nextPrompt.id,
+      deleted: true,
+      removedCharacter: false,
+    };
+  }
+
+  return { ...deleteStateCharacter(nextState, characterId), removedCharacter: true };
+}
+
 function normalizeIdList(value) {
   if (Array.isArray(value)) return value.map((item) => cleanId(item, "")).filter(Boolean);
   if (typeof value === "string") {
@@ -2558,14 +2608,15 @@ function renderLibrary(node, state, uiState, character, prompt) {
       }),
       makeButton("Delete preset", () => {
         const current = currentLibrarySelection();
-        if (current.character.prompts.length <= 1) {
-          setStatus(node, "At least one prompt preset must remain for this character.");
+        const result = deletePromptPreset(current.state, current.character.id, current.prompt.id);
+        if (!result.deleted) {
+          setStatus(node, "The selected prompt preset is no longer available.");
           return;
         }
-        const index = current.character.prompts.findIndex((item) => item.id === current.prompt.id);
-        if (index >= 0) current.character.prompts.splice(index, 1);
-        const next = current.character.prompts[Math.max(0, Math.min(index, current.character.prompts.length - 1))];
-        updateState(node, current.state, current.uiState, { characterId: current.character.id, promptId: next.id, status: "Deleted prompt preset." });
+        const status = result.removedCharacter
+          ? "Deleted prompt preset and its now-empty character."
+          : "Deleted prompt preset.";
+        updateState(node, result.state, current.uiState, { characterId: result.characterId, promptId: result.promptId, status });
       })
     );
   } else {
@@ -2593,14 +2644,12 @@ function renderLibrary(node, state, uiState, character, prompt) {
       }),
       makeButton("Delete character", () => {
         const current = currentLibrarySelection();
-        if (current.state.characters.length <= 1) {
-          setStatus(node, "At least one character must remain.");
+        const result = deleteStateCharacter(current.state, current.character.id);
+        if (!result.deleted) {
+          setStatus(node, "The selected character is no longer available.");
           return;
         }
-        const index = current.state.characters.findIndex((item) => item.id === current.character.id);
-        if (index >= 0) current.state.characters.splice(index, 1);
-        const next = current.state.characters[Math.max(0, Math.min(index, current.state.characters.length - 1))];
-        updateState(node, current.state, current.uiState, { characterId: next.id, promptId: next.prompts[0]?.id || "", status: "Deleted character." });
+        updateState(node, result.state, current.uiState, { characterId: result.characterId, promptId: result.promptId, status: "Deleted character." });
       })
     );
   }
@@ -2857,14 +2906,15 @@ function renderPromptPanelContent(section, node, state, uiState, character, prom
       updateState(node, state, uiState, { characterId: character.id, promptId: copy.id, status: "Duplicated prompt preset." });
     }),
     makeButton("Delete", () => {
-      if (character.prompts.length <= 1) {
-        setStatus(node, "At least one prompt preset must remain.");
+      const result = deletePromptPreset(state, character.id, prompt.id);
+      if (!result.deleted) {
+        setStatus(node, "The selected prompt preset is no longer available.");
         return;
       }
-      const index = character.prompts.findIndex((p) => p.id === prompt.id);
-      if (index >= 0) character.prompts.splice(index, 1);
-      const next = character.prompts[Math.max(0, Math.min(index, character.prompts.length - 1))];
-      updateState(node, state, uiState, { characterId: character.id, promptId: next.id, status: "Deleted prompt preset." });
+      const status = result.removedCharacter
+        ? "Deleted prompt preset and its now-empty character."
+        : "Deleted prompt preset.";
+      updateState(node, result.state, uiState, { characterId: result.characterId, promptId: result.promptId, status });
     })
   );
 


### PR DESCRIPTION
## Problem

Deleting a State Manager prompt preset can appear to flash the UI once while leaving the preset in place. This is reproducible when the selected preset is the character's only prompt preset.

## Root cause

The v1.0.41 backend-authoritative library supports an empty persisted character list and the frontend already renders a non-persistent default placeholder for that state. The delete controls still enforced the older embedded-state invariant that every character and library must keep at least one entry, so the sole-preset and final-character paths returned without scheduling a library write.

## Fix

- centralize prompt-preset deletion in a tested helper used by both the library toolbar and prompt editor;
- remove only the selected prompt and choose its adjacent preset when the character has others;
- remove a character when its sole prompt is deleted, because the persisted character schema requires at least one prompt;
- allow deletion of the final character and select the non-persistent default placeholder while persisting an empty library;
- treat ephemeral/already-missing selections as unavailable, repair them to a durable selection, and explicitly skip persistence;
- make status text distinguish a stored deletion, an empty-character removal, and stale-selection repair.

No backend, release-workflow, or runtime loader behavior changes.

## Release

- bump `pyproject.toml` from `1.0.41` to `1.0.42`, preventing the tested main-branch release workflow from colliding with the existing v1.0.41 tag;
- prepend focused v1.0.42 hotfix notes;
- keep the existing GitHub ZIP and Comfy Registry packaging configuration unchanged.

## Validation

- `node --check web/dora_state_manager.js`
- `node --test tests/test_frontend_state_persistence.mjs tests/test_state_manager_frontend.mjs` — 29 passed
- `python -m py_compile __init__.py nodes.py runtime_bypass.py state_manager_api.py state_manager_store.py`
- `git diff --check`
- built and integrity-tested `ComfyUI-DoRA-Dynamic-LoRA-Loader-v1.0.42.zip`
- verified the release ZIP contains `state_manager_api.py`, `state_manager_store.py`, and `web/dora_state_manager.js`

The GitHub test workflow runs the full Python/ComfyUI matrix.