### PR TITLE
Fix loaded LoRA rows on current frontend

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,8 +39,8 @@ jobs:
             node --check "${file}"
           done < <(find web -type f -name '*.js' -print0)
 
-      - name: Run frontend persistence regression tests
-        run: node --test tests/test_frontend_state_persistence.mjs tests/test_state_manager_frontend.mjs
+      - name: Run frontend regression tests
+        run: node --test tests/test_frontend_state_persistence.mjs tests/test_frontend_widget_compatibility.mjs tests/test_state_manager_frontend.mjs
 
       - name: Build package wheel
         run: |

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,13 @@
+# DoRA Dynamic LoRA Loader v1.0.43
+
+This hotfix restores the loaded LoRA row controls on current ComfyUI frontend master while preserving compatibility with older frontends.
+
+## Custom-widget rendering compatibility
+
+- Preserves the DoRA row and auto-strength report widgets' drawing, sizing, pointer, picker, editing, and serialization hooks when the frontend normalizes custom widgets into its store-backed legacy adapter.
+- Keeps the existing class instances and state model on classic and older frontends.
+- Adds a regression harness that reproduces the current frontend's prototype-replacement behavior and verifies that loaded LoRA names and strengths still render and remain interactive.
+
 # DoRA Dynamic LoRA Loader v1.0.42
 
 This hotfix makes State Manager prompt-preset and character deletion persist correctly when removing the final stored entry.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "dora-dynamic-lora-loader"
 description = "A ComfyUI custom node that loads and stacks regular LoRAs and DoRA LoRAs with Flux/Flux2 and OneTrainer compatibility fixes."
-version = "1.0.42"
+version = "1.0.43"
 license = { file = "LICENSE" }
 
 [project.urls]

--- a/tests/test_frontend_widget_compatibility.mjs
+++ b/tests/test_frontend_widget_compatibility.mjs
@@ -1,0 +1,182 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const NODE_CLASS = "DoRA Power LoRA Loader";
+
+function makeCanvasContext() {
+  const labels = [];
+  const noop = () => {};
+  return {
+    labels,
+    arc: noop,
+    beginPath: noop,
+    fill: noop,
+    fillText(text) {
+      labels.push(String(text));
+    },
+    measureText(text) {
+      return { width: String(text).length * 7 };
+    },
+    restore: noop,
+    roundRect: noop,
+    save: noop,
+    stroke: noop,
+  };
+}
+
+async function loadLoaderExtension() {
+  const sourceUrl = new URL("../web/dora_power_lora_loader.js", import.meta.url);
+  let source = await readFile(sourceUrl, "utf8");
+  let extension = null;
+  const previousFetch = globalThis.fetch;
+  const previousLiteGraph = globalThis.LiteGraph;
+
+  globalThis.fetch = async () => ({
+    ok: true,
+    async json() {
+      return ["loaded.safetensors"];
+    },
+  });
+  globalThis.LiteGraph = {};
+  globalThis.__doraWidgetCompatibilityTestApp = {
+    canvas: { canvas: {} },
+    graph: null,
+    registerExtension(value) {
+      extension = value;
+    },
+  };
+  globalThis.__doraWidgetCompatibilityTestApi = {
+    addEventListener() {},
+  };
+
+  source = source
+    .replace(
+      'import { app } from "../../scripts/app.js";',
+      "const app = globalThis.__doraWidgetCompatibilityTestApp;"
+    )
+    .replace(
+      'import { api } from "../../scripts/api.js";',
+      "const api = globalThis.__doraWidgetCompatibilityTestApi;"
+    );
+
+  const cleanup = () => {
+    delete globalThis.__doraWidgetCompatibilityTestApp;
+    delete globalThis.__doraWidgetCompatibilityTestApi;
+    globalThis.fetch = previousFetch;
+    globalThis.LiteGraph = previousLiteGraph;
+  };
+
+  try {
+    const encoded = Buffer.from(source, "utf8").toString("base64");
+    await import(`data:text/javascript;base64,${encoded}#${Date.now()}-${Math.random()}`);
+  } catch (error) {
+    cleanup();
+    throw error;
+  }
+
+  assert.ok(extension, "loader extension should register");
+  return { cleanup, extension };
+}
+
+function makeNodeType() {
+  class FakeNode {
+    constructor() {
+      this.id = 42;
+      this.graph = { change() {}, rootGraph: { id: "test-graph" } };
+      this.min_size = [0, 0];
+      this.properties = {
+        dora_power_lora: {
+          rows: [
+            {
+              enabled: true,
+              name: "loaded.safetensors",
+              strengthModel: 0.85,
+              strengthClip: 0.85,
+            },
+          ],
+          globals: {},
+        },
+      };
+      this.size = [360, 200];
+      this.widgets = [];
+    }
+
+    addWidget(type, name, value, callback, options = {}) {
+      const widget = { callback, name, options, type, value };
+      this.widgets.push(widget);
+      return widget;
+    }
+
+    addCustomWidget(widget) {
+      Object.setPrototypeOf(widget, Object.prototype);
+      this.widgets.push(widget);
+      return widget;
+    }
+
+    computeSize() {
+      const height = this.widgets.reduce((total, widget) => {
+        const widgetHeight = widget.computeSize?.(this.size[0])?.[1] ?? 20;
+        return total + widgetHeight;
+      }, 40);
+      return [this.size[0], height];
+    }
+
+    onNodeCreated() {
+      return this;
+    }
+
+    setDirtyCanvas() {}
+  }
+
+  FakeNode.comfyClass = NODE_CLASS;
+  return FakeNode;
+}
+
+test("current frontend prototype normalization preserves DoRA custom widget behavior", async () => {
+  const { cleanup, extension } = await loadLoaderExtension();
+  try {
+    const NodeType = makeNodeType();
+    await extension.beforeRegisterNodeDef(NodeType, {
+      display_name: NODE_CLASS,
+      name: NODE_CLASS,
+    });
+
+    const node = new NodeType();
+    node.onNodeCreated();
+    await new Promise((resolve) => setImmediate(resolve));
+
+    const rowWidget = node.widgets.find((widget) => widget.name === "LORA_1");
+    const reportWidget = node.widgets.find(
+      (widget) => widget.name === "auto_strength_visualization"
+    );
+
+    assert.ok(rowWidget, "LoRA row widget should be registered");
+    assert.equal(Object.getPrototypeOf(rowWidget), Object.prototype);
+    assert.equal(rowWidget.computeSize(360)[1], 24);
+    assert.equal(typeof rowWidget.draw, "function");
+    assert.equal(typeof rowWidget.mouse, "function");
+    assert.equal(typeof rowWidget.openLoraPicker, "function");
+    assert.equal(typeof rowWidget.serializeValue, "function");
+    assert.deepEqual(rowWidget.serializeValue(), {
+      lora: "loaded.safetensors",
+      on: true,
+      strength: 0.85,
+      strengthTwo: 0.85,
+    });
+
+    const context = makeCanvasContext();
+    rowWidget.draw(context, node, 360, 0, 24);
+    assert.ok(context.labels.includes("loaded.safetensors"));
+    assert.ok(context.labels.includes("0.85"));
+
+    assert.ok(reportWidget, "auto-strength report widget should be registered");
+    assert.equal(Object.getPrototypeOf(reportWidget), Object.prototype);
+    assert.equal(reportWidget.computeSize(360)[1], 72);
+    assert.equal(typeof reportWidget.draw, "function");
+    assert.equal(typeof reportWidget.mouse, "function");
+    assert.equal(typeof reportWidget._displayRows, "function");
+  } finally {
+    cleanup();
+  }
+});

--- a/web/dora_power_lora_loader.js
+++ b/web/dora_power_lora_loader.js
@@ -737,6 +737,38 @@ function setButtonCallback(widget, cb) {
   widget.options.callback = cb;
 }
 
+function preserveCustomWidgetPrototypeMethods(widget) {
+  let prototype = Object.getPrototypeOf(widget);
+  while (prototype && prototype !== Object.prototype) {
+    for (const [name, descriptor] of Object.entries(Object.getOwnPropertyDescriptors(prototype))) {
+      if (
+        name === "constructor" ||
+        Object.prototype.hasOwnProperty.call(widget, name) ||
+        typeof descriptor.value !== "function"
+      ) {
+        continue;
+      }
+      Object.defineProperty(widget, name, {
+        configurable: true,
+        enumerable: false,
+        value: descriptor.value.bind(widget),
+        writable: true,
+      });
+    }
+    prototype = Object.getPrototypeOf(prototype);
+  }
+  return widget;
+}
+
+function addDoraCustomWidget(node, widget) {
+  preserveCustomWidgetPrototypeMethods(widget);
+  if (typeof node.addCustomWidget === "function") {
+    return node.addCustomWidget(widget) || widget;
+  }
+  node.widgets.push(widget);
+  return widget;
+}
+
 function rebuild(node) {
   const st = getState(node);
   const lorasNow = _cachedLoras || ["None"];
@@ -1517,11 +1549,7 @@ function buildUI(node, state, loraValues) {
 
   node._doraRows.forEach((row, i) => {
     const widget = new DoraLoraRowWidget(`LORA_${i + 1}`, node, row);
-    if (typeof node.addCustomWidget === "function") {
-      node.addCustomWidget(widget);
-    } else {
-      node.widgets.push(widget);
-    }
+    addDoraCustomWidget(node, widget);
   });
 
   const wAdd = node.addWidget("button", "add_lora", "Add LoRA");
@@ -1722,12 +1750,10 @@ function buildUI(node, state, loraValues) {
   );
   wAutoStrengthCeiling.label = "Auto-strength ratio ceiling";
 
-  const wAutoStrengthReport = new DoraAutoStrengthReportWidget("auto_strength_visualization", node);
-  if (typeof node.addCustomWidget === "function") {
-    node.addCustomWidget(wAutoStrengthReport);
-  } else {
-    node.widgets.push(wAutoStrengthReport);
-  }
+  const wAutoStrengthReport = addDoraCustomWidget(
+    node,
+    new DoraAutoStrengthReportWidget("auto_strength_visualization", node)
+  );
   wAutoStrengthReport.serialize = false;
 
   const size = node.computeSize();


### PR DESCRIPTION
## Summary

- preserve the LoRA-row and auto-strength custom widgets' prototype-defined behavior across current frontend widget normalization
- keep classic/older frontend behavior and the existing property-backed loader state unchanged
- add a regression harness that destroys the widgets' prototypes exactly as the failing frontend path does, then verifies loaded names, strengths, sizing, drawing, pointer hooks, picker hooks, and serialization
- prepare the v1.0.43 hotfix release

## Root cause

ComfyUI frontend commit [`517489b`](https://github.com/Comfy-Org/ComfyUI_frontend/commit/517489bb4e30db92a585926967fc0bfb19ba87eb) normalizes `addCustomWidget()` inputs by replacing an extensible extension object's prototype with `LegacyWidget.prototype`. The loader's `DoraLoraRowWidget` and `DoraAutoStrengthReportWidget` behavior lives on their class prototypes, so registration removes `draw`, `computeSize`, `mouse`, and the methods they call. Loader state remains present while the node renders blank reserved space.

The frontend's proposed [ADR 0023](https://github.com/Comfy-Org/ComfyUI_frontend/blob/main/docs/adr/0023-widget-entities-and-legacy-behavior-boundary.md) now defines prototype preservation as the intended compatibility contract, though master does not implement that adapter yet. This hotfix materializes only these two widgets' existing prototype methods as non-enumerable own methods before registration.

## Validation

- `node --test tests/test_frontend_state_persistence.mjs tests/test_frontend_widget_compatibility.mjs tests/test_state_manager_frontend.mjs` — 30 passed
- `python -m pytest -q tests/test_state_manager_store.py` from the CI-style external test directory — 17 passed
- all frontend files pass `node --check`
- Python sources pass `py_compile`
- v1.0.43 wheel builds successfully
- `git diff --check` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed compatibility with newer ComfyUI frontends so DoRA row and auto-strength widgets continue to draw correctly, resize, respond to pointer and picker interactions, support editing, and serialize their values.
  * Preserved existing widget behavior on classic and older frontend versions.
  * Verified that loaded LoRA names and strength values remain visible and interactive.

* **Release**
  * Updated the DoRA Dynamic LoRA Loader to version 1.0.43.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->