### PR TITLE
Fix LoRA row interaction on current frontend

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,19 @@
+# DoRA Dynamic LoRA Loader v1.0.44
+
+This hotfix restores LoRA-row interaction on current ComfyUI frontend main when the displayed rows survive a dynamic loader rebuild.
+
+## Stable custom-widget lifetime
+
+- Keeps each existing LoRA row widget object stable across the loader's immediate build, asynchronous LoRA-list refresh, Add LoRA rebuilds, and other same-name UI rebuilds.
+- Rebinds a reused row widget to the newly sanitized canonical row state instead of leaving the frontend bound to an orphaned row object.
+- Keeps the auto-strength visualization widget identity stable for the same frontend lifecycle.
+- Prevents the v1.0.43 prototype-compatibility preparation from running again after a widget has already been normalized by the frontend.
+- Adds a regression that captures the row object before the asynchronous refresh, requires the same object afterward, verifies a click updates canonical loader state, and verifies Add LoRA creates the next row without replacing the existing row object.
+
+## Root cause
+
+Current Vue legacy-widget rendering binds the live custom-widget object when its component mounts and keeps that object while the stable WidgetId/type render key remains unchanged. The loader rebuilt its UI after fetching the LoRA list and created a new `LORA_1` object under the same widget identity. The frontend therefore continued drawing and dispatching pointer events to the old object while the node's live widget list and canonical row state belonged to the replacement object.
+
 # DoRA Dynamic LoRA Loader v1.0.43
 
 This hotfix restores the loaded LoRA row controls on current ComfyUI frontend master while preserving compatibility with older frontends.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "dora-dynamic-lora-loader"
 description = "A ComfyUI custom node that loads and stacks regular LoRAs and DoRA LoRAs with Flux/Flux2 and OneTrainer compatibility fixes."
-version = "1.0.43"
+version = "1.0.44"
 license = { file = "LICENSE" }
 
 [project.urls]

--- a/tests/test_frontend_widget_compatibility.mjs
+++ b/tests/test_frontend_widget_compatibility.mjs
@@ -133,7 +133,7 @@ function makeNodeType() {
   return FakeNode;
 }
 
-test("current frontend prototype normalization preserves DoRA custom widget behavior", async () => {
+test("frontend normalization and rebuilds preserve live DoRA custom widget behavior", async () => {
   const { cleanup, extension } = await loadLoaderExtension();
   try {
     const NodeType = makeNodeType();
@@ -144,6 +144,22 @@ test("current frontend prototype normalization preserves DoRA custom widget beha
 
     const node = new NodeType();
     node.onNodeCreated();
+
+    // Current Vue legacy-widget rendering binds the live widget instance on
+    // mount and keeps that object while the WidgetId/type render key is stable.
+    // Capture the first-build instances before fetchLoras() completes so the
+    // test detects a same-name replacement during the async refresh.
+    const initiallyBoundRowWidget = node.widgets.find((widget) => widget.name === "LORA_1");
+    const initiallyBoundReportWidget = node.widgets.find(
+      (widget) => widget.name === "auto_strength_visualization"
+    );
+    assert.ok(initiallyBoundRowWidget, "initial LoRA row widget should be registered");
+    assert.ok(initiallyBoundReportWidget, "initial auto-strength report should be registered");
+    let reboundDraws = 0;
+    initiallyBoundRowWidget.triggerDraw = () => {
+      reboundDraws += 1;
+    };
+
     await new Promise((resolve) => setImmediate(resolve));
 
     const rowWidget = node.widgets.find((widget) => widget.name === "LORA_1");
@@ -152,6 +168,17 @@ test("current frontend prototype normalization preserves DoRA custom widget beha
     );
 
     assert.ok(rowWidget, "LoRA row widget should be registered");
+    assert.strictEqual(
+      rowWidget,
+      initiallyBoundRowWidget,
+      "async LoRA refresh must preserve the live row widget object"
+    );
+    assert.strictEqual(
+      reportWidget,
+      initiallyBoundReportWidget,
+      "async LoRA refresh must preserve the live report widget object"
+    );
+    assert.ok(reboundDraws >= 1, "async rebuild should redraw the reused Vue-bound row");
     assert.equal(Object.getPrototypeOf(rowWidget), Object.prototype);
     assert.equal(rowWidget.computeSize(360)[1], 24);
     assert.equal(typeof rowWidget.draw, "function");
@@ -169,6 +196,31 @@ test("current frontend prototype normalization preserves DoRA custom widget beha
     rowWidget.draw(context, node, 360, 0, 24);
     assert.ok(context.labels.includes("loaded.safetensors"));
     assert.ok(context.labels.includes("0.85"));
+
+    const pointerDown = {
+      button: 0,
+      preventDefault() {},
+      stopPropagation() {},
+      type: "pointerdown",
+    };
+    assert.equal(rowWidget.mouse(pointerDown, [30, 12], node), true);
+    assert.equal(
+      node.properties.dora_power_lora.rows[0].enabled,
+      false,
+      "a click delivered to the originally bound row must update canonical live state"
+    );
+
+    const rowBeforeAdd = rowWidget;
+    const addWidget = node.widgets.find((widget) => widget.name === "add_lora");
+    assert.equal(typeof addWidget?.callback, "function");
+    addWidget.callback();
+    assert.equal(node.properties.dora_power_lora.rows.length, 2);
+    assert.ok(node.widgets.some((widget) => widget.name === "LORA_2"));
+    assert.strictEqual(
+      node.widgets.find((widget) => widget.name === "LORA_1"),
+      rowBeforeAdd,
+      "Add LoRA rebuild must keep the existing row widget object live"
+    );
 
     assert.ok(reportWidget, "auto-strength report widget should be registered");
     assert.equal(Object.getPrototypeOf(reportWidget), Object.prototype);

--- a/web/dora_power_lora_loader.js
+++ b/web/dora_power_lora_loader.js
@@ -737,7 +737,12 @@ function setButtonCallback(widget, cb) {
   widget.options.callback = cb;
 }
 
+const DORA_CUSTOM_WIDGET_KIND = "__doraDynamicLoraWidgetKind";
+const DORA_CUSTOM_WIDGET_METHODS_PREPARED = "__doraDynamicLoraMethodsPrepared";
+
 function preserveCustomWidgetPrototypeMethods(widget) {
+  if (!widget || widget[DORA_CUSTOM_WIDGET_METHODS_PREPARED]) return widget;
+
   let prototype = Object.getPrototypeOf(widget);
   while (prototype && prototype !== Object.prototype) {
     for (const [name, descriptor] of Object.entries(Object.getOwnPropertyDescriptors(prototype))) {
@@ -757,7 +762,27 @@ function preserveCustomWidgetPrototypeMethods(widget) {
     }
     prototype = Object.getPrototypeOf(prototype);
   }
+  Object.defineProperty(widget, DORA_CUSTOM_WIDGET_METHODS_PREPARED, {
+    configurable: true,
+    enumerable: false,
+    value: true,
+  });
   return widget;
+}
+
+function collectReusableDoraCustomWidgets(node) {
+  const rows = new Map();
+  let report = null;
+  for (const widget of Array.isArray(node?.widgets) ? node.widgets : []) {
+    if (!widget || widget.parentNode !== node) continue;
+    const kind = widget[DORA_CUSTOM_WIDGET_KIND];
+    if (kind === "lora-row") {
+      rows.set(String(widget.name ?? ""), widget);
+    } else if (kind === "auto-strength-report") {
+      report = widget;
+    }
+  }
+  return { rows, report };
 }
 
 function addDoraCustomWidget(node, widget) {
@@ -784,6 +809,11 @@ class DoraLoraRowWidget {
     this.name = name;
     this.type = "custom";
     this.parentNode = parentNode;
+    Object.defineProperty(this, DORA_CUSTOM_WIDGET_KIND, {
+      configurable: true,
+      enumerable: false,
+      value: "lora-row",
+    });
     this.row = row;
     this.last_y = 0;
     this._drag = null;
@@ -1217,6 +1247,11 @@ class DoraAutoStrengthReportWidget {
     this.name = name;
     this.type = "custom";
     this.parentNode = parentNode;
+    Object.defineProperty(this, DORA_CUSTOM_WIDGET_KIND, {
+      configurable: true,
+      enumerable: false,
+      value: "auto-strength-report",
+    });
     this.last_y = 0;
     this.hitAreas = [];
     this.hoverAreas = [];
@@ -1524,6 +1559,7 @@ class DoraAutoStrengthReportWidget {
 
 function buildUI(node, state, loraValues) {
   const st = sanitizeState(state);
+  const reusableCustomWidgets = collectReusableDoraCustomWidgets(node);
   clearCanvasTooltip();
   setState(node, st);
   removeAllWidgets(node);
@@ -1548,7 +1584,10 @@ function buildUI(node, state, loraValues) {
   wStateSlot.label = "State slot";
 
   node._doraRows.forEach((row, i) => {
-    const widget = new DoraLoraRowWidget(`LORA_${i + 1}`, node, row);
+    const name = `LORA_${i + 1}`;
+    const widget = reusableCustomWidgets.rows.get(name) || new DoraLoraRowWidget(name, node, row);
+    widget.parentNode = node;
+    widget.row = row;
     addDoraCustomWidget(node, widget);
   });
 
@@ -1750,10 +1789,10 @@ function buildUI(node, state, loraValues) {
   );
   wAutoStrengthCeiling.label = "Auto-strength ratio ceiling";
 
-  const wAutoStrengthReport = addDoraCustomWidget(
-    node,
-    new DoraAutoStrengthReportWidget("auto_strength_visualization", node)
-  );
+  const autoStrengthReportWidget =
+    reusableCustomWidgets.report || new DoraAutoStrengthReportWidget("auto_strength_visualization", node);
+  autoStrengthReportWidget.parentNode = node;
+  const wAutoStrengthReport = addDoraCustomWidget(node, autoStrengthReportWidget);
   wAutoStrengthReport.serialize = false;
 
   const size = node.computeSize();
@@ -1764,6 +1803,9 @@ function buildUI(node, state, loraValues) {
   node.min_size = minSize;
   node.size[0] = Math.max(node.size[0], size[0], minWidth);
   syncNodeHeightToContent(node);
+  for (const widget of Array.isArray(node.widgets) ? node.widgets : []) {
+    if (widget?.[DORA_CUSTOM_WIDGET_KIND]) widget.triggerDraw?.();
+  }
 }
 
 installGlobalStateApi();


### PR DESCRIPTION
## Summary

- preserve the live `LORA_n` custom-widget object across same-name loader rebuilds
- rebind reused row widgets to the newly sanitized canonical row state
- preserve the auto-strength report widget object across the same lifecycle
- prevent the v1.0.43 prototype compatibility preparation from being repeated on already-normalized reused widgets
- add regression coverage for the initial asynchronous LoRA refresh, canonical click persistence, and Add LoRA rebuild behavior
- prepare v1.0.44

## Root cause

Current ComfyUI frontend main renders legacy custom widgets through a stable `WidgetId:type` key. `WidgetLegacy.vue` resolves the live widget object when it binds and retains that object while the component stays mounted.

The loader performs an immediate UI build and then a second build after the asynchronous LoRA-list fetch. Before this fix, the second build created a new `LORA_1` object under the same widget identity. The Vue component therefore remained bound to the old object while the node's live widget list and canonical `_doraRows` state belonged to the replacement object. The old row could still draw the same LoRA, but pointer actions mutated an orphaned row and were discarded by canonical persistence.

## Invariant

For a stable legacy custom-widget identity, the loader must keep the same live widget object for as long as the frontend may keep the corresponding component mounted.

## Regression coverage

The frontend compatibility harness now:
- captures `LORA_1` and the report widget before `fetchLoras()` completes
- requires strict object identity after the asynchronous rebuild
- delivers a real pointer-down to the originally bound row and verifies canonical property state changes
- invokes Add LoRA and verifies `LORA_2` is created while `LORA_1` keeps the same object identity

The existing prototype-normalization coverage remains in place for the v1.0.43 compatibility boundary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored interaction with LoRA rows on the latest ComfyUI frontend.
  * Preserved LoRA row behavior and state during asynchronous refreshes and when adding LoRAs.
  * Prevented custom widget interactions from becoming unresponsive after dynamic UI updates.

* **Tests**
  * Added regression coverage for widget interactions, refreshes, and rebuilding the LoRA list.

* **Release**
  * Updated DoRA Dynamic LoRA Loader to version 1.0.44.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->