### PR TITLE
Fix bidirectional State Manager / DoRA loader synchronization

### DIFF
--- a/tests/test_frontend_widget_compatibility.mjs
+++ b/tests/test_frontend_widget_compatibility.mjs
@@ -31,6 +31,8 @@ async function loadLoaderExtension() {
   let extension = null;
   const previousFetch = globalThis.fetch;
   const previousLiteGraph = globalThis.LiteGraph;
+  const previousStateManagerSyncApi = globalThis.__doraStateManagerSyncApi;
+  const syncCalls = [];
 
   globalThis.fetch = async () => ({
     ok: true,
@@ -49,6 +51,12 @@ async function loadLoaderExtension() {
   globalThis.__doraWidgetCompatibilityTestApi = {
     addEventListener() {},
   };
+  globalThis.__doraStateManagerSyncApi = {
+    loaderStateChanged(node, details = {}) {
+      syncCalls.push({ node, details });
+      return 1;
+    },
+  };
 
   source = source
     .replace(
@@ -65,6 +73,8 @@ async function loadLoaderExtension() {
     delete globalThis.__doraWidgetCompatibilityTestApi;
     globalThis.fetch = previousFetch;
     globalThis.LiteGraph = previousLiteGraph;
+    if (previousStateManagerSyncApi === undefined) delete globalThis.__doraStateManagerSyncApi;
+    else globalThis.__doraStateManagerSyncApi = previousStateManagerSyncApi;
   };
 
   try {
@@ -76,7 +86,7 @@ async function loadLoaderExtension() {
   }
 
   assert.ok(extension, "loader extension should register");
-  return { cleanup, extension };
+  return { cleanup, extension, syncCalls };
 }
 
 function makeNodeType() {
@@ -228,6 +238,52 @@ test("frontend normalization and rebuilds preserve live DoRA custom widget behav
     assert.equal(typeof reportWidget.draw, "function");
     assert.equal(typeof reportWidget.mouse, "function");
     assert.equal(typeof reportWidget._displayRows, "function");
+  } finally {
+    cleanup();
+  }
+});
+
+
+test("loader-owned settings debounce continuous edits while discrete slot changes stay immediate", async () => {
+  const { cleanup, extension, syncCalls } = await loadLoaderExtension();
+  try {
+    const NodeType = makeNodeType();
+    await extension.beforeRegisterNodeDef(NodeType, {
+      display_name: NODE_CLASS,
+      name: NODE_CLASS,
+    });
+
+    const node = new NodeType();
+    node.onNodeCreated();
+    await new Promise((resolve) => setImmediate(resolve));
+    await new Promise((resolve) => setTimeout(resolve, 180));
+    syncCalls.length = 0;
+
+    const autoStrength = node.widgets.find((widget) => widget.name === "auto_strength_enabled");
+    assert.equal(typeof autoStrength?.callback, "function");
+    autoStrength.callback(true);
+    autoStrength.callback(false);
+    autoStrength.callback(true);
+    assert.equal(node.properties.dora_power_lora.globals.auto_strength_enabled, true);
+    assert.equal(syncCalls.length, 0, "continuous loader edits should be coalesced before notifying State Manager");
+
+    await new Promise((resolve) => setTimeout(resolve, 180));
+    assert.equal(syncCalls.length, 1);
+    assert.strictEqual(syncCalls[0]?.node, node);
+
+    const stateSlot = node.widgets.find((widget) => widget.name === "state_slot");
+    assert.equal(typeof stateSlot?.callback, "function");
+    stateSlot.callback("character_style");
+    assert.equal(node.properties.dora_state_slot, "character_style");
+    assert.equal(syncCalls.length, 2, "State slot identity changes should synchronize immediately");
+    assert.strictEqual(syncCalls.at(-1)?.node, node);
+    assert.equal(syncCalls.at(-1)?.details?.previousSlot, "loader_42");
+
+    autoStrength.callback(false);
+    assert.equal(syncCalls.length, 2);
+    node.onRemoved?.();
+    await new Promise((resolve) => setTimeout(resolve, 180));
+    assert.equal(syncCalls.length, 2, "removing the loader must cancel a pending debounced notification");
   } finally {
     cleanup();
   }

--- a/tests/test_state_manager_frontend.mjs
+++ b/tests/test_state_manager_frontend.mjs
@@ -10,7 +10,7 @@ async function loadStateManagerHelpers() {
     .replace('import { app } from "../../scripts/app.js";', "let capturedExtension = null; const app = { registerExtension(value) { capturedExtension = value; }, graph: { extra: {} } };")
     .replace('import { api } from "../../scripts/api.js";', "const api = { fetchApi() { throw new Error('not used'); }, apiURL(value) { return value; } };")
     .replace('import "../../scripts/domWidget.js";', "");
-  source += `\nexport { capturedExtension, defaultBinding, defaultState, deletePromptPreset, deleteStateCharacter, makeId, materializeEditedDefault, mergeScheduledLibraryUpdate, persistentCharacters, serializeBinding, serializeWorkflowUiState, serializeQueuedUiStateOverride, parseLegacyEmbeddedState, stateLibraryClient, stateViewForSelection };\n`;
+  source += `\nexport { capturedExtension, defaultBinding, defaultState, deletePromptPreset, deleteStateCharacter, makeId, materializeEditedDefault, mergeScheduledLibraryUpdate, persistentCharacters, serializeBinding, serializeWorkflowUiState, serializeQueuedUiStateOverride, parseLegacyEmbeddedState, stateLibraryClient, stateViewForSelection, syncCharacterLoaderStacksToConnectedNodes, syncConnectedLoaderStateIntoManager, synchronizeConnectedLoadersAfterLibraryLoad, restoreNodeAndConnectedLoadersFromLibrary, normalizeLoaderGlobals, pickPrimarySettingsLoaderStack, refreshAllNodesFromLibrary };\n`;
   const encoded = Buffer.from(source, "utf8").toString("base64");
   return import(`data:text/javascript;base64,${encoded}#${Date.now()}-${Math.random()}`);
 }
@@ -330,8 +330,9 @@ test("browser persistence code cannot resurrect a private library", async () => 
   assert.equal(source.includes("setWidgetValue(widgets.uiStateWidget, serializeUiState"), false);
   const stashIndex = source.indexOf("node.__dsmPendingLegacyState = structuredCloneCompat(embeddedLegacy)");
   const scrubIndex = source.indexOf("setWidgetValue(currentWidgets.stateWidget, serializeBinding())");
-  const successIndex = source.indexOf("if (loaded) delete node.__dsmPendingLegacyState");
+  const successIndex = source.indexOf("delete node.__dsmPendingLegacyState;");
   assert.ok(stashIndex >= 0 && scrubIndex > stashIndex && successIndex > scrubIndex);
+  assert.match(source, /if \(loaded\) \{[\s\S]*delete node\.__dsmPendingLegacyState;/);
   assert.match(source, /this\.__dsmPendingLegacyState\s*\?\s*serializeState\(this\.__dsmPendingLegacyState\)/);
 });
 
@@ -347,5 +348,690 @@ test("queued library values never synchronize into the workflow copy", async () 
 test("blocked writes clear pending work and restore the persisted view", async () => {
   const source = await readFile(new URL("../web/dora_state_manager.js", import.meta.url), "utf8");
   assert.match(source, /function blockLibraryWrites[\s\S]*stateLibraryClient\.pending = \[\]/);
-  assert.match(source, /if \(stateLibraryClient\.blocked\) \{[\s\S]*refreshNodeFromLibrary\(node/);
+  assert.match(source, /function blockLibraryWrites[\s\S]*restoreNodeAndConnectedLoadersFromLibrary\(node/);
+  assert.match(source, /if \(stateLibraryClient\.blocked\) \{[\s\S]*restoreNodeAndConnectedLoadersFromLibrary\(node/);
+});
+
+
+function makeConnectedManagerAndLoader(helpers, character) {
+  const manager = {
+    id: 1,
+    comfyClass: "State Manager",
+    outputs: [{ name: "state_control", links: [100] }],
+    properties: {},
+    widgets: [
+      { name: "state_json", value: helpers.serializeBinding() },
+      { name: "ui_state_json", value: helpers.serializeWorkflowUiState({}) },
+      { name: "selected_character_id", value: character.id },
+      { name: "selected_prompt_id", value: character.prompts[0].id },
+    ],
+    __dsm: {
+      state: { version: 2, characters: [structuredClone(character)] },
+      uiState: {},
+    },
+    setDirtyCanvas() {},
+  };
+  const loader = {
+    id: 2,
+    comfyClass: "DoRA Power LoRA Loader",
+    title: "DoRA Power LoRA Loader",
+    inputs: [{ name: "state_control" }],
+    properties: { dora_state_slot: "default" },
+    widgets: [{ name: "state_slot", value: "default" }],
+    setDirtyCanvas() {},
+  };
+  const graph = {
+    links: {
+      100: { origin_id: 1, origin_slot: 0, target_id: 2, target_slot: 0 },
+    },
+    getNodeById(id) {
+      if (id === manager.id) return manager;
+      if (id === loader.id) return loader;
+      return null;
+    },
+    change() {},
+  };
+  manager.graph = graph;
+  loader.graph = graph;
+  return { manager, loader };
+}
+
+
+test("connected loader edits replace the selected State Manager stack immediately", async () => {
+  const helpers = await loadStateManagerHelpers();
+  const character = privateCharacter("character-a", "A", "A0");
+  character.loader_stacks = [{
+    slot: "default",
+    label: "Default loader",
+    loras: [{
+      enabled: true,
+      name: "old.safetensors",
+      strength_model: 1.0,
+      strength_clip: 1.0,
+    }],
+    loader_globals: {
+      auto_strength_enabled: false,
+      auto_strength_device: "gpu",
+      auto_strength_ratio_floor: 0.3,
+      auto_strength_ratio_ceiling: 1.5,
+    },
+  }];
+  character.loras = structuredClone(character.loader_stacks[0].loras);
+  character.loader_globals = structuredClone(character.loader_stacks[0].loader_globals);
+  const { manager, loader } = makeConnectedManagerAndLoader(helpers, character);
+
+  const previousLoaderApi = globalThis.__doraPowerLoraLoaderApi;
+  globalThis.__doraPowerLoraLoaderApi = {
+    getSlot() {
+      return "default";
+    },
+    getState() {
+      return {
+        slot: "default",
+        label: "Default loader",
+        rows: [{
+          enabled: true,
+          name: "h3-character.safetensors",
+          strengthModel: 0.82,
+          strengthClip: 0.61,
+        }],
+        globals: {
+          auto_strength_enabled: true,
+          auto_strength_device: "cpu",
+          auto_strength_ratio_floor: 0.44,
+          auto_strength_ratio_ceiling: 1.91,
+        },
+      };
+    },
+  };
+
+  try {
+    const changed = helpers.syncConnectedLoaderStateIntoManager(
+      manager,
+      loader,
+      { persist: false, render: false, dirty: false },
+    );
+    assert.equal(changed, 1);
+
+    const savedCharacter = manager.__dsm.state.characters.find((item) => item.id === "character-a");
+    const savedStack = savedCharacter.loader_stacks.find((item) => item.slot === "default");
+    assert.equal(savedStack.loader_globals.auto_strength_enabled, true);
+    assert.equal(savedStack.loader_globals.auto_strength_device, "cpu");
+    assert.equal(savedStack.loader_globals.auto_strength_ratio_floor, 0.44);
+    assert.equal(savedStack.loader_globals.auto_strength_ratio_ceiling, 1.91);
+    assert.equal(savedStack.loras[0].name, "h3-character.safetensors");
+    assert.equal(savedStack.loras[0].strength_model, 0.82);
+    assert.equal(savedStack.loras[0].strength_clip, 0.61);
+  } finally {
+    if (previousLoaderApi === undefined) delete globalThis.__doraPowerLoraLoaderApi;
+    else globalThis.__doraPowerLoraLoaderApi = previousLoaderApi;
+  }
+});
+
+
+test("State Manager loader edits are pushed into the matching loader without a sync loop", async () => {
+  const helpers = await loadStateManagerHelpers();
+  const character = privateCharacter("character-a", "A", "A0");
+  character.loader_stacks = [{
+    slot: "default",
+    label: "Default loader",
+    loras: [{
+      enabled: true,
+      name: "saved.safetensors",
+      strength_model: 0.73,
+      strength_clip: 0.52,
+    }],
+    loader_globals: {
+      auto_strength_enabled: true,
+      auto_strength_device: "gpu",
+      auto_strength_ratio_floor: 0.41,
+      auto_strength_ratio_ceiling: 1.77,
+    },
+  }];
+  character.loras = structuredClone(character.loader_stacks[0].loras);
+  character.loader_globals = structuredClone(character.loader_stacks[0].loader_globals);
+  const { manager, loader } = makeConnectedManagerAndLoader(helpers, character);
+
+  const calls = [];
+  const previousLoaderApi = globalThis.__doraPowerLoraLoaderApi;
+  globalThis.__doraPowerLoraLoaderApi = {
+    getSlot() {
+      return "default";
+    },
+    setSlot(node, slot, options) {
+      calls.push({ kind: "slot", node, slot, options });
+      node.properties.dora_state_slot = slot;
+      return slot;
+    },
+    setState(node, payload, options) {
+      calls.push({ kind: "state", node, payload: structuredClone(payload), options });
+      return true;
+    },
+  };
+
+  try {
+    const changed = helpers.syncCharacterLoaderStacksToConnectedNodes(manager, character, "default");
+    assert.equal(changed, 1);
+    const stateCall = calls.find((call) => call.kind === "state");
+    assert.ok(stateCall);
+    assert.equal(stateCall.payload.loader_globals.auto_strength_enabled, true);
+    assert.equal(stateCall.payload.loader_globals.auto_strength_ratio_floor, 0.41);
+    assert.equal(stateCall.payload.loras[0].strength_model, 0.73);
+    assert.deepEqual(stateCall.options, { notifyStateManager: false });
+
+    assert.equal(
+      calls.some((call) => call.kind === "slot"),
+      false,
+      "same-slot State Manager edits must not rebuild the loader just to rewrite its slot"
+    );
+  } finally {
+    if (previousLoaderApi === undefined) delete globalThis.__doraPowerLoraLoaderApi;
+    else globalThis.__doraPowerLoraLoaderApi = previousLoaderApi;
+  }
+});
+
+
+test("loader-side State slot rename moves the saved stack identity instead of duplicating it", async () => {
+  const helpers = await loadStateManagerHelpers();
+  const character = privateCharacter("character-a", "A", "A0");
+  character.loader_stacks = [{
+    slot: "default",
+    label: "Default loader",
+    loras: [{ enabled: true, name: "old.safetensors", strength_model: 1.0, strength_clip: 1.0 }],
+    loader_globals: { auto_strength_enabled: false },
+  }];
+  character.loras = structuredClone(character.loader_stacks[0].loras);
+  character.loader_globals = structuredClone(character.loader_stacks[0].loader_globals);
+  const { manager, loader } = makeConnectedManagerAndLoader(helpers, character);
+  loader.properties.dora_state_slot = "style";
+  loader.widgets[0].value = "style";
+
+  const previousLoaderApi = globalThis.__doraPowerLoraLoaderApi;
+  globalThis.__doraPowerLoraLoaderApi = {
+    getSlot(node) {
+      return node.properties.dora_state_slot;
+    },
+    getState(node) {
+      return {
+        slot: node.properties.dora_state_slot,
+        label: "Style",
+        rows: [{
+          enabled: true,
+          name: "style.safetensors",
+          strengthModel: 0.66,
+          strengthClip: 0.55,
+        }],
+        globals: {
+          auto_strength_enabled: true,
+          auto_strength_device: "gpu",
+          auto_strength_ratio_floor: 0.4,
+          auto_strength_ratio_ceiling: 1.8,
+        },
+      };
+    },
+  };
+
+  try {
+    const changed = helpers.syncConnectedLoaderStateIntoManager(
+      manager,
+      loader,
+      { persist: false, render: false, dirty: false, previousSlot: "default" },
+    );
+    assert.equal(changed, 1);
+    const savedCharacter = manager.__dsm.state.characters.find((item) => item.id === "character-a");
+    assert.equal(savedCharacter.loader_stacks.length, 1);
+    assert.equal(savedCharacter.loader_stacks[0].slot, "style");
+    assert.equal(savedCharacter.loader_stacks[0].loras[0].name, "style.safetensors");
+    assert.equal(savedCharacter.loader_stacks[0].loader_globals.auto_strength_enabled, true);
+    assert.equal(savedCharacter.loader_stacks.some((item) => item.slot === "default"), false);
+  } finally {
+    if (previousLoaderApi === undefined) delete globalThis.__doraPowerLoraLoaderApi;
+    else globalThis.__doraPowerLoraLoaderApi = previousLoaderApi;
+  }
+});
+
+
+test("loader-side State slot collision is visibly reverted without overwriting either saved stack", async () => {
+  const helpers = await loadStateManagerHelpers();
+  const character = privateCharacter("character-a", "A", "A0");
+  character.loader_stacks = [
+    {
+      slot: "default",
+      label: "Default loader",
+      loras: [{ enabled: true, name: "default-old.safetensors", strength_model: 1.0, strength_clip: 1.0 }],
+      loader_globals: { auto_strength_enabled: false },
+    },
+    {
+      slot: "style",
+      label: "Existing style",
+      loras: [{ enabled: true, name: "existing-style.safetensors", strength_model: 0.4, strength_clip: 0.4 }],
+      loader_globals: { auto_strength_enabled: false },
+    },
+  ];
+  character.loras = structuredClone(character.loader_stacks[0].loras);
+  character.loader_globals = structuredClone(character.loader_stacks[0].loader_globals);
+  const { manager, loader } = makeConnectedManagerAndLoader(helpers, character);
+  loader.properties.dora_state_slot = "style";
+  loader.widgets[0].value = "style";
+
+  const setSlotCalls = [];
+  const previousLoaderApi = globalThis.__doraPowerLoraLoaderApi;
+  globalThis.__doraPowerLoraLoaderApi = {
+    getSlot(node) {
+      return node.properties.dora_state_slot;
+    },
+    getState(node) {
+      return {
+        slot: node.properties.dora_state_slot,
+        label: "Renamed loader",
+        rows: [{
+          enabled: true,
+          name: "live-loader.safetensors",
+          strengthModel: 0.77,
+          strengthClip: 0.68,
+        }],
+        globals: { auto_strength_enabled: true },
+      };
+    },
+    setSlot(node, slot, options) {
+      setSlotCalls.push({ slot, options });
+      node.properties.dora_state_slot = slot;
+      node.widgets[0].value = slot;
+      return slot;
+    },
+  };
+
+  try {
+    const changed = helpers.syncConnectedLoaderStateIntoManager(
+      manager,
+      loader,
+      { persist: false, render: false, dirty: false, previousSlot: "default" },
+    );
+    assert.equal(changed, 1);
+    assert.equal(loader.properties.dora_state_slot, "default");
+    assert.deepEqual(setSlotCalls, [{
+      slot: "default",
+      options: { notifyStateManager: false },
+    }]);
+
+    const savedCharacter = manager.__dsm.state.characters.find((item) => item.id === "character-a");
+    const defaultStack = savedCharacter.loader_stacks.find((item) => item.slot === "default");
+    const styleStack = savedCharacter.loader_stacks.find((item) => item.slot === "style");
+    assert.equal(defaultStack.loras[0].name, "live-loader.safetensors");
+    assert.equal(defaultStack.loader_globals.auto_strength_enabled, true);
+    assert.equal(styleStack.loras[0].name, "existing-style.safetensors");
+    assert.equal(savedCharacter.loader_stacks.length, 2);
+  } finally {
+    if (previousLoaderApi === undefined) delete globalThis.__doraPowerLoraLoaderApi;
+    else globalThis.__doraPowerLoraLoaderApi = previousLoaderApi;
+  }
+});
+
+
+test("first load of a durable preset applies saved loader state instead of overwriting the preset", async () => {
+  const helpers = await loadStateManagerHelpers();
+  const character = privateCharacter("character-a", "Saved Character", "A0");
+  character.loader_stacks = [{
+    slot: "default",
+    label: "Default loader",
+    loras: [{
+      enabled: true,
+      name: "saved-character.safetensors",
+      strength_model: 0.58,
+      strength_clip: 0.49,
+    }],
+    loader_globals: {
+      auto_strength_enabled: true,
+      auto_strength_device: "cpu",
+      auto_strength_ratio_floor: 0.46,
+      auto_strength_ratio_ceiling: 1.88,
+    },
+  }];
+  character.loras = structuredClone(character.loader_stacks[0].loras);
+  character.loader_globals = structuredClone(character.loader_stacks[0].loader_globals);
+  const { manager, loader } = makeConnectedManagerAndLoader(helpers, character);
+
+  const calls = [];
+  const previousLoaderApi = globalThis.__doraPowerLoraLoaderApi;
+  globalThis.__doraPowerLoraLoaderApi = {
+    getSlot() {
+      return "default";
+    },
+    setSlot(node, slot, options) {
+      calls.push({ kind: "slot", slot, options });
+      node.properties.dora_state_slot = slot;
+      return slot;
+    },
+    setState(node, payload, options) {
+      calls.push({ kind: "state", payload: structuredClone(payload), options });
+      return true;
+    },
+  };
+
+  try {
+    const before = structuredClone(manager.__dsm.state);
+    const changed = helpers.synchronizeConnectedLoadersAfterLibraryLoad(manager);
+    assert.equal(changed, 1);
+    assert.deepEqual(manager.__dsm.state, before, "opening a saved preset must not rewrite its library state");
+
+    const stateCall = calls.find((call) => call.kind === "state");
+    assert.ok(stateCall);
+    assert.equal(stateCall.payload.loras[0].name, "saved-character.safetensors");
+    assert.equal(stateCall.payload.loader_globals.auto_strength_enabled, true);
+    assert.equal(stateCall.payload.loader_globals.auto_strength_device, "cpu");
+    assert.equal(stateCall.payload.loader_globals.auto_strength_ratio_floor, 0.46);
+    assert.deepEqual(stateCall.options, { notifyStateManager: false });
+  } finally {
+    if (previousLoaderApi === undefined) delete globalThis.__doraPowerLoraLoaderApi;
+    else globalThis.__doraPowerLoraLoaderApi = previousLoaderApi;
+  }
+});
+
+
+test("library rollback restores the persisted loader globals into the visible connected loader", async () => {
+  const helpers = await loadStateManagerHelpers();
+  const persisted = privateCharacter("character-a", "A", "A0");
+  persisted.loader_stacks = [{
+    slot: "default",
+    label: "Default loader",
+    loras: [{
+      enabled: true,
+      name: "persisted.safetensors",
+      strength_model: 0.62,
+      strength_clip: 0.51,
+    }],
+    loader_globals: {
+      auto_strength_enabled: false,
+      auto_strength_device: "gpu",
+      auto_strength_ratio_floor: 0.3,
+      auto_strength_ratio_ceiling: 1.5,
+    },
+  }];
+  persisted.loras = structuredClone(persisted.loader_stacks[0].loras);
+  persisted.loader_globals = structuredClone(persisted.loader_stacks[0].loader_globals);
+  helpers.stateLibraryClient.state = { version: 2, characters: [structuredClone(persisted)] };
+
+  const unpersisted = structuredClone(persisted);
+  unpersisted.loader_stacks[0].loras[0].name = "unpersisted.safetensors";
+  unpersisted.loader_stacks[0].loader_globals.auto_strength_enabled = true;
+  unpersisted.loader_globals = structuredClone(unpersisted.loader_stacks[0].loader_globals);
+  unpersisted.loras = structuredClone(unpersisted.loader_stacks[0].loras);
+  const { manager, loader } = makeConnectedManagerAndLoader(helpers, unpersisted);
+
+  const calls = [];
+  const previousLoaderApi = globalThis.__doraPowerLoraLoaderApi;
+  const previousRaf = globalThis.requestAnimationFrame;
+  globalThis.requestAnimationFrame = () => 1;
+  globalThis.__doraPowerLoraLoaderApi = {
+    getSlot() {
+      return "default";
+    },
+    setSlot(node, slot, options) {
+      calls.push({ kind: "slot", slot, options });
+      node.properties.dora_state_slot = slot;
+      return slot;
+    },
+    setState(node, payload, options) {
+      calls.push({ kind: "state", payload: structuredClone(payload), options });
+      return true;
+    },
+  };
+
+  try {
+    const changed = helpers.restoreNodeAndConnectedLoadersFromLibrary(manager, {
+      status: "Library write rejected.",
+    });
+    assert.equal(changed, 1);
+
+    const restoredCharacter = manager.__dsm.state.characters.find((item) => item.id === "character-a");
+    assert.equal(restoredCharacter.loader_stacks[0].loras[0].name, "persisted.safetensors");
+    assert.equal(restoredCharacter.loader_stacks[0].loader_globals.auto_strength_enabled, false);
+
+    const stateCall = calls.find((call) => call.kind === "state");
+    assert.ok(stateCall);
+    assert.equal(stateCall.payload.loras[0].name, "persisted.safetensors");
+    assert.equal(stateCall.payload.loader_globals.auto_strength_enabled, false);
+    assert.deepEqual(stateCall.options, { notifyStateManager: false });
+  } finally {
+    if (previousLoaderApi === undefined) delete globalThis.__doraPowerLoraLoaderApi;
+    else globalThis.__doraPowerLoraLoaderApi = previousLoaderApi;
+    if (previousRaf === undefined) delete globalThis.requestAnimationFrame;
+    else globalThis.requestAnimationFrame = previousRaf;
+  }
+});
+
+
+test("untouched default loader state does not materialize a persistent preset on first load", async () => {
+  const helpers = await loadStateManagerHelpers();
+  const character = helpers.defaultState().characters[0];
+  const { manager } = makeConnectedManagerAndLoader(helpers, character);
+
+  const previousLoaderApi = globalThis.__doraPowerLoraLoaderApi;
+  globalThis.__doraPowerLoraLoaderApi = {
+    getSlot() {
+      return "default";
+    },
+    getState() {
+      return {
+        slot: "default",
+        label: "Default loader",
+        rows: [{ enabled: true, name: "None", strengthModel: 1.0, strengthClip: 1.0 }],
+        globals: {
+          stack_enabled: true,
+          verbose: false,
+          log_unloaded_keys: false,
+          broadcast_auto_scale: true,
+          broadcast_modulations: true,
+          broadcast_include_dora_scale: false,
+          broadcast_scale: 1.0,
+          dora_decompose_debug: false,
+          dora_decompose_debug_n: 30,
+          dora_decompose_debug_stack_depth: 10,
+          dora_slice_fix: true,
+          dora_adaln_swap_fix: true,
+          zimage_lumina2_compat: true,
+          auto_strength_enabled: false,
+          auto_strength_device: "gpu",
+          auto_strength_ratio_floor: 0.30,
+          auto_strength_ratio_ceiling: 1.50,
+        },
+      };
+    },
+  };
+
+  try {
+    const changed = helpers.synchronizeConnectedLoadersAfterLibraryLoad(manager);
+    assert.equal(changed, 0);
+    assert.equal(manager.__dsm.state.characters[0].id, "default_character");
+    assert.deepEqual(helpers.persistentCharacters(manager.__dsm.state), []);
+  } finally {
+    if (previousLoaderApi === undefined) delete globalThis.__doraPowerLoraLoaderApi;
+    else globalThis.__doraPowerLoraLoaderApi = previousLoaderApi;
+  }
+});
+
+
+test("State Manager canonicalizes auto-strength ratio bounds with loader semantics", async () => {
+  const helpers = await loadStateManagerHelpers();
+  assert.deepEqual(
+    helpers.normalizeLoaderGlobals({
+      auto_strength_ratio_floor: 2.0,
+      auto_strength_ratio_ceiling: 0.5,
+    }),
+    {
+      auto_strength_ratio_floor: 0.5,
+      auto_strength_ratio_ceiling: 2.0,
+    },
+  );
+  assert.deepEqual(
+    helpers.normalizeLoaderGlobals({
+      auto_strength_ratio_ceiling: 0.2,
+    }),
+    {
+      auto_strength_ratio_floor: 0.2,
+      auto_strength_ratio_ceiling: 0.3,
+    },
+  );
+});
+
+
+test("capturing a named connected loader replaces the unused sole default stack", async () => {
+  const helpers = await loadStateManagerHelpers();
+  const character = privateCharacter("character-a", "A", "A0");
+  character.loader_stacks = [{
+    slot: "default",
+    label: "Default loader",
+    loras: [],
+    loader_globals: {},
+  }];
+  character.loras = [];
+  character.loader_globals = {};
+  const { manager, loader } = makeConnectedManagerAndLoader(helpers, character);
+  loader.properties.dora_state_slot = "loader_207";
+  loader.widgets[0].value = "loader_207";
+
+  const previousLoaderApi = globalThis.__doraPowerLoraLoaderApi;
+  globalThis.__doraPowerLoraLoaderApi = {
+    getSlot(node) {
+      return node.properties.dora_state_slot;
+    },
+    getState(node) {
+      return {
+        slot: node.properties.dora_state_slot,
+        label: "DoRA loader",
+        rows: [{
+          enabled: true,
+          name: "h3.safetensors",
+          strengthModel: 0.9,
+          strengthClip: 0.9,
+        }],
+        globals: { auto_strength_enabled: true },
+      };
+    },
+  };
+
+  try {
+    const changed = helpers.syncConnectedLoaderStateIntoManager(
+      manager,
+      loader,
+      { persist: false, render: false, dirty: false },
+    );
+    assert.equal(changed, 1);
+    const savedCharacter = manager.__dsm.state.characters.find((item) => item.id === "character-a");
+    assert.equal(savedCharacter.loader_stacks.length, 1);
+    assert.equal(savedCharacter.loader_stacks[0].slot, "loader_207");
+    assert.equal(savedCharacter.loader_stacks[0].loader_globals.auto_strength_enabled, true);
+    assert.equal(savedCharacter.loader_stacks[0].loras[0].name, "h3.safetensors");
+  } finally {
+    if (previousLoaderApi === undefined) delete globalThis.__doraPowerLoraLoaderApi;
+    else globalThis.__doraPowerLoraLoaderApi = previousLoaderApi;
+  }
+});
+
+
+test("State Manager settings select the connected loader stack instead of an unused default stack", async () => {
+  const helpers = await loadStateManagerHelpers();
+  const character = privateCharacter("character-a", "A", "A0");
+  character.loader_stacks = [
+    {
+      slot: "default",
+      label: "Unused default",
+      loras: [],
+      loader_globals: { auto_strength_enabled: false },
+    },
+    {
+      slot: "loader_207",
+      label: "Connected loader",
+      loras: [{ enabled: true, name: "h3.safetensors", strength_model: 1.0, strength_clip: 1.0 }],
+      loader_globals: { auto_strength_enabled: true },
+    },
+  ];
+  character.loras = [];
+  character.loader_globals = {};
+  const { manager, loader } = makeConnectedManagerAndLoader(helpers, character);
+  loader.properties.dora_state_slot = "loader_207";
+  loader.widgets[0].value = "loader_207";
+
+  const previousLoaderApi = globalThis.__doraPowerLoraLoaderApi;
+  globalThis.__doraPowerLoraLoaderApi = {
+    getSlot(node) {
+      return node.properties.dora_state_slot;
+    },
+  };
+
+  try {
+    const selected = helpers.pickPrimarySettingsLoaderStack(manager, character);
+    assert.equal(selected.slot, "loader_207");
+    assert.equal(selected.loader_globals.auto_strength_enabled, true);
+  } finally {
+    if (previousLoaderApi === undefined) delete globalThis.__doraPowerLoraLoaderApi;
+    else globalThis.__doraPowerLoraLoaderApi = previousLoaderApi;
+  }
+});
+
+
+test("persistent library refresh updates connected loaders and can skip the writer node", async () => {
+  const helpers = await loadStateManagerHelpers();
+  const persisted = privateCharacter("character-a", "A", "A0");
+  persisted.loader_stacks = [{
+    slot: "default",
+    label: "Default loader",
+    loras: [{ enabled: true, name: "persisted.safetensors", strength_model: 0.7, strength_clip: 0.6 }],
+    loader_globals: { auto_strength_enabled: true },
+  }];
+  persisted.loras = structuredClone(persisted.loader_stacks[0].loras);
+  persisted.loader_globals = structuredClone(persisted.loader_stacks[0].loader_globals);
+  helpers.stateLibraryClient.state = { version: 2, characters: [structuredClone(persisted)] };
+
+  const { manager } = makeConnectedManagerAndLoader(helpers, persisted);
+  helpers.stateLibraryClient.nodes.add(manager);
+
+  const calls = [];
+  const previousLoaderApi = globalThis.__doraPowerLoraLoaderApi;
+  const previousRaf = globalThis.requestAnimationFrame;
+  globalThis.requestAnimationFrame = () => 1;
+  globalThis.__doraPowerLoraLoaderApi = {
+    getSlot() {
+      return "default";
+    },
+    setState(node, payload, options) {
+      calls.push({ payload: structuredClone(payload), options });
+      return true;
+    },
+  };
+
+  try {
+    helpers.refreshAllNodesFromLibrary({ syncLoaders: true });
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].payload.loras[0].name, "persisted.safetensors");
+    assert.equal(calls[0].payload.loader_globals.auto_strength_enabled, true);
+    assert.deepEqual(calls[0].options, { notifyStateManager: false });
+
+    calls.length = 0;
+    helpers.refreshAllNodesFromLibrary({ syncLoaders: true, skipLoaderSyncNode: manager });
+    assert.equal(calls.length, 0);
+  } finally {
+    helpers.stateLibraryClient.nodes.delete(manager);
+    if (previousLoaderApi === undefined) delete globalThis.__doraPowerLoraLoaderApi;
+    else globalThis.__doraPowerLoraLoaderApi = previousLoaderApi;
+    if (previousRaf === undefined) delete globalThis.requestAnimationFrame;
+    else globalThis.requestAnimationFrame = previousRaf;
+  }
+});
+
+
+test("post-load loader synchronization frame is tracked and canceled on State Manager removal", async () => {
+  const source = await readFile(new URL("../web/dora_state_manager.js", import.meta.url), "utf8");
+  assert.match(source, /ctx\.postLoadSyncFrame\s*=\s*requestAnimationFrame/);
+  assert.match(source, /if \(ctx\.postLoadSyncFrame\) \{[\s\S]*cancelAnimationFrame\(ctx\.postLoadSyncFrame\)[\s\S]*ctx\.postLoadSyncFrame\s*=\s*0/);
+  assert.match(source, /if \(!stateLibraryClient\.nodes\.has\(node\)\) return;/);
+});
+
+
+test("applying a saved loader stack does not contain the dead self-comparison slot guard", async () => {
+  const source = await readFile(new URL("../web/dora_state_manager.js", import.meta.url), "utf8");
+  assert.equal(
+    source.includes('normalizeLoaderSlot(getDoraLoaderSlot(targetNode), "default") !== slot'),
+    false,
+  );
 });

--- a/web/dora_power_lora_loader.js
+++ b/web/dora_power_lora_loader.js
@@ -659,9 +659,45 @@ function setState(node, st) {
   node.properties.dora_power_lora = sanitizeState(st);
 }
 
+function notifyStateManagerOfLoaderChange(node, details = {}) {
+  if (!node) return false;
+  cancelScheduledStateManagerNotify(node);
+  const syncApi = globalThis.__doraStateManagerSyncApi;
+  if (typeof syncApi?.loaderStateChanged !== "function") return false;
+  try {
+    return !!syncApi.loaderStateChanged(node, details);
+  } catch (err) {
+    console.warn(`[${EXT_NAME}] Failed to synchronize loader state into State Manager`, err);
+    return false;
+  }
+}
+
+const STATE_MANAGER_NOTIFY_DELAY_MS = 150;
+const _stateManagerNotifyTimers = new WeakMap();
+
+function cancelScheduledStateManagerNotify(node) {
+  const timer = node ? _stateManagerNotifyTimers.get(node) : null;
+  if (timer == null) return false;
+  clearTimeout(timer);
+  _stateManagerNotifyTimers.delete(node);
+  return true;
+}
+
+function scheduleStateManagerNotify(node) {
+  if (!node) return false;
+  cancelScheduledStateManagerNotify(node);
+  const timer = setTimeout(() => {
+    _stateManagerNotifyTimers.delete(node);
+    notifyStateManagerOfLoaderChange(node);
+  }, STATE_MANAGER_NOTIFY_DELAY_MS);
+  _stateManagerNotifyTimers.set(node, timer);
+  return true;
+}
+
 function persistNodeState(node) {
   setState(node, { rows: node._doraRows || [], globals: node._doraGlobals || {} });
   clearExecutionReport(node);
+  scheduleStateManagerNotify(node);
 }
 
 
@@ -698,7 +734,7 @@ function installGlobalStateApi() {
       const state = getState(node);
       return { ...state, slot: getStateSlot(node), label: String(node?.title || getStateSlot(node)) };
     },
-    setState(node, externalState) {
+    setState(node, externalState, options = {}) {
       if (!node) return false;
       const next = normalizeExternalDoraState(externalState);
       if (externalState && Object.prototype.hasOwnProperty.call(externalState, "slot")) {
@@ -715,16 +751,21 @@ function installGlobalStateApi() {
       }
       node.setDirtyCanvas?.(true, true);
       node.graph?.change?.();
+      if (options?.notifyStateManager !== false) notifyStateManagerOfLoaderChange(node);
       return true;
     },
     getSlot(node) {
       return getStateSlot(node);
     },
-    setSlot(node, value) {
+    setSlot(node, value, options = {}) {
+      const previousSlot = getStateSlot(node);
       const slot = setStateSlot(node, value);
       try { rebuild(node); } catch (_) {}
       node?.setDirtyCanvas?.(true, true);
       node?.graph?.change?.();
+      if (options?.notifyStateManager !== false) {
+        notifyStateManagerOfLoaderChange(node, { previousSlot });
+      }
       return slot;
     },
   };
@@ -1577,9 +1618,11 @@ function buildUI(node, state, loraValues) {
   wRefresh.serialize = false;
 
   const wStateSlot = node.addWidget("text", "state_slot", getStateSlot(node), (v) => {
+    const previousSlot = getStateSlot(node);
     wStateSlot.value = setStateSlot(node, v);
     node.setDirtyCanvas?.(true, true);
     node.graph?.change?.();
+    notifyStateManagerOfLoaderChange(node, { previousSlot });
   });
   wStateSlot.label = "State slot";
 
@@ -1832,6 +1875,12 @@ app.registerExtension({
       this.resizable = true;
       rebuild(this);
       return r;
+    };
+
+    const origOnRemoved = nodeType.prototype.onRemoved;
+    nodeType.prototype.onRemoved = function () {
+      cancelScheduledStateManagerNotify(this);
+      return origOnRemoved?.apply(this, arguments);
     };
 
     const origConfigure = nodeType.prototype.configure;

--- a/web/dora_state_manager.js
+++ b/web/dora_state_manager.js
@@ -25,6 +25,25 @@ const MIN_NODE_WIDTH = 820;
 const MIN_NODE_HEIGHT = 720;
 const THUMBNAIL_SUBFOLDER = "dora_state_manager";
 const AUTO_STRENGTH_DEVICE_CHOICES = ["auto", "cpu", "gpu"];
+const DORA_LOADER_GLOBAL_DEFAULTS = Object.freeze({
+  stack_enabled: true,
+  verbose: false,
+  log_unloaded_keys: false,
+  broadcast_auto_scale: true,
+  broadcast_modulations: true,
+  broadcast_include_dora_scale: false,
+  broadcast_scale: 1.0,
+  dora_decompose_debug: false,
+  dora_decompose_debug_n: 30,
+  dora_decompose_debug_stack_depth: 10,
+  dora_slice_fix: true,
+  dora_adaln_swap_fix: true,
+  zimage_lumina2_compat: true,
+  auto_strength_enabled: false,
+  auto_strength_device: "gpu",
+  auto_strength_ratio_floor: 0.30,
+  auto_strength_ratio_ceiling: 1.50,
+});
 const OUTPUT_NAMES = {
   control: ["state_control"],
   // Legacy/runtime outputs remain readable for compatibility, but Save/Load connected
@@ -408,7 +427,26 @@ function normalizeLoaderGlobals(globalsIn) {
     if (Object.prototype.hasOwnProperty.call(src, key)) out[key] = normalizeBoolean(src[key]);
   }
   for (const key of ["broadcast_scale", "auto_strength_ratio_floor", "auto_strength_ratio_ceiling"]) {
-    if (Object.prototype.hasOwnProperty.call(src, key)) out[key] = normalizeNumber(src[key], key === "broadcast_scale" ? 1.0 : 0.0);
+    if (!Object.prototype.hasOwnProperty.call(src, key)) continue;
+    const fallback = key === "broadcast_scale"
+      ? DORA_LOADER_GLOBAL_DEFAULTS.broadcast_scale
+      : DORA_LOADER_GLOBAL_DEFAULTS[key];
+    const value = normalizeNumber(src[key], fallback);
+    out[key] = key === "broadcast_scale" ? value : Math.max(0, value);
+  }
+  if (
+    Object.prototype.hasOwnProperty.call(out, "auto_strength_ratio_floor")
+    || Object.prototype.hasOwnProperty.call(out, "auto_strength_ratio_ceiling")
+  ) {
+    let floor = Object.prototype.hasOwnProperty.call(out, "auto_strength_ratio_floor")
+      ? out.auto_strength_ratio_floor
+      : DORA_LOADER_GLOBAL_DEFAULTS.auto_strength_ratio_floor;
+    let ceiling = Object.prototype.hasOwnProperty.call(out, "auto_strength_ratio_ceiling")
+      ? out.auto_strength_ratio_ceiling
+      : DORA_LOADER_GLOBAL_DEFAULTS.auto_strength_ratio_ceiling;
+    if (ceiling < floor) [floor, ceiling] = [ceiling, floor];
+    out.auto_strength_ratio_floor = floor;
+    out.auto_strength_ratio_ceiling = ceiling;
   }
   for (const key of ["dora_decompose_debug_n", "dora_decompose_debug_stack_depth"]) {
     if (Object.prototype.hasOwnProperty.call(src, key)) out[key] = Math.floor(normalizeNumber(src[key], key === "dora_decompose_debug_n" ? 30 : 10));
@@ -831,8 +869,26 @@ function refreshNodeFromLibrary(node, { status = "" } = {}) {
   scheduleRender(node);
 }
 
-function refreshAllNodesFromLibrary() {
-  for (const node of stateLibraryClient.nodes) refreshNodeFromLibrary(node);
+function refreshAllNodesFromLibrary({ syncLoaders = false, skipLoaderSyncNode = null } = {}) {
+  for (const node of stateLibraryClient.nodes) {
+    refreshNodeFromLibrary(node);
+    if (!syncLoaders || node === skipLoaderSyncNode || !node?.__dsm) continue;
+    const current = getRenderableState(node);
+    const selection = ensureSelection(node, current.state);
+    const character = selection.character;
+    if (!character || character.__dsm_ephemeral) continue;
+    syncCharacterLoaderStacksToConnectedNodes(node, character);
+  }
+}
+
+function restoreNodeAndConnectedLoadersFromLibrary(node, { status = "" } = {}) {
+  refreshNodeFromLibrary(node, { status });
+  if (!node?.__dsm) return 0;
+  const current = getRenderableState(node);
+  const selection = ensureSelection(node, current.state);
+  const character = selection.character;
+  if (!character || character.__dsm_ephemeral) return 0;
+  return syncCharacterLoaderStacksToConnectedNodes(node, character);
 }
 
 function mergeScheduledLibraryUpdate(baseCharacters, desiredCharacters, currentCharacters, { allowOverwrite = false } = {}) {
@@ -871,9 +927,7 @@ function blockLibraryWrites(status) {
   stateLibraryClient.blocked = true;
   stateLibraryClient.pending = [];
   for (const node of stateLibraryClient.nodes) {
-    const current = getRenderableState(node);
-    cacheRenderableState(node, current.state, { ...current.uiState, status });
-    scheduleRender(node);
+    restoreNodeAndConnectedLoadersFromLibrary(node, { status });
   }
 }
 
@@ -908,7 +962,7 @@ async function writePendingLibrary() {
         });
         installLibrarySnapshot(snapshot);
         stateLibraryClient.lastAppliedNode = pending.node;
-        refreshAllNodesFromLibrary();
+        refreshAllNodesFromLibrary({ syncLoaders: true, skipLoaderSyncNode: pending.node });
       } catch (error) {
         if (error.status === 409) {
           blockLibraryWrites("Library changed in another tab or State Manager. Reload the library before editing again; the stale write was rejected.");
@@ -927,7 +981,7 @@ function scheduleLibraryPersist(node, state) {
   const desiredCharacters = persistentCharacters(state);
   const canonical = canonicalJson(desiredCharacters);
   if (stateLibraryClient.blocked) {
-    refreshNodeFromLibrary(node, {
+    restoreNodeAndConnectedLoadersFromLibrary(node, {
       status: "This edit was not applied. Reload the State Manager library before editing again.",
     });
     return;
@@ -950,7 +1004,7 @@ async function reloadStateLibrary(node, { status = "Reloaded State Manager libra
   stateLibraryClient.lastAppliedNode = null;
   const snapshot = await stateLibraryRequest();
   installLibrarySnapshot(snapshot, { force: true });
-  refreshAllNodesFromLibrary();
+  refreshAllNodesFromLibrary({ syncLoaders: true });
   refreshNodeFromLibrary(node, { status });
 }
 
@@ -1039,7 +1093,7 @@ async function importStateJsonFile(node, file) {
     body: JSON.stringify(parsed),
   });
   installLibrarySnapshot(result.snapshot);
-  refreshAllNodesFromLibrary();
+  refreshAllNodesFromLibrary({ syncLoaders: true });
   const characterId = result.character?.id || result.character_ids?.[0] || "";
   if (characterId) {
     const character = stateLibraryClient.state.characters.find((item) => item.id === characterId);
@@ -1047,7 +1101,7 @@ async function importStateJsonFile(node, file) {
     setWidgetValue(widgets.characterWidget, characterId);
     setWidgetValue(widgets.promptWidget, character?.prompts?.[0]?.id || "");
   }
-  refreshNodeFromLibrary(node, { status: `Imported ${file.name || "State Manager JSON"}.` });
+  restoreNodeAndConnectedLoadersFromLibrary(node, { status: `Imported ${file.name || "State Manager JSON"}.` });
 }
 
 function getWidgets(node) {
@@ -1172,6 +1226,18 @@ function updateState(node, state, uiState, opts = {}) {
   delete node.properties.dora_state_manager;
   delete node.properties.dora_state_manager_backup_node_uid;
   cacheRenderableState(node, normalizedState, nextUiState);
+  if (opts.renameLoaderSlotFrom != null) {
+    renameConnectedLoaderSlot(
+      node,
+      character,
+      opts.renameLoaderSlotFrom,
+      opts.syncLoaderSlot ?? opts.renameLoaderSlotFrom
+    );
+  } else if (opts.syncLoaders === true) {
+    syncCharacterLoaderStacksToConnectedNodes(node, character);
+  } else if (opts.syncLoaderSlot != null) {
+    syncCharacterLoaderStacksToConnectedNodes(node, character, opts.syncLoaderSlot);
+  }
   if (opts.persist !== false) scheduleLibraryPersist(node, normalizedState);
   if (opts.dirty !== false) markNodeDirty(node);
   if (opts.render !== false) scheduleRender(node);
@@ -1226,6 +1292,18 @@ function scheduleRender(node) {
     ctx.renderFrame = 0;
     renderNode(node);
   });
+}
+
+function schedulePostLoadLoaderSync(node) {
+  const ctx = node?.__dsm;
+  if (!ctx) return false;
+  if (ctx.postLoadSyncFrame) cancelAnimationFrame(ctx.postLoadSyncFrame);
+  ctx.postLoadSyncFrame = requestAnimationFrame(() => {
+    ctx.postLoadSyncFrame = 0;
+    if (!stateLibraryClient.nodes.has(node)) return;
+    synchronizeConnectedLoadersAfterLibraryLoad(node);
+  });
+  return true;
 }
 
 function chainNodeCallback(node, name, fn) {
@@ -1410,8 +1488,7 @@ function applyLoraStackToNode(targetNode, character) {
   };
   const loaderApi = globalThis.__doraPowerLoraLoaderApi;
   if (loaderApi?.setState) {
-    loaderApi.setSlot?.(targetNode, slot);
-    return !!loaderApi.setState(targetNode, payload);
+    return !!loaderApi.setState(targetNode, payload, { notifyStateManager: false });
   }
 
   const rows = (payload.loras || []).map((row) => ({
@@ -1469,6 +1546,212 @@ function uniqueNodes(targets) {
     out.push(node);
   }
   return out;
+}
+
+function getManagedLoaderNodes(managerNode) {
+  const controlled = getControlledNodes(managerNode).filter(isDoraLoaderNode);
+  if (controlled.length) return controlled;
+  return uniqueNodes(getOutputTargets(managerNode, OUTPUT_NAMES.lora)).filter(isDoraLoaderNode);
+}
+
+function pickPrimarySettingsLoaderStack(managerNode, character) {
+  const stacks = getCharacterLoaderStacks(character);
+  for (const loader of getManagedLoaderNodes(managerNode)) {
+    const slot = normalizeLoaderSlot(getDoraLoaderSlot(loader), "default");
+    const matching = stacks.find(
+      (stack) => normalizeLoaderSlot(stack?.slot, "default") === slot
+    );
+    if (matching) return matching;
+  }
+  return stacks.find((stack) => normalizeLoaderSlot(stack?.slot, "default") === "default")
+    || stacks[0]
+    || defaultLoaderStack();
+}
+
+function syncCharacterLoaderStacksToConnectedNodes(managerNode, character, slot = null) {
+  const wanted = slot == null ? null : normalizeLoaderSlot(slot, "default");
+  let changed = 0;
+  for (const loader of getManagedLoaderNodes(managerNode)) {
+    if (wanted != null && normalizeLoaderSlot(getDoraLoaderSlot(loader), "default") !== wanted) continue;
+    if (applyLoraStackToNode(loader, character)) changed += 1;
+  }
+  return changed;
+}
+
+function renameConnectedLoaderSlot(managerNode, character, fromSlot, toSlot) {
+  const from = normalizeLoaderSlot(fromSlot, "default");
+  const to = normalizeLoaderSlot(toSlot, from);
+  const loaderApi = globalThis.__doraPowerLoraLoaderApi;
+  let changed = 0;
+  for (const loader of getManagedLoaderNodes(managerNode)) {
+    if (normalizeLoaderSlot(getDoraLoaderSlot(loader), "default") !== from) continue;
+    if (loaderApi?.setSlot) {
+      loaderApi.setSlot(loader, to, { notifyStateManager: false });
+    } else {
+      loader.properties = loader.properties || {};
+      loader.properties.dora_state_slot = to;
+    }
+    if (applyLoraStackToNode(loader, character)) changed += 1;
+  }
+  return changed;
+}
+
+function syncConnectedLoaderStateIntoManager(
+  managerNode,
+  onlyLoader = null,
+  { persist = true, status = "", render = true, dirty = true, previousSlot = null } = {}
+) {
+  if (!managerNode) return 0;
+  const loaders = getManagedLoaderNodes(managerNode);
+  const current = getRenderableState(managerNode);
+  const selection = ensureSelection(managerNode, current.state);
+  let changed = 0;
+
+  let syncStatus = status;
+  for (const [index, loader] of loaders.entries()) {
+    if (onlyLoader && loader !== onlyLoader) continue;
+    const stack = extractLoraStackFromNode(loader, index);
+    if (!stack) continue;
+    let incomingNormalized = normalizeLoaderStack(stack, index);
+
+    const oldSlot = onlyLoader && previousSlot != null
+      ? normalizeLoaderSlot(previousSlot, "")
+      : "";
+    const newSlot = normalizeLoaderSlot(incomingNormalized.slot, "default");
+    if (oldSlot && oldSlot !== newSlot) {
+      const stacks = getCharacterLoaderStacks(selection.character);
+      const oldIndex = stacks.findIndex(
+        (item) => normalizeLoaderSlot(item?.slot, "default") === oldSlot
+      );
+      const targetIndex = stacks.findIndex(
+        (item) => normalizeLoaderSlot(item?.slot, "default") === newSlot
+      );
+
+      if (oldIndex >= 0 && targetIndex >= 0 && targetIndex !== oldIndex) {
+        // A loader slot is an identity key. Never silently overwrite a different
+        // saved stack when the user renames a connected loader onto an occupied slot.
+        const loaderApi = globalThis.__doraPowerLoraLoaderApi;
+        loaderApi?.setSlot?.(loader, oldSlot, { notifyStateManager: false });
+        incomingNormalized = {
+          ...incomingNormalized,
+          slot: oldSlot,
+          label: stacks[oldIndex]?.label || incomingNormalized.label || oldSlot,
+        };
+        syncStatus = `State slot "${newSlot}" already exists in this preset; kept connected loader on "${oldSlot}".`;
+      } else if (oldIndex >= 0) {
+        // Preserve stack identity across a loader-side slot rename instead of
+        // appending a second stack and leaving the old slot stale.
+        stacks[oldIndex] = incomingNormalized;
+        syncLegacyLoaderMirror(selection.character);
+        changed += 1;
+        continue;
+      }
+    }
+
+    const existing = findCharacterLoaderStack(selection.character, incomingNormalized.slot, { allowFallback: false });
+    const existingNormalized = existing ? normalizeLoaderStack(existing, index) : null;
+    if (existingNormalized && canonicalJson(existingNormalized) === canonicalJson(incomingNormalized)) continue;
+
+    if (!existing && normalizeLoaderSlot(incomingNormalized.slot, "default") !== "default") {
+      const stacks = getCharacterLoaderStacks(selection.character);
+      const soleDefault = stacks.length === 1
+        && normalizeLoaderSlot(stacks[0]?.slot, "default") === "default"
+        && !loaderStackHasMeaningfulState(stacks[0]);
+      if (soleDefault) {
+        stacks[0] = incomingNormalized;
+        syncLegacyLoaderMirror(selection.character);
+        changed += 1;
+        continue;
+      }
+    }
+
+    setCharacterLoaderStack(selection.character, incomingNormalized);
+    changed += 1;
+  }
+
+  if (changed) {
+    updateState(managerNode, current.state, current.uiState, {
+      characterId: selection.character.id,
+      promptId: selection.prompt.id,
+      persist,
+      render,
+      dirty,
+      status: syncStatus || `Synced ${changed} connected DoRA loader${changed === 1 ? "" : "s"} into this preset.`,
+    });
+  }
+  return changed;
+}
+
+function loaderStackHasMeaningfulState(stack) {
+  const normalized = normalizeLoaderStack(stack || {});
+  if ((normalized.loras || []).some((row) => row?.name && row.name !== "None")) {
+    return true;
+  }
+  const globals = normalizeLoaderGlobals(normalized.loader_globals || {});
+  for (const [key, defaultValue] of Object.entries(DORA_LOADER_GLOBAL_DEFAULTS)) {
+    const value = Object.prototype.hasOwnProperty.call(globals, key)
+      ? globals[key]
+      : defaultValue;
+    if (value !== defaultValue) return true;
+  }
+  return false;
+}
+
+function synchronizeConnectedLoadersAfterLibraryLoad(managerNode) {
+  if (!managerNode) return 0;
+  const current = getRenderableState(managerNode);
+  const selection = ensureSelection(managerNode, current.state);
+  const character = selection.character;
+  const prompt = selection.prompt;
+
+  // A durable saved preset is authoritative when its workflow binding is restored:
+  // reflect the state that will execute into the visible loader immediately.
+  if (
+    character
+    && character.id !== "default_character"
+    && !character.__dsm_ephemeral
+    && prompt
+    && !prompt.__dsm_ephemeral
+  ) {
+    return syncCharacterLoaderStacksToConnectedNodes(managerNode, character);
+  }
+
+  // The built-in default is only a placeholder and is not stored in the library.
+  // If it controls a configured loader, capture that visible state and let the normal
+  // edited-default materialization path create a durable preset. This prevents the
+  // backend's empty default stack from silently replacing the visible loader at run time.
+  if (character?.id === "default_character" && !character.__dsm_ephemeral) {
+    const hasMeaningfulLoaderState = getManagedLoaderNodes(managerNode).some((loader, index) => {
+      const stack = extractLoraStackFromNode(loader, index);
+      return stack ? loaderStackHasMeaningfulState(stack) : false;
+    });
+    return hasMeaningfulLoaderState
+      ? syncConnectedLoaderStateIntoManager(managerNode)
+      : 0;
+  }
+
+  // Missing/ephemeral selections are intentionally not allowed to rewrite either side.
+  return 0;
+}
+
+function syncLoaderStateIntoConnectedManagers(loaderNode, details = {}) {
+  if (!loaderNode) return 0;
+  let changed = 0;
+  for (const managerNode of stateLibraryClient.nodes) {
+    if (!getManagedLoaderNodes(managerNode).includes(loaderNode)) continue;
+    changed += syncConnectedLoaderStateIntoManager(managerNode, loaderNode, {
+      previousSlot: details?.previousSlot ?? null,
+    });
+  }
+  return changed;
+}
+
+function installLoaderStateSyncApi() {
+  globalThis.__doraStateManagerSyncApi = {
+    loaderStateChanged(loaderNode, details = {}) {
+      return syncLoaderStateIntoConnectedManagers(loaderNode, details);
+    },
+  };
 }
 
 function getWidgetMap(node) {
@@ -2270,7 +2553,12 @@ function renderCharacterTile(node, state, uiState, character, selectedId, select
     const promptId = nextCharacter.id === currentSelection.character.id && nextCharacter.prompts.some((item) => item.id === currentSelection.prompt.id)
       ? currentSelection.prompt.id
       : nextCharacter.prompts[0]?.id || "";
-    updateState(node, current.state, current.uiState, { characterId: nextCharacter.id, promptId, status: `Editing ${nextCharacter.name}. Use Load/Apply to push it into connected nodes.` });
+    updateState(node, current.state, current.uiState, {
+      characterId: nextCharacter.id,
+      promptId,
+      syncLoaders: true,
+      status: `Editing ${nextCharacter.name}. Connected DoRA loaders were synchronized.`,
+    });
   };
   tile.addEventListener("click", selectCharacter);
   tile.addEventListener("keydown", (event) => {
@@ -3125,7 +3413,13 @@ function renderLoraStackEditor(section, node, state, uiState, character, prompt,
     const oldSlot = stack.slot;
     stack.slot = normalizeLoaderSlot(value, oldSlot || `loader_${stackIndex + 1}`);
     if (stack.slot !== oldSlot) syncLegacyLoaderMirror(character);
-    updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id, status: `Renamed loader slot ${oldSlot} -> ${stack.slot}. Update the matching DoRA loader's State slot too.` });
+    updateState(node, state, uiState, {
+      characterId: character.id,
+      promptId: prompt.id,
+      renameLoaderSlotFrom: oldSlot,
+      syncLoaderSlot: stack.slot,
+      status: `Renamed loader slot ${oldSlot} -> ${stack.slot} and synchronized the matching DoRA loader.`,
+    });
   });
   const label = makeInput(stack.label, (value) => {
     stack.label = String(value || stack.slot).trim() || stack.slot;
@@ -3138,7 +3432,7 @@ function renderLoraStackEditor(section, node, state, uiState, character, prompt,
     makeButton("Add row", () => {
       stack.loras.push({ enabled: true, name: "None", strength_model: 1.0, strength_clip: 1.0 });
       syncLegacyLoaderMirror(character);
-      updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id, status: `Added LoRA row to ${stack.slot}.` });
+      updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id, syncLoaderSlot: stack.slot, status: `Added LoRA row to ${stack.slot}.` });
     }),
     makeButton("Delete stack", () => {
       const stacks = getCharacterLoaderStacks(character);
@@ -3160,19 +3454,23 @@ function renderLoraStackEditor(section, node, state, uiState, character, prompt,
   globalsLine.append(
     labelledControl("Stack enabled", makeCheckbox(globals.stack_enabled ?? true, (checked) => {
       updateCharacterLoaderGlobals(character, stack, { stack_enabled: checked });
-      updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id });
+      updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id, syncLoaderSlot: stack.slot });
     })),
     labelledControl("Auto-strength", makeCheckbox(globals.auto_strength_enabled ?? false, (checked) => {
       updateCharacterLoaderGlobals(character, stack, { auto_strength_enabled: checked });
-      updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id });
+      updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id, syncLoaderSlot: stack.slot });
     })),
     labelledControl("Analysis device", makeSelect(AUTO_STRENGTH_DEVICE_CHOICES, normalizeDevice(globals.auto_strength_device ?? "gpu"), (value) => {
       updateCharacterLoaderGlobals(character, stack, { auto_strength_device: value });
-      updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id });
+      updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id, syncLoaderSlot: stack.slot });
     })),
+    labelledControl("Ratio floor", makeInput(globals.auto_strength_ratio_floor ?? 0.3, (value) => {
+      updateCharacterLoaderGlobals(character, stack, { auto_strength_ratio_floor: normalizeNumber(value, 0.3) });
+      updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id, syncLoaderSlot: stack.slot });
+    }, { type: "number", step: "0.01" })),
     labelledControl("Ratio ceiling", makeInput(globals.auto_strength_ratio_ceiling ?? 1.5, (value) => {
       updateCharacterLoaderGlobals(character, stack, { auto_strength_ratio_ceiling: normalizeNumber(value, 1.5) });
-      updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id });
+      updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id, syncLoaderSlot: stack.slot });
     }, { type: "number", step: "0.01" }))
   );
   box.appendChild(globalsLine);
@@ -3190,27 +3488,27 @@ function renderLoraStackEditor(section, node, state, uiState, character, prompt,
     const enabled = makeCheckbox(row.enabled, (checked) => {
       row.enabled = checked;
       syncLegacyLoaderMirror(character);
-      updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id });
+      updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id, syncLoaderSlot: stack.slot });
     });
     const name = makeInput(row.name, (value) => {
       row.name = value.trim() || "None";
       syncLegacyLoaderMirror(character);
-      updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id });
+      updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id, syncLoaderSlot: stack.slot });
     });
     const sm = makeInput(row.strength_model, (value) => {
       row.strength_model = normalizeNumber(value, row.strength_model);
       syncLegacyLoaderMirror(character);
-      updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id });
+      updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id, syncLoaderSlot: stack.slot });
     }, { type: "number", step: "0.05" });
     const sc = makeInput(row.strength_clip, (value) => {
       row.strength_clip = normalizeNumber(value, row.strength_clip);
       syncLegacyLoaderMirror(character);
-      updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id });
+      updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id, syncLoaderSlot: stack.slot });
     }, { type: "number", step: "0.05" });
     line.append(enabled, name, sm, sc, makeButton("×", () => {
       stack.loras.splice(index, 1);
       syncLegacyLoaderMirror(character);
-      updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id, status: `Removed LoRA row from ${stack.slot}.` });
+      updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id, syncLoaderSlot: stack.slot, status: `Removed LoRA row from ${stack.slot}.` });
     }));
     box.appendChild(line);
   });
@@ -3262,44 +3560,48 @@ function renderLoraPanelContent(section, node, state, uiState, character, prompt
 
 
 function renderSettingsPanelContent(section, node, state, uiState, character, prompt) {
-  const primaryStack = findCharacterLoaderStack(character, "default") || getCharacterLoaderStacks(character)[0];
+  const primaryStack = pickPrimarySettingsLoaderStack(node, character);
   const globals = primaryStack.loader_globals || (primaryStack.loader_globals = {});
+  const loaderSettingsNote = document.createElement("div");
+  loaderSettingsNote.className = "dsm-muted";
+  loaderSettingsNote.textContent = `Loader settings shown for State slot: ${primaryStack.slot}`;
   const grid = document.createElement("div");
   grid.className = "dsm-grid2";
 
   const stackEnabled = makeCheckbox(globals.stack_enabled ?? true, (checked) => {
     updateCharacterLoaderGlobals(character, primaryStack, { stack_enabled: checked });
-    updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id });
+    updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id, syncLoaderSlot: primaryStack.slot });
   });
   const autoStrength = makeCheckbox(globals.auto_strength_enabled ?? false, (checked) => {
     updateCharacterLoaderGlobals(character, primaryStack, { auto_strength_enabled: checked });
-    updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id });
+    updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id, syncLoaderSlot: primaryStack.slot });
   });
   const device = makeSelect(AUTO_STRENGTH_DEVICE_CHOICES, normalizeDevice(globals.auto_strength_device ?? "gpu"), (value) => {
     updateCharacterLoaderGlobals(character, primaryStack, { auto_strength_device: value });
-    updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id });
+    updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id, syncLoaderSlot: primaryStack.slot });
   });
   const broadcastMods = makeCheckbox(globals.broadcast_modulations ?? true, (checked) => {
     updateCharacterLoaderGlobals(character, primaryStack, { broadcast_modulations: checked });
-    updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id });
+    updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id, syncLoaderSlot: primaryStack.slot });
   });
   const floor = makeInput(globals.auto_strength_ratio_floor ?? 0.3, (value) => {
     updateCharacterLoaderGlobals(character, primaryStack, { auto_strength_ratio_floor: normalizeNumber(value, 0.3) });
-    updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id });
+    updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id, syncLoaderSlot: primaryStack.slot });
   }, { type: "number", step: "0.01" });
   const ceiling = makeInput(globals.auto_strength_ratio_ceiling ?? 1.5, (value) => {
     updateCharacterLoaderGlobals(character, primaryStack, { auto_strength_ratio_ceiling: normalizeNumber(value, 1.5) });
-    updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id });
+    updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id, syncLoaderSlot: primaryStack.slot });
   }, { type: "number", step: "0.01" });
   const sliceFix = makeCheckbox(globals.dora_slice_fix ?? true, (checked) => {
     updateCharacterLoaderGlobals(character, primaryStack, { dora_slice_fix: checked });
-    updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id });
+    updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id, syncLoaderSlot: primaryStack.slot });
   });
   const adalnFix = makeCheckbox(globals.dora_adaln_swap_fix ?? true, (checked) => {
     updateCharacterLoaderGlobals(character, primaryStack, { dora_adaln_swap_fix: checked });
-    updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id });
+    updateState(node, state, uiState, { characterId: character.id, promptId: prompt.id, syncLoaderSlot: primaryStack.slot });
   });
 
+  section.appendChild(loaderSettingsNote);
   grid.append(
     labelledControl("Stack enabled", stackEnabled),
     labelledControl("Auto-strength", autoStrength),
@@ -3660,7 +3962,10 @@ function initializeNode(node, widget) {
     const promptId = String(widgetValue(currentWidgets.promptWidget, "") || "");
     try {
       const loaded = await initializeStateLibrary(node, legacy, characterId, promptId, token);
-      if (loaded) delete node.__dsmPendingLegacyState;
+      if (loaded) {
+        delete node.__dsmPendingLegacyState;
+        schedulePostLoadLoaderSync(node);
+      }
     } catch (err) {
       if (node.__dsmLibraryLoadToken !== token) return;
       const fallback = stateViewForSelection(characterId, promptId);
@@ -3686,9 +3991,15 @@ function initializeNode(node, widget) {
   chainNodeCallback(node, "onRemoved", function () {
     stateLibraryClient.nodes.delete(node);
     const ctx = node.__dsm;
-    if (!ctx?.renderFrame) return;
-    cancelAnimationFrame(ctx.renderFrame);
-    ctx.renderFrame = 0;
+    if (!ctx) return;
+    if (ctx.renderFrame) {
+      cancelAnimationFrame(ctx.renderFrame);
+      ctx.renderFrame = 0;
+    }
+    if (ctx.postLoadSyncFrame) {
+      cancelAnimationFrame(ctx.postLoadSyncFrame);
+      ctx.postLoadSyncFrame = 0;
+    }
   });
 
   scheduleRender(node);
@@ -4406,6 +4717,8 @@ function maybeInjectWidgetInput(nodeData) {
   nodeData.input.required = { ...required, [CUSTOM_WIDGET_INPUT]: [CUSTOM_WIDGET_TYPE, {}] };
 }
 
+installLoaderStateSyncApi();
+
 app.registerExtension({
   name: EXT_NAME,
 
@@ -4418,6 +4731,7 @@ app.registerExtension({
         node.__dsm = {
           root,
           renderFrame: 0,
+          postLoadSyncFrame: 0,
           state: null,
           uiState: null,
           libraryMode: "presets",


### PR DESCRIPTION
Fix the split-state bug between State Manager loader stacks and the visible DoRA Power LoRA Loader.

- Keep loader edits and the selected State Manager loader stack synchronized in both directions, including LoRA rows, strengths, Auto-strength, analysis device, ratio bounds, and other persisted globals.
- Keep the visible loader aligned with saved preset changes, character switches, library reload/import, persistence rollback, and first-load ownership rules.
- Preserve loader State-slot identity across renames, reject collisions without overwriting another stack, and show the settings for the actually connected loader slot.
- Suppress reverse notifications for State Manager-originated updates to prevent feedback loops.
- Debounce continuous loader edits to avoid persistence-write bursts while keeping discrete slot changes immediate.
- Track and cancel deferred post-load synchronization when a State Manager node is removed.
- Add regression coverage for both synchronization directions, slot rename/collision handling, rollback/refresh behavior, default-state handling, Auto-strength normalization, debounce behavior, and removal cleanup.

Validation: frontend/package tests plus compatibility/runtime-bypass suites against ComfyUI v0.29.2, v0.30.2, v0.31.1, and the pinned 2026-08-21 revision.