### PR TITLE
Mirror validation: Auto-strength residual hybrid

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,10 +100,12 @@ then enabling auto-strength is a true no-op.
 - derives linear cohort shape from the adapter's logical update matrix when possible, so packed/quantized checkpoint storage does not split an otherwise identical role
 - retains the legacy broad **family arithmetic reference** across eligible linear logical sources
 - for ordered repeated-block roles, builds a robust **local depth reference** with a centered 7-member moving log-median
-- applies `family_reference / local_depth_reference` as the main gain, so a coherently weak depth region can still receive the large boosts that made the original Auto-strength useful
+- applies `family_reference / local_depth_reference` as the robust regional baseline, so a coherently weak depth region can still receive the large boosts that made the original Auto-strength useful
+- restores a configurable fraction of the remaining per-layer residual in log space: `final_gain = depth_gain * (local_depth_reference / layer_score)^β`
+- exposes **Auto-strength residual β** in the node and State Manager, clamped to `0…1`, with default `0.50`
+- `β = 0` reproduces the local-depth-only behavior; `β = 1` reproduces the original direct family/per-layer gain; intermediate values are geometric/log-space blends rather than linear ratio interpolation
 - uses one role-wide arithmetic-mean gain only as a fallback when a reliable depth profile cannot be inferred
-- preserves local residual structure because neighboring blocks share the same robust local trend instead of each block being independently forced to the family mean
-- optionally composes one isolated-member correction on top; when a true isolated outlier is detected, the local reference is used as its correction target
+- isolated statistical outliers are promoted to residual exponent `1.0` regardless of β, preserving the conservative full correction already used for a single clearly broken member
 - multiple anomaly candidates suppress only the isolated-member correction; they do not suppress coherent depth redistribution
 - requires at least five ordered logical sources for depth profiling and at least five for isolated-outlier inference
 - leaves unclassifiable linear destinations at their normal global strength
@@ -121,8 +123,11 @@ The first role-aware redesign protected depth structure too aggressively and cou
 collapse Auto-strength to a near no-op.
 
 The current policy keeps the original family target but estimates a robust local trend
-inside each semantic role. Coherent weak regions therefore keep strong corrections,
-while isolated layer noise does not define the baseline for its neighbors.
+inside each semantic role. It then restores a controlled fraction of the remaining
+layer-to-layer residual in multiplicative/log space. This makes the behavior explicitly
+testable between the two useful endpoints instead of hard-coding another smoothing
+choice: β=0 is the current regional correction, β=1 is the old direct per-layer
+correction, and the default β=0.5 is their geometric midpoint for ordinary members.
 
 Ordinary LoRA scoring remains independent of destination weight numeric values.
 A base-relative score such as `RMS(ΔW) / RMS(W0)` would make the same LoRA

--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ This node includes optional **auto-strength** redistribution for loaded LoRAs / 
 When enabled, the loader:
 
 - measures a comparable per-base update magnitude
-- computes a per-base target relative to the mean of similar mapped destinations
+- groups repeated transformer projections by mapped destination role, exact tensor shape, and slice identity
+- detects isolated per-base magnitude anomalies against comparable logical sources
 - converts those absolute targets into **redistribution ratios**
 - bakes only that **ratio** into the LoRA tensors before loading
 
@@ -92,13 +93,41 @@ then enabling auto-strength is a true no-op.
 
 ### Current auto-strength behavior
 
-- compares mapped bases using a normalized magnitude score
+- scores ordinary LoRA with absolute `RMS(ΔW)` after LoRA alpha/rank scaling
+- scores DoRA with the RMS of its actual post-normalization weight update
+- separates model and CLIP and keeps tensor families isolated
+- infers repeated-block projection roles structurally from mapped destination paths; there is no MiniMax-H3 role table
+- derives linear cohort shape from the adapter's logical update matrix when possible, so packed/quantized checkpoint storage does not split an otherwise identical role
+- retains the legacy broad **family arithmetic reference** across eligible linear logical sources
+- for ordered repeated-block roles, builds a robust **local depth reference** with a centered 7-member moving log-median
+- applies `family_reference / local_depth_reference` as the main gain, so a coherently weak depth region can still receive the large boosts that made the original Auto-strength useful
+- uses one role-wide arithmetic-mean gain only as a fallback when a reliable depth profile cannot be inferred
+- preserves local residual structure because neighboring blocks share the same robust local trend instead of each block being independently forced to the family mean
+- optionally composes one isolated-member correction on top; when a true isolated outlier is detected, the local reference is used as its correction target
+- multiple anomaly candidates suppress only the isolated-member correction; they do not suppress coherent depth redistribution
+- requires at least five ordered logical sources for depth profiling and at least five for isolated-outlier inference
+- leaves unclassifiable linear destinations at their normal global strength
+- preserves arithmetic-mean redistribution for non-linear families such as convolution cohorts
 - keeps Flux / Flux2 compat-broadcasted logical sources from being over-counted during measurement
 - preserves the normal outer patch strength during final application
-- is intended to redistribute relative base strength, not replace the row's overall weight
 - `auto` resolves to CPU-safe analysis
 - `gpu` is the explicit accelerator path
 - default node UI state is `gpu`
+
+The linear policy deliberately sits between the two previous extremes. The original
+implementation compared every individual layer directly with one broad family mean,
+which could produce useful 4–5× boosts but also reacted to every layer independently.
+The first role-aware redesign protected depth structure too aggressively and could
+collapse Auto-strength to a near no-op.
+
+The current policy keeps the original family target but estimates a robust local trend
+inside each semantic role. Coherent weak regions therefore keep strong corrections,
+while isolated layer noise does not define the baseline for its neighbors.
+
+Ordinary LoRA scoring remains independent of destination weight numeric values.
+A base-relative score such as `RMS(ΔW) / RMS(W0)` would make the same LoRA
+redistribute differently across base checkpoints. DoRA remains the exception because
+its update is defined by normalization against the live effective destination weight.
 
 ### Performance note
 

--- a/nodes.py
+++ b/nodes.py
@@ -1923,6 +1923,13 @@ _AUTO_STRENGTH_RATIO_FLOOR = 0.30
 _AUTO_STRENGTH_RATIO_CEILING = 1.50
 _AUTO_STRENGTH_DISPLAY_RATIO_EPS = 1e-3
 _AUTO_STRENGTH_EPS = 1e-8
+_AUTO_STRENGTH_LINEAR_MIN_SAMPLE = 5
+_AUTO_STRENGTH_LINEAR_ROLE_MIN_SAMPLE = 2
+_AUTO_STRENGTH_LINEAR_DEPTH_MIN_SAMPLE = 5
+_AUTO_STRENGTH_LINEAR_DEPTH_WINDOW = 7
+_AUTO_STRENGTH_LINEAR_MAD_Z = 3.5
+_AUTO_STRENGTH_LINEAR_MIN_FACTOR = 1.5
+_AUTO_STRENGTH_LINEAR_MAX_CANDIDATES = 1
 _AUTO_STRENGTH_ANALYSIS_MIN_NUMEL = 65536
 
 
@@ -3327,6 +3334,339 @@ def _auto_strength_destination_family(weight: Optional[torch.Tensor]) -> str:
     return f"tensor:{ndim}d"
 
 
+_AUTO_STRENGTH_REPEAT_CONTAINER_NAMES = {
+    "block",
+    "blocks",
+    "cell",
+    "cells",
+    "group",
+    "groups",
+    "h",
+    "layer",
+    "layers",
+    "resblock",
+    "resblocks",
+    "resnet",
+    "resnets",
+    "stage",
+    "stages",
+}
+
+
+def _auto_strength_is_repeat_container(token: str) -> bool:
+    """Return whether a path component conventionally owns repeated block indices."""
+    normalized = str(token or "").strip().lower().replace("-", "_")
+    if normalized in _AUTO_STRENGTH_REPEAT_CONTAINER_NAMES:
+        return True
+    return any(part in _AUTO_STRENGTH_REPEAT_CONTAINER_NAMES for part in normalized.split("_") if part)
+
+
+def _auto_strength_destination_shape(weight: Optional[torch.Tensor]) -> str:
+    if not isinstance(weight, torch.Tensor):
+        return "unknown"
+    try:
+        return "x".join(str(int(dim)) for dim in weight.shape)
+    except Exception:
+        return "unknown"
+
+
+def _auto_strength_logical_destination_shape(
+    lora_sd: Dict[str, Any],
+    base: str,
+    weight: Optional[torch.Tensor],
+) -> Tuple[str, str]:
+    """Return the logical update shape without depending on packed weight storage."""
+    for suffix in (".diff", ".diff_b", ".set_weight"):
+        tensor = lora_sd.get(base + suffix)
+        if isinstance(tensor, torch.Tensor):
+            shape = _auto_strength_destination_shape(tensor)
+            if shape != "unknown":
+                return shape, "adapter_update"
+
+    for up_suffix, down_suffix in _LORA_DIRECTION_SUFFIX_PAIRS:
+        up = lora_sd.get(base + up_suffix)
+        down = lora_sd.get(base + down_suffix)
+        if not isinstance(up, torch.Tensor) or not isinstance(down, torch.Tensor):
+            continue
+        try:
+            up_rows = int(up.shape[0])
+            down_rows = int(down.shape[0])
+            up_cols = int(up.numel()) // max(1, up_rows)
+            down_cols = int(down.numel()) // max(1, down_rows)
+        except Exception:
+            continue
+        if up_rows > 0 and down_cols > 0 and up_cols == down_rows:
+            return f"{up_rows}x{down_cols}", "adapter_update"
+
+    return _auto_strength_destination_shape(weight), "destination_tensor"
+
+
+def _auto_strength_projection_metadata(
+    base: str,
+    key_map: Dict[str, Any],
+    weight: Optional[torch.Tensor],
+    *,
+    destination_shape: Optional[str] = None,
+    destination_shape_source: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Infer a repeatable linear projection role from the mapped destination path.
+
+    The inference is deliberately structural. Numeric indices are abstracted only
+    when their path component is owned by a conventional repeated-block container
+    (``blocks``, ``layers``, ``transformer_blocks``, ``down_blocks``, and similar).
+    Names such as ``attn1`` and ``fc2`` remain semantic role components.
+
+    Exact destination shape and slice identity are retained in the cohort key so
+    similarly named projections with incompatible layouts are never pooled.
+    """
+    dest, sl = _unwrap_key_map_target(key_map.get(base))
+    shape = str(destination_shape or _auto_strength_destination_shape(weight))
+    shape_source = str(destination_shape_source or "destination_tensor")
+    result: Dict[str, Any] = {
+        "destination": dest,
+        "destination_shape": shape,
+        "destination_shape_source": shape_source,
+        "destination_slice": list(sl) if sl is not None else None,
+        "semantic_role": None,
+        "role_path": None,
+        "block_identity": None,
+        "cohort_id": f"linear:unclassified|shape={shape}",
+        "cohort_eligible": False,
+        "fallback_reason": "semantic_role_unresolved",
+    }
+    if not dest:
+        return result
+
+    path = str(dest)
+    if path.endswith(".weight"):
+        path = path[:-len(".weight")]
+    parts = [part for part in path.split(".") if part]
+    if not parts:
+        return result
+
+    normalized = list(parts)
+    repeated_positions: List[int] = []
+    block_identities: List[str] = []
+
+    for index, token in enumerate(parts):
+        if token.isdigit() and index > 0 and _auto_strength_is_repeat_container(parts[index - 1]):
+            normalized[index] = "*"
+            repeated_positions.append(index)
+            block_identities.append(f"{parts[index - 1]}.{token}")
+            continue
+
+        embedded = re.match(r"^(?P<container>.+?)[_-](?P<index>\d+)$", token)
+        if embedded and _auto_strength_is_repeat_container(embedded.group("container")):
+            container = embedded.group("container")
+            block_index = embedded.group("index")
+            separator = "_" if "_" in token else "-"
+            normalized[index] = f"{container}{separator}*"
+            repeated_positions.append(index)
+            block_identities.append(f"{container}.{block_index}")
+
+    if not repeated_positions:
+        return result
+
+    role_parts = parts[repeated_positions[-1] + 1 :]
+    if not role_parts:
+        return result
+
+    semantic_role = ".".join(role_parts)
+    role_path = ".".join(normalized)
+    slice_suffix = ""
+    if sl is not None:
+        slice_suffix = f"|slice={int(sl[0])}:{int(sl[1])}:{int(sl[2])}"
+
+    result.update(
+        {
+            "semantic_role": semantic_role,
+            "role_path": role_path,
+            "block_identity": "/".join(block_identities),
+            "cohort_id": f"{role_path}|shape={shape}{slice_suffix}",
+            "cohort_eligible": True,
+            "fallback_reason": None,
+        }
+    )
+    return result
+
+
+def _auto_strength_log_median(values: Iterable[float]) -> Optional[float]:
+    """Return a robust multiplicative center for positive magnitude scores."""
+    logs: List[float] = []
+    for value in values:
+        try:
+            value_f = float(value)
+        except Exception:
+            continue
+        if value_f > _AUTO_STRENGTH_EPS and math.isfinite(value_f):
+            logs.append(math.log(value_f))
+    logs.sort()
+    if not logs:
+        return None
+    middle = len(logs) // 2
+    if len(logs) % 2:
+        center = logs[middle]
+    else:
+        center = (logs[middle - 1] + logs[middle]) * 0.5
+    return float(math.exp(center))
+
+
+def _auto_strength_median(values: Iterable[float]) -> Optional[float]:
+    finite = sorted(float(value) for value in values if math.isfinite(float(value)))
+    if not finite:
+        return None
+    middle = len(finite) // 2
+    if len(finite) % 2:
+        return finite[middle]
+    return (finite[middle - 1] + finite[middle]) * 0.5
+
+
+def _auto_strength_linear_outlier_model(values_by_logical: Dict[str, float]) -> Dict[str, Any]:
+    """Fit a conservative log-space anomaly gate for one linear role cohort.
+
+    The cohort center describes the expected distribution; it is not an automatic
+    target for every member. A member is correctable only when it is outside a
+    robust MAD envelope and it is the cohort's only candidate. The single-candidate
+    guard prevents a coherent depth regime from being mistaken for bad layers.
+    """
+    filtered = {
+        str(logical_id): float(value)
+        for logical_id, value in values_by_logical.items()
+        if math.isfinite(float(value)) and float(value) > _AUTO_STRENGTH_EPS
+    }
+    reference = _auto_strength_log_median(filtered.values())
+    sample_count = len(filtered)
+    candidate_limit = _AUTO_STRENGTH_LINEAR_MAX_CANDIDATES
+    result: Dict[str, Any] = {
+        "reference": reference,
+        "sample_count": sample_count,
+        "log_mad": None,
+        "robust_sigma": None,
+        "log_deviation_threshold": None,
+        "candidate_ids": set(),
+        "detected_candidate_ids": set(),
+        "candidate_count": 0,
+        "candidate_limit": candidate_limit,
+        "eligible": False,
+        "fallback_reason": "insufficient_outlier_sample",
+    }
+    if reference is None or sample_count < _AUTO_STRENGTH_LINEAR_MIN_SAMPLE:
+        return result
+
+    log_center = math.log(reference)
+    logs = {logical_id: math.log(value) for logical_id, value in filtered.items()}
+    log_mad = _auto_strength_median(abs(value - log_center) for value in logs.values())
+    if log_mad is None:
+        return result
+    robust_sigma = 1.4826 * log_mad
+    threshold = max(
+        _AUTO_STRENGTH_LINEAR_MAD_Z * robust_sigma,
+        math.log(_AUTO_STRENGTH_LINEAR_MIN_FACTOR),
+    )
+    candidate_ids = {
+        logical_id
+        for logical_id, value in logs.items()
+        if abs(value - log_center) > threshold
+    }
+    result.update(
+        {
+            "log_mad": float(log_mad),
+            "robust_sigma": float(robust_sigma),
+            "log_deviation_threshold": float(threshold),
+            "detected_candidate_ids": candidate_ids,
+            "candidate_count": len(candidate_ids),
+        }
+    )
+    if len(candidate_ids) > candidate_limit:
+        result["fallback_reason"] = "multiple_outlier_candidates"
+        return result
+
+    result.update(
+        {
+            "candidate_ids": candidate_ids,
+            "eligible": True,
+            "fallback_reason": None,
+        }
+    )
+    return result
+
+
+def _auto_strength_block_coordinate(block_identity: Optional[str]) -> Optional[Tuple[int, ...]]:
+    """Extract a stable repeated-block coordinate from structural block metadata."""
+    if not block_identity:
+        return None
+    coords: List[int] = []
+    for component in str(block_identity).split("/"):
+        match = re.search(r"\.(\d+)$", component)
+        if match is None:
+            return None
+        coords.append(int(match.group(1)))
+    return tuple(coords) if coords else None
+
+
+def _auto_strength_linear_depth_model(
+    values_by_logical: Dict[str, float],
+    coordinates_by_logical: Dict[str, Tuple[int, ...]],
+) -> Dict[str, Any]:
+    """Build robust local depth baselines without reacting to single-layer noise.
+
+    A centered moving log-median recovers the useful part of legacy per-layer
+    redistribution while making neighboring layers share one local trend. Coherent
+    weak/strong depth regions can therefore receive substantial family-level
+    correction without forcing every individual member to the same magnitude.
+    """
+    ordered = [
+        (coordinates_by_logical[logical_id], logical_id, float(value))
+        for logical_id, value in values_by_logical.items()
+        if logical_id in coordinates_by_logical
+        and math.isfinite(float(value))
+        and float(value) > _AUTO_STRENGTH_EPS
+    ]
+    ordered.sort(key=lambda item: (item[0], item[1]))
+    result: Dict[str, Any] = {
+        "eligible": False,
+        "sample_count": len(ordered),
+        "window_size": None,
+        "local_references": {},
+        "fallback_reason": "insufficient_depth_sample",
+    }
+    if len(ordered) < _AUTO_STRENGTH_LINEAR_DEPTH_MIN_SAMPLE:
+        return result
+
+    window_size = min(_AUTO_STRENGTH_LINEAR_DEPTH_WINDOW, len(ordered))
+    if window_size % 2 == 0 and window_size > 1:
+        window_size -= 1
+    window_size = max(1, window_size)
+    radius = window_size // 2
+    local_references: Dict[str, float] = {}
+
+    for index, (_coord, logical_id, _value) in enumerate(ordered):
+        start = index - radius
+        end = index + radius + 1
+        if start < 0:
+            end = min(len(ordered), end - start)
+            start = 0
+        if end > len(ordered):
+            start = max(0, start - (end - len(ordered)))
+            end = len(ordered)
+        reference = _auto_strength_log_median(entry[2] for entry in ordered[start:end])
+        if reference is not None and reference > _AUTO_STRENGTH_EPS:
+            local_references[logical_id] = float(reference)
+
+    if len(local_references) < _AUTO_STRENGTH_LINEAR_DEPTH_MIN_SAMPLE:
+        return result
+
+    result.update(
+        {
+            "eligible": True,
+            "window_size": window_size,
+            "local_references": local_references,
+            "fallback_reason": None,
+        }
+    )
+    return result
+
+
 def _auto_strength_measure_dora_effect(
     weight: torch.Tensor,
     delta: torch.Tensor,
@@ -3580,36 +3920,38 @@ def _auto_strength_analyze_base_targets(
     current_model: Any = None,
     current_clip: Any = None,
 ) -> Tuple[Dict[str, float], Dict[str, Any]]:
-    """
-    Compute per-base target strengths and preserve a structured report that matches
-    the loader's real logical-group-aware measurement model.
+    """Compute role-preserving Auto-strength targets and a structured report.
 
-    Invariants:
-      - auto-strength must modulate the same *linear delta* that standard LoRA and
-        DoRA feed into Comfy's patch loader.
-      - auto-strength must be invariant to synthetic compat expansion. Broadcasting one
-        logical source into N per-block bases must not change its measured target just
-        because the loader expanded the keys before comfy.lora.load_lora(...).
+    Linear adapters use two independent layers of inference:
 
-    We therefore compute a base-local score from the linear update representation, fold
-    compat-broadcast clones back into their logical source groups for measurement, and
-    then convert those absolute targets into per-base redistribution ratios before
-    comfy.lora.load_lora(...).
+    1. Role redistribution projects the legacy broad family equalization onto one
+       uniform gain per structural role/shape/slice cohort. The arithmetic mean of
+       each role is moved toward the legacy family arithmetic reference while every
+       within-role block-to-block ratio is preserved.
+    2. A conservative log-median/MAD gate may additionally correct one isolated
+       member inside a role. Coherent tails or multimodal depth regimes are never
+       flattened by this secondary correction.
+
+    Model/CLIP groups, logical fanout, tensor families, sliced mappings, outer patch
+    strength, LoRA alpha semantics, and DoRA post-normalization measurement remain
+    unchanged.
     """
     ratio_floor = max(0.0, float(ratio_floor))
     ratio_ceiling = max(ratio_floor, float(ratio_ceiling))
     logical_groups = logical_groups or {}
 
-    grouped_norms: Dict[Tuple[str, str], Dict[str, List[float]]] = {}
+    grouped_norms: Dict[Tuple[str, str, str], Dict[str, List[float]]] = {}
     base_groups: Dict[str, str] = {}
     base_families: Dict[str, str] = {}
-    base_cohorts: Dict[str, Tuple[str, str]] = {}
+    base_cohorts: Dict[str, Tuple[str, str, str]] = {}
+    base_metadata: Dict[str, Dict[str, Any]] = {}
+    base_measurement_kinds: Dict[str, str] = {}
     base_norms: Dict[str, float] = {}
     base_logical_ids: Dict[str, str] = {}
     base_logical_scales: Dict[str, float] = {}
-    logical_norms: Dict[Tuple[str, str, str], float] = {}
-    logical_members: Dict[Tuple[str, str, str], List[str]] = {}
-    skipped_zero_strength_members: Dict[Tuple[str, str, str], List[str]] = {}
+    logical_norms: Dict[Tuple[str, str, str, str], float] = {}
+    logical_members: Dict[Tuple[str, str, str, str], List[str]] = {}
+    skipped_zero_strength_members: Dict[Tuple[str, str, str, str], List[str]] = {}
     skipped_zero_strength_bases: List[str] = []
     targets: Dict[str, float] = {}
 
@@ -3621,8 +3963,41 @@ def _auto_strength_analyze_base_targets(
         dest_weight = _auto_strength_get_destination_weight(base, key_map, model_state_dict, clip_state_dict)
         family = _auto_strength_destination_family(dest_weight)
         base_families[base] = family
-        cohort = (group, family)
+
+        if family == "linear":
+            logical_shape, shape_source = _auto_strength_logical_destination_shape(
+                lora_sd, base, dest_weight
+            )
+            metadata = _auto_strength_projection_metadata(
+                base,
+                key_map,
+                dest_weight,
+                destination_shape=logical_shape,
+                destination_shape_source=shape_source,
+            )
+        else:
+            dest, sl = _unwrap_key_map_target(key_map.get(base))
+            metadata = {
+                "destination": dest,
+                "destination_shape": _auto_strength_destination_shape(dest_weight),
+                "destination_shape_source": "destination_tensor",
+                "destination_slice": list(sl) if sl is not None else None,
+                "semantic_role": None,
+                "role_path": None,
+                "block_identity": None,
+                "cohort_id": family,
+                "cohort_eligible": family != "unknown",
+                "fallback_reason": None if family != "unknown" else "unsupported_destination_family",
+            }
+
+        base_metadata[base] = metadata
+        cohort = (group, family, str(metadata.get("cohort_id") or family))
         base_cohorts[base] = cohort
+        base_measurement_kinds[base] = (
+            "dora_post_normalization_update_rms"
+            if isinstance(lora_sd.get(base + ".dora_scale"), torch.Tensor)
+            else "update_rms"
+        )
         global_strength = float(strength_model if group == "model" else strength_clip)
         targets[base] = global_strength
 
@@ -3640,7 +4015,7 @@ def _auto_strength_analyze_base_targets(
             logical_scale = 1.0
         base_logical_ids[base] = logical_id
         base_logical_scales[base] = logical_scale
-        logical_key = (cohort[0], cohort[1], logical_id)
+        logical_key = (cohort[0], cohort[1], cohort[2], logical_id)
 
         if abs(global_strength) < _AUTO_STRENGTH_EPS:
             skipped_zero_strength_members.setdefault(logical_key, []).append(base)
@@ -3661,20 +4036,151 @@ def _auto_strength_analyze_base_targets(
             current_model=current_model,
             current_clip=current_clip,
         )
-        if norm is None or not (norm > _AUTO_STRENGTH_EPS):
+        if norm is None or not math.isfinite(float(norm)) or not (norm > _AUTO_STRENGTH_EPS):
             continue
         base_norms[base] = norm
         logical_norm = float(norm / logical_scale)
         logical_norms[logical_key] = logical_norm
         grouped_norms.setdefault(cohort, {}).setdefault(logical_id, []).append(logical_norm)
 
-    group_means: Dict[Tuple[str, str], Optional[float]] = {}
+    cohort_logical_values: Dict[Tuple[str, str, str], Dict[str, float]] = {}
+    cohort_anomaly_references: Dict[Tuple[str, str, str], Optional[float]] = {}
+    cohort_role_references: Dict[Tuple[str, str, str], Optional[float]] = {}
+    cohort_models: Dict[Tuple[str, str, str], Dict[str, Any]] = {}
+    cohort_reference_statistics: Dict[Tuple[str, str, str], str] = {}
+    cohort_role_eligible: Dict[Tuple[str, str, str], bool] = {}
+    cohort_depth_models: Dict[Tuple[str, str, str], Dict[str, Any]] = {}
+    family_values: Dict[Tuple[str, str], List[float]] = {}
+
     for cohort, vals_by_logical in grouped_norms.items():
-        logical_vals = [float(sum(vals) / len(vals)) for vals in vals_by_logical.values() if vals]
-        group_means[cohort] = float(sum(logical_vals) / len(logical_vals)) if logical_vals else None
-        for logical_id, vals in vals_by_logical.items():
-            if vals:
-                logical_norms[(cohort[0], cohort[1], logical_id)] = float(sum(vals) / len(vals))
+        logical_values = {
+            str(logical_id): float(sum(vals) / len(vals))
+            for logical_id, vals in vals_by_logical.items()
+            if vals
+        }
+        cohort_logical_values[cohort] = logical_values
+        for logical_id, logical_value in logical_values.items():
+            logical_norms[(cohort[0], cohort[1], cohort[2], logical_id)] = logical_value
+
+        cohort_is_eligible = any(
+            bool(base_metadata.get(base, {}).get("cohort_eligible"))
+            for base, base_cohort in base_cohorts.items()
+            if base_cohort == cohort
+        )
+        logical_vals = list(logical_values.values())
+
+        if cohort[1] == "linear":
+            anomaly_model = _auto_strength_linear_outlier_model(logical_values)
+            if not cohort_is_eligible:
+                anomaly_model["eligible"] = False
+                anomaly_model["candidate_ids"] = set()
+                anomaly_model["fallback_reason"] = "cohort_ineligible"
+            cohort_models[cohort] = anomaly_model
+            cohort_anomaly_references[cohort] = anomaly_model.get("reference")
+            cohort_reference_statistics[cohort] = "log_median"
+
+            role_reference = (
+                float(sum(logical_vals) / len(logical_vals))
+                if logical_vals
+                else None
+            )
+            role_eligible = (
+                cohort_is_eligible
+                and role_reference is not None
+                and role_reference > _AUTO_STRENGTH_EPS
+                and len(logical_vals) >= _AUTO_STRENGTH_LINEAR_ROLE_MIN_SAMPLE
+            )
+            cohort_role_references[cohort] = role_reference
+            cohort_role_eligible[cohort] = role_eligible
+
+            coordinates_by_logical: Dict[str, Tuple[int, ...]] = {}
+            for logical_id in logical_values.keys():
+                logical_key = (cohort[0], cohort[1], cohort[2], logical_id)
+                coords = {
+                    _auto_strength_block_coordinate(
+                        base_metadata.get(base, {}).get("block_identity")
+                    )
+                    for base in logical_members.get(logical_key, [])
+                }
+                coords.discard(None)
+                if len(coords) == 1:
+                    coordinates_by_logical[logical_id] = next(iter(coords))
+            depth_model = _auto_strength_linear_depth_model(
+                logical_values,
+                coordinates_by_logical,
+            )
+            if not cohort_is_eligible:
+                depth_model["eligible"] = False
+                depth_model["local_references"] = {}
+                depth_model["fallback_reason"] = "cohort_ineligible"
+            cohort_depth_models[cohort] = depth_model
+
+            if role_eligible:
+                family_values.setdefault((cohort[0], cohort[1]), []).extend(logical_vals)
+        else:
+            reference = float(sum(logical_vals) / len(logical_vals)) if logical_vals else None
+            eligible = cohort_is_eligible and len(logical_vals) >= 2 and reference is not None
+            cohort_models[cohort] = {
+                "reference": reference,
+                "sample_count": len(logical_vals),
+                "candidate_ids": set(logical_values.keys()) if eligible else set(),
+                "detected_candidate_ids": set(logical_values.keys()) if eligible else set(),
+                "candidate_count": len(logical_vals) if eligible else 0,
+                "candidate_limit": None,
+                "eligible": eligible,
+                "fallback_reason": None if eligible else "insufficient_comparable_members",
+                "log_mad": None,
+                "robust_sigma": None,
+                "log_deviation_threshold": None,
+            }
+            cohort_anomaly_references[cohort] = reference
+            cohort_role_references[cohort] = reference
+            cohort_role_eligible[cohort] = eligible
+            cohort_depth_models[cohort] = {
+                "eligible": False,
+                "sample_count": len(logical_vals),
+                "window_size": None,
+                "local_references": {},
+                "fallback_reason": "non_linear_family",
+            }
+            cohort_reference_statistics[cohort] = "arithmetic_mean"
+
+    family_references: Dict[Tuple[str, str], Optional[float]] = {}
+    for family_key, values in family_values.items():
+        family_references[family_key] = (
+            float(sum(values) / len(values)) if values else None
+        )
+
+    cohort_role_gains: Dict[Tuple[str, str, str], Optional[float]] = {}
+    cohort_role_gain_reasons: Dict[Tuple[str, str, str], Optional[str]] = {}
+    for cohort in set(base_cohorts.values()):
+        if cohort[1] != "linear":
+            cohort_role_gains[cohort] = None
+            cohort_role_gain_reasons[cohort] = None
+            continue
+        role_reference = cohort_role_references.get(cohort)
+        family_reference = family_references.get((cohort[0], cohort[1]))
+        if not cohort_role_eligible.get(cohort, False):
+            cohort_role_gains[cohort] = None
+            metadata_base = next(
+                (base for base, base_cohort in base_cohorts.items() if base_cohort == cohort),
+                None,
+            )
+            metadata = base_metadata.get(metadata_base, {}) if metadata_base else {}
+            cohort_role_gain_reasons[cohort] = str(
+                metadata.get("fallback_reason")
+                or "insufficient_role_sample"
+            )
+        elif (
+            role_reference is None
+            or family_reference is None
+            or not (role_reference > _AUTO_STRENGTH_EPS)
+        ):
+            cohort_role_gains[cohort] = None
+            cohort_role_gain_reasons[cohort] = "unmeasurable_role_reference"
+        else:
+            cohort_role_gains[cohort] = float(family_reference / role_reference)
+            cohort_role_gain_reasons[cohort] = None
 
     for base, group in base_groups.items():
         global_strength = float(strength_model if group == "model" else strength_clip)
@@ -3683,113 +4189,444 @@ def _auto_strength_analyze_base_targets(
             continue
 
         family = base_families.get(base, "unknown")
-        cohort = base_cohorts.get(base, (group, family))
+        cohort = base_cohorts.get(base, (group, family, family))
         logical_id = base_logical_ids.get(base, base)
-        norm = logical_norms.get((cohort[0], cohort[1], logical_id))
-        mean_norm = group_means.get(cohort)
-        if norm is None or mean_norm is None or not (norm > _AUTO_STRENGTH_EPS):
+        norm = logical_norms.get((cohort[0], cohort[1], cohort[2], logical_id))
+        if norm is None or not (norm > _AUTO_STRENGTH_EPS):
             targets[base] = global_strength
             continue
 
-        ratio = mean_norm / norm
+        if family == "linear":
+            role_gain = cohort_role_gains.get(cohort)
+            if role_gain is None:
+                targets[base] = global_strength
+                continue
+            family_reference = family_references.get((cohort[0], cohort[1]))
+            depth_model = cohort_depth_models.get(cohort, {})
+            depth_reference = depth_model.get("local_references", {}).get(logical_id)
+            base_gain = role_gain
+            if (
+                depth_reference is not None
+                and family_reference is not None
+                and depth_reference > _AUTO_STRENGTH_EPS
+            ):
+                base_gain = float(family_reference / depth_reference)
+
+            anomaly_gain = 1.0
+            model = cohort_models.get(cohort, {})
+            correction_reference = depth_reference or cohort_anomaly_references.get(cohort)
+            if (
+                logical_id in model.get("candidate_ids", set())
+                and correction_reference is not None
+                and correction_reference > _AUTO_STRENGTH_EPS
+            ):
+                anomaly_gain = float(correction_reference / norm)
+            ratio = float(base_gain * anomaly_gain)
+        else:
+            reference = cohort_anomaly_references.get(cohort)
+            model = cohort_models.get(cohort, {})
+            if (
+                reference is None
+                or not bool(model.get("eligible"))
+                or logical_id not in model.get("candidate_ids", set())
+            ):
+                targets[base] = global_strength
+                continue
+            ratio = float(reference / norm)
+
         ratio = max(ratio_floor, min(ratio_ceiling, ratio))
         targets[base] = float(global_strength * ratio)
 
     measured = len(base_norms)
     total = len(base_groups)
     analyzable = sum(len(v) for v in logical_members.values())
-    measured_logical = sum(1 for logical_key in logical_members.keys() if logical_norms.get(logical_key, 0.0) > _AUTO_STRENGTH_EPS)
+    measured_logical = sum(
+        1
+        for logical_key in logical_members.keys()
+        if logical_norms.get(logical_key, 0.0) > _AUTO_STRENGTH_EPS
+    )
 
     cohorts_report: List[Dict[str, Any]] = []
     for cohort in sorted(set(base_cohorts.values())):
-        group, family = cohort
-        cohort_members = [k for k in logical_members.keys() if k[0] == group and k[1] == family]
-        measured_members = [k for k in cohort_members if logical_norms.get(k, 0.0) > _AUTO_STRENGTH_EPS]
-        total_bases = sum(len(logical_members.get(k, [])) for k in cohort_members)
-        measured_bases = sum(sum(1 for base in logical_members.get(k, []) if base in base_norms) for k in cohort_members)
-        skipped_bases = sum(
-            len(skipped_zero_strength_members.get(k, []))
-            for k in skipped_zero_strength_members.keys()
-            if k[0] == group and k[1] == family
+        group, family, cohort_id = cohort
+        cohort_members = [key for key in logical_members.keys() if key[:3] == cohort]
+        measured_members = [
+            key for key in cohort_members if logical_norms.get(key, 0.0) > _AUTO_STRENGTH_EPS
+        ]
+        total_bases = sum(len(logical_members.get(key, [])) for key in cohort_members)
+        measured_bases = sum(
+            sum(1 for base in logical_members.get(key, []) if base in base_norms)
+            for key in cohort_members
         )
+        skipped_bases = sum(
+            len(skipped_zero_strength_members.get(key, []))
+            for key in skipped_zero_strength_members.keys()
+            if key[:3] == cohort
+        )
+        cohort_bases = [base for base, base_cohort in base_cohorts.items() if base_cohort == cohort]
+        metadata = base_metadata.get(cohort_bases[0], {}) if cohort_bases else {}
+        model = cohort_models.get(cohort, {})
+        depth_model = cohort_depth_models.get(cohort, {})
+        anomaly_reference = cohort_anomaly_references.get(cohort)
+        role_reference = cohort_role_references.get(cohort)
+        family_reference = family_references.get((group, family))
+        role_gain = cohort_role_gains.get(cohort)
+        depth_references = depth_model.get("local_references", {}) if family == "linear" else {}
+        depth_gains = [
+            float(family_reference / reference)
+            for reference in depth_references.values()
+            if family_reference is not None and reference > _AUTO_STRENGTH_EPS
+        ]
+        is_linear = family == "linear"
+
+        if is_linear:
+            redistribution_eligible = role_gain is not None
+            fallback_reason = cohort_role_gain_reasons.get(cohort)
+            anomaly_fallback_reason = (
+                None if bool(model.get("eligible")) else model.get("fallback_reason")
+            )
+        else:
+            redistribution_eligible = bool(model.get("eligible"))
+            fallback_reason = (
+                None if redistribution_eligible else model.get("fallback_reason")
+            )
+            anomaly_fallback_reason = None
+
         cohorts_report.append(
             {
                 "group": group,
                 "family": family,
-                "mean_norm": _auto_strength_safe_number(group_means.get(cohort)),
+                "destination_group": group,
+                "tensor_family": family,
+                "semantic_role": metadata.get("semantic_role"),
+                "role_path": metadata.get("role_path"),
+                "destination_shape": metadata.get("destination_shape"),
+                "destination_shape_source": metadata.get("destination_shape_source"),
+                "destination_slice": metadata.get("destination_slice"),
+                "cohort_id": cohort_id,
+                "redistribution_eligible": redistribution_eligible,
+                "role_redistribution_eligible": redistribution_eligible if is_linear else None,
+                "anomaly_detection_eligible": bool(model.get("eligible")) if is_linear else None,
+                "outlier_gate": "log_median_mad_single" if is_linear else None,
+                "minimum_sample": _AUTO_STRENGTH_LINEAR_MIN_SAMPLE if is_linear else 2,
+                "minimum_role_sample": _AUTO_STRENGTH_LINEAR_ROLE_MIN_SAMPLE if is_linear else None,
+                "log_mad": _auto_strength_safe_number(model.get("log_mad")),
+                "robust_sigma": _auto_strength_safe_number(model.get("robust_sigma")),
+                "log_deviation_threshold": _auto_strength_safe_number(
+                    model.get("log_deviation_threshold")
+                ),
+                "minimum_deviation_factor": _AUTO_STRENGTH_LINEAR_MIN_FACTOR if is_linear else None,
+                "outlier_candidate_count": (
+                    int(model.get("candidate_count", 0)) if is_linear else None
+                ),
+                "outlier_candidate_limit": (
+                    int(model.get("candidate_limit", 0)) if is_linear else None
+                ),
+                "corrected_logical_count": len(model.get("candidate_ids", set())) if is_linear else len(model.get("candidate_ids", set())),
+                "scoring_basis": "absolute_update_rms",
+                "reference_statistic": cohort_reference_statistics.get(cohort),
+                "reference_score": _auto_strength_safe_number(anomaly_reference),
+                "role_reference_statistic": "arithmetic_mean" if is_linear else None,
+                "role_reference_score": _auto_strength_safe_number(role_reference),
+                "family_reference_statistic": "arithmetic_mean" if is_linear else None,
+                "family_reference_score": _auto_strength_safe_number(family_reference),
+                "role_gain_raw": _auto_strength_safe_number(role_gain),
+                "depth_profile_eligible": bool(depth_model.get("eligible")) if is_linear else None,
+                "depth_profile_sample_count": int(depth_model.get("sample_count", 0)) if is_linear else None,
+                "depth_profile_window_size": depth_model.get("window_size") if is_linear else None,
+                "depth_profile_fallback_reason": depth_model.get("fallback_reason") if is_linear else None,
+                "depth_gain_min_raw": _auto_strength_safe_number(min(depth_gains)) if depth_gains else None,
+                "depth_gain_max_raw": _auto_strength_safe_number(max(depth_gains)) if depth_gains else None,
+                "role_gain_at_bounds": (
+                    _auto_strength_safe_number(max(ratio_floor, min(ratio_ceiling, role_gain)))
+                    if role_gain is not None
+                    else None
+                ),
+                # Compatibility aliases retained for existing report readers.
+                "mean_norm": _auto_strength_safe_number(anomaly_reference),
                 "logical_count": len(cohort_members),
                 "measured_logical_count": len(measured_members),
                 "base_count": total_bases,
                 "skipped_zero_strength_base_count": skipped_bases,
                 "measured_base_count": measured_bases,
+                "fallback_reason": fallback_reason,
+                "anomaly_fallback_reason": anomaly_fallback_reason,
             }
         )
 
     logical_reports: List[Dict[str, Any]] = []
     for logical_key, members in logical_members.items():
-        group, family, logical_id = logical_key
+        group, family, cohort_id, logical_id = logical_key
+        cohort = (group, family, cohort_id)
         global_strength = float(strength_model if group == "model" else strength_clip)
         logical_norm = logical_norms.get(logical_key)
-        cohort_mean = group_means.get((group, family))
+        model = cohort_models.get(cohort, {})
+        metadata = base_metadata.get(members[0], {}) if members else {}
+        anomaly_reference = cohort_anomaly_references.get(cohort)
+        role_reference = cohort_role_references.get(cohort)
+        family_reference = family_references.get((group, family))
+        role_gain = cohort_role_gains.get(cohort)
+        depth_model = cohort_depth_models.get(cohort, {})
+        depth_reference = depth_model.get("local_references", {}).get(logical_id)
+        depth_gain_raw = None
+        if (
+            depth_reference is not None
+            and family_reference is not None
+            and depth_reference > _AUTO_STRENGTH_EPS
+        ):
+            depth_gain_raw = float(family_reference / depth_reference)
+
         ratio_raw = None
         ratio_applied = None
-        if logical_norm is not None and cohort_mean is not None and logical_norm > _AUTO_STRENGTH_EPS:
-            ratio_raw = float(cohort_mean / logical_norm)
-            ratio_applied = float(max(ratio_floor, min(ratio_ceiling, ratio_raw)))
+        anomaly_gain_raw = None
+        decision_reason = None
+        fallback_reason = None
+        anomaly_fallback_reason = None
+
+        if logical_norm is None or not (logical_norm > _AUTO_STRENGTH_EPS):
+            fallback_reason = "unmeasurable_update"
+        elif family == "linear":
+            if role_gain is None:
+                fallback_reason = cohort_role_gain_reasons.get(cohort) or "role_redistribution_unavailable"
+            else:
+                base_gain = depth_gain_raw if depth_gain_raw is not None else role_gain
+                anomaly_gain_raw = 1.0
+                correction_reference = depth_reference or anomaly_reference
+                if (
+                    logical_id in model.get("candidate_ids", set())
+                    and correction_reference is not None
+                    and correction_reference > _AUTO_STRENGTH_EPS
+                ):
+                    anomaly_gain_raw = float(correction_reference / logical_norm)
+                    decision_reason = (
+                        "depth_profile_redistribution_plus_outlier_correction"
+                        if depth_gain_raw is not None
+                        else "role_redistribution_plus_outlier_correction"
+                    )
+                elif logical_id in model.get("detected_candidate_ids", set()):
+                    decision_reason = (
+                        "depth_profile_redistribution_anomaly_suppressed_candidate"
+                        if depth_gain_raw is not None
+                        else "role_redistribution_anomaly_suppressed_candidate"
+                    )
+                elif model.get("fallback_reason") == "multiple_outlier_candidates":
+                    decision_reason = (
+                        "depth_profile_redistribution_anomaly_suppressed"
+                        if depth_gain_raw is not None
+                        else "role_redistribution_anomaly_suppressed"
+                    )
+                else:
+                    decision_reason = (
+                        "depth_profile_redistribution"
+                        if depth_gain_raw is not None
+                        else "role_redistribution"
+                    )
+
+                if not bool(model.get("eligible")):
+                    anomaly_fallback_reason = model.get("fallback_reason")
+                ratio_raw = float(base_gain * anomaly_gain_raw)
+                ratio_applied = float(max(ratio_floor, min(ratio_ceiling, ratio_raw)))
+        else:
+            if (
+                anomaly_reference is not None
+                and bool(model.get("eligible"))
+                and logical_id in model.get("candidate_ids", set())
+            ):
+                ratio_raw = float(anomaly_reference / logical_norm)
+                ratio_applied = float(max(ratio_floor, min(ratio_ceiling, ratio_raw)))
+                decision_reason = "family_redistribution"
+            else:
+                fallback_reason = str(model.get("fallback_reason") or "unmeasurable_cohort")
+
         fallback_to_global = ratio_applied is None
-        target_strength = float(global_strength if fallback_to_global else global_strength * ratio_applied)
+        if fallback_to_global:
+            decision_reason = fallback_reason
+        target_strength = float(
+            global_strength if fallback_to_global else global_strength * ratio_applied
+        )
+
         bases_report = []
         measured_base_count = 0
         for base in sorted(members):
             base_target = float(targets.get(base, global_strength))
-            base_ratio = None
-            if abs(global_strength) > _AUTO_STRENGTH_EPS:
+            base_ratio = ratio_applied
+            if base_ratio is not None and abs(global_strength) > _AUTO_STRENGTH_EPS:
                 base_ratio = float(base_target / global_strength)
             if base in base_norms:
                 measured_base_count += 1
+            base_meta = base_metadata.get(base, {})
             bases_report.append(
                 {
                     "base": base,
+                    "destination": base_meta.get("destination"),
+                    "destination_group": group,
+                    "tensor_family": family,
+                    "semantic_role": base_meta.get("semantic_role"),
+                    "block_identity": base_meta.get("block_identity"),
+                    "destination_shape": base_meta.get("destination_shape"),
+                    "destination_shape_source": base_meta.get("destination_shape_source"),
+                    "destination_slice": base_meta.get("destination_slice"),
+                    "measurement_kind": base_measurement_kinds.get(base, "update_rms"),
                     "norm": _auto_strength_safe_number(base_norms.get(base)),
+                    "update_rms": _auto_strength_safe_number(base_norms.get(base)),
+                    "base_weight_rms": None,
+                    "relative_perturbation": None,
                     "logical_scale": _auto_strength_safe_number(base_logical_scales.get(base, 1.0)),
                     "measured": base in base_norms,
+                    "role_gain_raw": _auto_strength_safe_number(role_gain),
+                    "depth_reference_score": _auto_strength_safe_number(depth_reference),
+                    "depth_gain_raw": _auto_strength_safe_number(depth_gain_raw),
+                    "anomaly_gain_raw": _auto_strength_safe_number(anomaly_gain_raw),
                     "ratio_applied": _auto_strength_safe_number(base_ratio),
                     "target_strength": base_target,
+                    "decision_reason": decision_reason,
+                    "fallback_reason": fallback_reason,
+                    "anomaly_fallback_reason": anomaly_fallback_reason,
                 }
             )
+
+        block_identities = sorted(
+            {
+                str(base_metadata.get(base, {}).get("block_identity"))
+                for base in members
+                if base_metadata.get(base, {}).get("block_identity")
+            }
+        )
+        destinations = sorted(
+            {
+                str(base_metadata.get(base, {}).get("destination"))
+                for base in members
+                if base_metadata.get(base, {}).get("destination")
+            }
+        )
+        measurement_kinds = sorted(
+            {base_measurement_kinds.get(base, "update_rms") for base in members}
+        )
+        log_deviation = None
+        if (
+            logical_norm is not None
+            and anomaly_reference is not None
+            and logical_norm > _AUTO_STRENGTH_EPS
+        ):
+            log_deviation = abs(math.log(logical_norm) - math.log(anomaly_reference))
+        robust_sigma = _auto_strength_safe_number(model.get("robust_sigma"))
+        robust_z = None
+        if (
+            log_deviation is not None
+            and robust_sigma is not None
+            and robust_sigma > _AUTO_STRENGTH_EPS
+        ):
+            robust_z = float(log_deviation / robust_sigma)
 
         logical_reports.append(
             {
                 "group": group,
                 "family": family,
+                "destination_group": group,
+                "tensor_family": family,
+                "semantic_role": metadata.get("semantic_role"),
+                "role_path": metadata.get("role_path"),
+                "cohort_id": cohort_id,
                 "logical_id": logical_id,
+                "block_identity": block_identities[0] if len(block_identities) == 1 else None,
+                "block_identities": block_identities,
+                "destinations": destinations,
+                "destination_shape": metadata.get("destination_shape"),
+                "destination_shape_source": metadata.get("destination_shape_source"),
+                "destination_slice": metadata.get("destination_slice"),
+                "measurement_kind": (
+                    measurement_kinds[0] if len(measurement_kinds) == 1 else "mixed_update_rms"
+                ),
+                "scoring_basis": "absolute_update_rms",
                 "fanout": len(members),
                 "measured_base_count": measured_base_count,
+                "update_rms": _auto_strength_safe_number(logical_norm),
+                "base_weight_rms": None,
+                "relative_perturbation": None,
+                "score": _auto_strength_safe_number(logical_norm),
                 "mean_norm": _auto_strength_safe_number(logical_norm),
-                "cohort_mean_norm": _auto_strength_safe_number(cohort_mean),
+                "cohort_reference_statistic": cohort_reference_statistics.get(cohort),
+                "cohort_reference_score": _auto_strength_safe_number(anomaly_reference),
+                "cohort_mean_norm": _auto_strength_safe_number(anomaly_reference),
+                "role_reference_score": _auto_strength_safe_number(role_reference),
+                "family_reference_score": _auto_strength_safe_number(family_reference),
+                "role_gain_raw": _auto_strength_safe_number(role_gain),
+                "depth_reference_score": _auto_strength_safe_number(depth_reference),
+                "depth_gain_raw": _auto_strength_safe_number(depth_gain_raw),
+                "anomaly_gain_raw": _auto_strength_safe_number(anomaly_gain_raw),
+                "log_deviation": _auto_strength_safe_number(log_deviation),
+                "robust_z": _auto_strength_safe_number(robust_z),
+                "outlier_candidate": logical_id in model.get("detected_candidate_ids", set()),
+                "outlier_corrected": logical_id in model.get("candidate_ids", set()),
                 "ratio_raw": _auto_strength_safe_number(ratio_raw),
                 "ratio_applied": _auto_strength_safe_number(ratio_applied),
                 "global_strength": global_strength,
                 "target_strength": target_strength,
                 "fallback_to_global": fallback_to_global,
+                "decision_reason": decision_reason,
+                "fallback_reason": fallback_reason,
+                "anomaly_fallback_reason": anomaly_fallback_reason,
                 "bases": bases_report,
             }
         )
 
-    logical_reports.sort(
-        key=lambda item: (
-            -abs((_auto_strength_safe_number(item.get("ratio_applied")) or 1.0) - 1.0),
+    def _report_sort_key(item: Dict[str, Any]) -> Tuple[Any, ...]:
+        if item.get("outlier_corrected"):
+            priority = 0
+        elif item.get("outlier_candidate"):
+            priority = 1
+        else:
+            priority = 2
+
+        ratio = _auto_strength_safe_number(item.get("ratio_raw"))
+        if ratio is not None and ratio > _AUTO_STRENGTH_EPS:
+            deviation = abs(math.log(ratio))
+        else:
+            deviation = _auto_strength_safe_number(item.get("log_deviation")) or 0.0
+
+        return (
+            priority,
+            -float(deviation),
             str(item.get("group") or ""),
             str(item.get("family") or ""),
             str(item.get("logical_id") or ""),
         )
-    )
+
+    logical_reports.sort(key=_report_sort_key)
 
     report = {
-        "schema": 1,
+        "schema": 2,
         "kind": "dora_auto_strength_report",
         "analysis_device_mode": str(analysis_device_mode),
         "analysis_load_device": _auto_strength_describe_device(analysis_load_device),
+        "scoring_basis": "absolute_update_rms",
+        "base_relative_scoring": False,
+        "cohort_reference_policy": {
+            "repeated_block_linear": "family_arithmetic_local_depth_log_median_plus_single_outlier_gate",
+            "other_tensor_families": "arithmetic_mean",
+        },
+        "linear_cohorting": "repeated_block_semantic_role_logical_shape_and_slice",
+        "linear_role_redistribution_policy": {
+            "family_reference": "arithmetic_mean_of_eligible_logical_sources",
+            "role_reference": "arithmetic_mean_fallback",
+            "minimum_role_sample": _AUTO_STRENGTH_LINEAR_ROLE_MIN_SAMPLE,
+            "fallback_gain": "family_reference_divided_by_role_reference",
+        },
+        "linear_depth_redistribution_policy": {
+            "minimum_sample": _AUTO_STRENGTH_LINEAR_DEPTH_MIN_SAMPLE,
+            "window_size": _AUTO_STRENGTH_LINEAR_DEPTH_WINDOW,
+            "local_reference": "centered_moving_log_median",
+            "gain": "family_reference_divided_by_local_depth_reference",
+            "preserves_local_residual_structure": True,
+        },
+        "linear_outlier_policy": {
+            "minimum_sample": _AUTO_STRENGTH_LINEAR_MIN_SAMPLE,
+            "mad_z_threshold": _AUTO_STRENGTH_LINEAR_MAD_Z,
+            "minimum_deviation_factor": _AUTO_STRENGTH_LINEAR_MIN_FACTOR,
+            "maximum_candidates": _AUTO_STRENGTH_LINEAR_MAX_CANDIDATES,
+            "correction_target": "cohort_log_median",
+            "composition": "depth_or_role_gain_times_outlier_gain",
+        },
         "strength_model": float(strength_model),
         "strength_clip": float(strength_clip),
         "ratio_floor": ratio_floor,
@@ -3800,42 +4637,110 @@ def _auto_strength_analyze_base_targets(
         "logical_groups_total": len(logical_members),
         "logical_groups_measured": measured_logical,
         "logical_groups_skipped_zero_strength": len(skipped_zero_strength_members),
+        "family_references": {
+            f"{group}/{family}": _auto_strength_safe_number(reference)
+            for (group, family), reference in sorted(family_references.items())
+        },
         "cohorts": cohorts_report,
         "logical_groups": logical_reports,
         "skipped_zero_strength_bases": sorted(skipped_zero_strength_bases),
         "unmeasured_bases": sorted(
-            base for base in base_groups.keys()
+            base
+            for base in base_groups.keys()
             if base not in base_norms and base not in skipped_zero_strength_bases
         ),
     }
 
     if verbose:
-        cohort_summary = {
-            f"{group}/{family}": mean
-            for (group, family), mean in sorted(group_means.items())
-        }
+        cohort_summary = {}
+        for cohort in sorted(set(base_cohorts.values())):
+            group, family, cohort_id = cohort
+            cohort_summary[f"{group}/{family}/{cohort_id}"] = {
+                "role_reference": _auto_strength_safe_number(
+                    cohort_role_references.get(cohort)
+                ),
+                "family_reference": _auto_strength_safe_number(
+                    family_references.get((group, family))
+                ),
+                "role_gain": _auto_strength_safe_number(cohort_role_gains.get(cohort)),
+                "depth_profile": {
+                    "eligible": bool(cohort_depth_models.get(cohort, {}).get("eligible")),
+                    "window_size": cohort_depth_models.get(cohort, {}).get("window_size"),
+                    "gain_min": _auto_strength_safe_number(
+                        min(
+                            [
+                                family_references.get((group, family)) / reference
+                                for reference in cohort_depth_models.get(cohort, {}).get("local_references", {}).values()
+                                if family_references.get((group, family)) is not None
+                                and reference > _AUTO_STRENGTH_EPS
+                            ],
+                            default=None,
+                        )
+                    ),
+                    "gain_max": _auto_strength_safe_number(
+                        max(
+                            [
+                                family_references.get((group, family)) / reference
+                                for reference in cohort_depth_models.get(cohort, {}).get("local_references", {}).values()
+                                if family_references.get((group, family)) is not None
+                                and reference > _AUTO_STRENGTH_EPS
+                            ],
+                            default=None,
+                        )
+                    ),
+                } if family == "linear" else None,
+                "anomaly_reference": _auto_strength_safe_number(
+                    cohort_anomaly_references.get(cohort)
+                ),
+                "outlier_candidates": int(
+                    cohort_models.get(cohort, {}).get("candidate_count", 0)
+                )
+                if family == "linear"
+                else None,
+                "anomaly_fallback": (
+                    cohort_models.get(cohort, {}).get("fallback_reason")
+                    if family == "linear"
+                    and not bool(cohort_models.get(cohort, {}).get("eligible"))
+                    else None
+                ),
+            }
+
         _LOG.info(
-            "[DoRA Power LoRA Loader] auto-strength: measured %s/%s mapped bases (%s/%s logical groups) (cohort_means=%s ratio_floor=%s ratio_ceiling=%s)",
+            "[DoRA Power LoRA Loader] auto-strength: measured %s/%s mapped bases (%s/%s logical groups) (scoring=absolute_update_rms linear_policy=family_local_depth_log_median_plus_single_outlier_gate family_references=%s cohorts=%s ratio_floor=%s ratio_ceiling=%s)",
             measured,
             total,
             measured_logical,
             len(logical_members),
+            report["family_references"],
             cohort_summary,
             ratio_floor,
             ratio_ceiling,
         )
-        sample = logical_reports[:20]
-        for item in sample:
+        for item in logical_reports[:20]:
             _LOG.info(
-                "[DoRA Power LoRA Loader] auto-strength: logical=%s group=%s family=%s fanout=%s mean_norm=%s cohort_mean=%s ratio=%s target=%s",
+                "[DoRA Power LoRA Loader] auto-strength: logical=%s group=%s family=%s role=%s block=%s fanout=%s update_rms=%s role_reference=%s family_reference=%s role_gain=%s depth_reference=%s depth_gain=%s anomaly_gain=%s robust_z=%s outlier=%s corrected=%s ratio_raw=%s ratio_applied=%s target=%s decision=%s fallback=%s anomaly_fallback=%s",
                 item.get("logical_id"),
                 item.get("group"),
                 item.get("family"),
+                item.get("semantic_role"),
+                item.get("block_identity") or item.get("block_identities"),
                 item.get("fanout"),
                 item.get("mean_norm"),
-                item.get("cohort_mean_norm"),
+                item.get("role_reference_score"),
+                item.get("family_reference_score"),
+                item.get("role_gain_raw"),
+                item.get("depth_reference_score"),
+                item.get("depth_gain_raw"),
+                item.get("anomaly_gain_raw"),
+                item.get("robust_z"),
+                item.get("outlier_candidate"),
+                item.get("outlier_corrected"),
+                item.get("ratio_raw"),
                 item.get("ratio_applied"),
                 item.get("target_strength"),
+                item.get("decision_reason"),
+                item.get("fallback_reason"),
+                item.get("anomaly_fallback_reason"),
             )
 
     return targets, report
@@ -4541,9 +5446,18 @@ def _auto_strength_report_line_for_group(item: Dict[str, Any]) -> str:
     target_text = "?" if target is None else f"{target:.4f}"
     norm_text = "?" if mean_norm is None else f"{mean_norm:.6g}"
     cohort_text = "?" if cohort_mean is None else f"{cohort_mean:.6g}"
+    role = str(item.get("semantic_role") or "unclassified")
+    block = item.get("block_identity")
+    fallback = item.get("fallback_reason")
+    decision = item.get("decision_reason")
+    reference_statistic = str(item.get("cohort_reference_statistic") or "reference")
+    block_text = f", block={block}" if block else ""
+    decision_text = f", decision={decision}" if decision else ""
+    fallback_text = f", fallback={fallback}" if fallback else ""
     return (
-        f"    - {item.get('group')}/{item.get('family')} :: {logical_id} "
-        f"(fanout={fanout}, ratio={ratio_text}, target={target_text}, norm={norm_text}, cohort={cohort_text})"
+        f"    - {item.get('group')}/{item.get('family')}/{role} :: {logical_id} "
+        f"(fanout={fanout}{block_text}, ratio={ratio_text}, target={target_text}, "
+        f"update_rms={norm_text}, cohort_{reference_statistic}={cohort_text}{decision_text}{fallback_text})"
     )
 
 
@@ -4605,6 +5519,8 @@ def _build_auto_strength_row_text_report(row: Dict[str, Any]) -> str:
     lines.extend(
         [
             f"  Analysis device  : {report.get('analysis_device_mode')} (load_device={report.get('analysis_load_device')})",
+            f"  Scoring          : {report.get('scoring_basis', 'absolute_update_rms')} (base_relative={bool(report.get('base_relative_scoring', False))})",
+            f"  Cohort reference : {report.get('cohort_reference_policy', {})}",
             f"  Ratio window     : {float(report.get('ratio_floor', 0.0)):.4f} .. {float(report.get('ratio_ceiling', 0.0)):.4f}",
             f"  Bases            : mapped={int(report.get('mapped_bases', 0))} analyzable={int(report.get('analyzable_bases', 0))} measured={int(report.get('measured_bases', 0))}",
             f"  Logical groups   : total={int(report.get('logical_groups_total', 0))} measured={int(report.get('logical_groups_measured', 0))} skipped_zero_strength={int(report.get('logical_groups_skipped_zero_strength', 0))}",
@@ -4614,18 +5530,33 @@ def _build_auto_strength_row_text_report(row: Dict[str, Any]) -> str:
     cohorts = report.get("cohorts") if isinstance(report.get("cohorts"), list) else []
     if cohorts:
         for cohort in cohorts:
-            mean_norm = _auto_strength_safe_number(cohort.get("mean_norm"))
-            mean_text = "?" if mean_norm is None else f"{mean_norm:.6g}"
+            reference = _auto_strength_safe_number(cohort.get("reference_score", cohort.get("mean_norm")))
+            reference_text = "?" if reference is None else f"{reference:.6g}"
+            role = cohort.get("semantic_role") or "unclassified"
+            statistic = cohort.get("reference_statistic") or "reference"
+            fallback = cohort.get("fallback_reason")
+            fallback_text = f" fallback={fallback}" if fallback else ""
+            outlier_text = ""
+            if cohort.get("family") == "linear":
+                outlier_text = " outliers={corrected}/{candidates} limit={limit}".format(
+                    corrected=int(cohort.get("corrected_logical_count", 0)),
+                    candidates=int(cohort.get("outlier_candidate_count", 0)),
+                    limit=int(cohort.get("outlier_candidate_limit", 0)),
+                )
             lines.append(
-                "    - {group}/{family}: mean={mean} logical={logical} measured_logical={measured_logical} bases={bases} measured_bases={measured_bases} skipped_zero_strength_bases={skipped}".format(
+                "    - {group}/{family}/{role}: {statistic}={reference} logical={logical} measured_logical={measured_logical} bases={bases} measured_bases={measured_bases} skipped_zero_strength_bases={skipped}{outliers}{fallback}".format(
                     group=cohort.get("group"),
                     family=cohort.get("family"),
-                    mean=mean_text,
+                    role=role,
+                    statistic=statistic,
+                    reference=reference_text,
                     logical=int(cohort.get("logical_count", 0)),
                     measured_logical=int(cohort.get("measured_logical_count", 0)),
                     bases=int(cohort.get("base_count", 0)),
                     measured_bases=int(cohort.get("measured_base_count", 0)),
                     skipped=int(cohort.get("skipped_zero_strength_base_count", 0)),
+                    outliers=outlier_text,
+                    fallback=fallback_text,
                 )
             )
     else:

--- a/nodes.py
+++ b/nodes.py
@@ -495,6 +495,7 @@ _DORA_STATE_LOADER_GLOBAL_KEYS: Set[str] = {
     "auto_strength_device",
     "auto_strength_ratio_floor",
     "auto_strength_ratio_ceiling",
+    "auto_strength_residual_beta",
 }
 
 
@@ -1927,6 +1928,7 @@ _AUTO_STRENGTH_LINEAR_MIN_SAMPLE = 5
 _AUTO_STRENGTH_LINEAR_ROLE_MIN_SAMPLE = 2
 _AUTO_STRENGTH_LINEAR_DEPTH_MIN_SAMPLE = 5
 _AUTO_STRENGTH_LINEAR_DEPTH_WINDOW = 7
+_AUTO_STRENGTH_LINEAR_RESIDUAL_BETA = 0.50
 _AUTO_STRENGTH_LINEAR_MAD_Z = 3.5
 _AUTO_STRENGTH_LINEAR_MIN_FACTOR = 1.5
 _AUTO_STRENGTH_LINEAR_MAX_CANDIDATES = 1
@@ -3915,6 +3917,7 @@ def _auto_strength_analyze_base_targets(
     strength_clip: float,
     ratio_floor: float,
     ratio_ceiling: float,
+    residual_beta: float = _AUTO_STRENGTH_LINEAR_RESIDUAL_BETA,
     logical_groups: Optional[Dict[str, Tuple[str, float]]] = None,
     verbose: bool = False,
     current_model: Any = None,
@@ -3938,6 +3941,10 @@ def _auto_strength_analyze_base_targets(
     """
     ratio_floor = max(0.0, float(ratio_floor))
     ratio_ceiling = max(ratio_floor, float(ratio_ceiling))
+    try:
+        residual_beta = max(0.0, min(1.0, float(residual_beta)))
+    except Exception:
+        residual_beta = _AUTO_STRENGTH_LINEAR_RESIDUAL_BETA
     logical_groups = logical_groups or {}
 
     grouped_norms: Dict[Tuple[str, str, str], Dict[str, List[float]]] = {}
@@ -4212,16 +4219,30 @@ def _auto_strength_analyze_base_targets(
             ):
                 base_gain = float(family_reference / depth_reference)
 
-            anomaly_gain = 1.0
             model = cohort_models.get(cohort, {})
             correction_reference = depth_reference or cohort_anomaly_references.get(cohort)
+            residual_gain = 1.0
             if (
+                depth_reference is not None
+                and depth_reference > _AUTO_STRENGTH_EPS
+            ):
+                residual_exponent = (
+                    1.0
+                    if logical_id in model.get("candidate_ids", set())
+                    else residual_beta
+                )
+                residual_gain = float(
+                    math.exp(
+                        math.log(depth_reference / norm) * residual_exponent
+                    )
+                )
+            elif (
                 logical_id in model.get("candidate_ids", set())
                 and correction_reference is not None
                 and correction_reference > _AUTO_STRENGTH_EPS
             ):
-                anomaly_gain = float(correction_reference / norm)
-            ratio = float(base_gain * anomaly_gain)
+                residual_gain = float(correction_reference / norm)
+            ratio = float(base_gain * residual_gain)
         else:
             reference = cohort_anomaly_references.get(cohort)
             model = cohort_models.get(cohort, {})
@@ -4337,6 +4358,7 @@ def _auto_strength_analyze_base_targets(
                 "depth_profile_fallback_reason": depth_model.get("fallback_reason") if is_linear else None,
                 "depth_gain_min_raw": _auto_strength_safe_number(min(depth_gains)) if depth_gains else None,
                 "depth_gain_max_raw": _auto_strength_safe_number(max(depth_gains)) if depth_gains else None,
+                "residual_beta": residual_beta if is_linear else None,
                 "role_gain_at_bounds": (
                     _auto_strength_safe_number(max(ratio_floor, min(ratio_ceiling, role_gain)))
                     if role_gain is not None
@@ -4376,8 +4398,19 @@ def _auto_strength_analyze_base_targets(
         ):
             depth_gain_raw = float(family_reference / depth_reference)
 
+        direct_family_gain_raw = None
+        if (
+            family == "linear"
+            and logical_norm is not None
+            and family_reference is not None
+            and logical_norm > _AUTO_STRENGTH_EPS
+        ):
+            direct_family_gain_raw = float(family_reference / logical_norm)
+
         ratio_raw = None
         ratio_applied = None
+        residual_gain_raw = None
+        residual_exponent_applied = None
         anomaly_gain_raw = None
         decision_reason = None
         fallback_reason = None
@@ -4390,41 +4423,62 @@ def _auto_strength_analyze_base_targets(
                 fallback_reason = cohort_role_gain_reasons.get(cohort) or "role_redistribution_unavailable"
             else:
                 base_gain = depth_gain_raw if depth_gain_raw is not None else role_gain
-                anomaly_gain_raw = 1.0
                 correction_reference = depth_reference or anomaly_reference
+                isolated_candidate = logical_id in model.get("candidate_ids", set())
+                residual_gain_raw = 1.0
+                residual_exponent_applied = 0.0
+                anomaly_gain_raw = 1.0
+
                 if (
-                    logical_id in model.get("candidate_ids", set())
+                    depth_reference is not None
+                    and depth_reference > _AUTO_STRENGTH_EPS
+                ):
+                    residual_exponent_applied = 1.0 if isolated_candidate else residual_beta
+                    residual_gain_raw = float(
+                        math.exp(
+                            math.log(depth_reference / logical_norm)
+                            * residual_exponent_applied
+                        )
+                    )
+                    if isolated_candidate:
+                        anomaly_gain_raw = float(depth_reference / logical_norm)
+                elif (
+                    isolated_candidate
                     and correction_reference is not None
                     and correction_reference > _AUTO_STRENGTH_EPS
                 ):
-                    anomaly_gain_raw = float(correction_reference / logical_norm)
+                    residual_exponent_applied = 1.0
+                    residual_gain_raw = float(correction_reference / logical_norm)
+                    anomaly_gain_raw = residual_gain_raw
+
+                if isolated_candidate:
                     decision_reason = (
-                        "depth_profile_redistribution_plus_outlier_correction"
+                        "depth_profile_hybrid_plus_outlier_correction"
                         if depth_gain_raw is not None
                         else "role_redistribution_plus_outlier_correction"
                     )
                 elif logical_id in model.get("detected_candidate_ids", set()):
                     decision_reason = (
-                        "depth_profile_redistribution_anomaly_suppressed_candidate"
+                        "depth_profile_hybrid_anomaly_suppressed_candidate"
                         if depth_gain_raw is not None
                         else "role_redistribution_anomaly_suppressed_candidate"
                     )
                 elif model.get("fallback_reason") == "multiple_outlier_candidates":
                     decision_reason = (
-                        "depth_profile_redistribution_anomaly_suppressed"
+                        "depth_profile_hybrid_anomaly_suppressed"
                         if depth_gain_raw is not None
                         else "role_redistribution_anomaly_suppressed"
                     )
                 else:
                     decision_reason = (
-                        "depth_profile_redistribution"
+                        "depth_profile_hybrid_redistribution"
                         if depth_gain_raw is not None
                         else "role_redistribution"
                     )
 
                 if not bool(model.get("eligible")):
                     anomaly_fallback_reason = model.get("fallback_reason")
-                ratio_raw = float(base_gain * anomaly_gain_raw)
+                ratio_raw = float(base_gain * residual_gain_raw)
                 ratio_applied = float(max(ratio_floor, min(ratio_ceiling, ratio_raw)))
         else:
             if (
@@ -4476,6 +4530,10 @@ def _auto_strength_analyze_base_targets(
                     "role_gain_raw": _auto_strength_safe_number(role_gain),
                     "depth_reference_score": _auto_strength_safe_number(depth_reference),
                     "depth_gain_raw": _auto_strength_safe_number(depth_gain_raw),
+                    "direct_family_gain_raw": _auto_strength_safe_number(direct_family_gain_raw),
+                    "residual_beta": residual_beta if family == "linear" else None,
+                    "residual_exponent_applied": _auto_strength_safe_number(residual_exponent_applied),
+                    "residual_gain_raw": _auto_strength_safe_number(residual_gain_raw),
                     "anomaly_gain_raw": _auto_strength_safe_number(anomaly_gain_raw),
                     "ratio_applied": _auto_strength_safe_number(base_ratio),
                     "target_strength": base_target,
@@ -4553,6 +4611,10 @@ def _auto_strength_analyze_base_targets(
                 "role_gain_raw": _auto_strength_safe_number(role_gain),
                 "depth_reference_score": _auto_strength_safe_number(depth_reference),
                 "depth_gain_raw": _auto_strength_safe_number(depth_gain_raw),
+                "direct_family_gain_raw": _auto_strength_safe_number(direct_family_gain_raw),
+                "residual_beta": residual_beta if family == "linear" else None,
+                "residual_exponent_applied": _auto_strength_safe_number(residual_exponent_applied),
+                "residual_gain_raw": _auto_strength_safe_number(residual_gain_raw),
                 "anomaly_gain_raw": _auto_strength_safe_number(anomaly_gain_raw),
                 "log_deviation": _auto_strength_safe_number(log_deviation),
                 "robust_z": _auto_strength_safe_number(robust_z),
@@ -4617,7 +4679,11 @@ def _auto_strength_analyze_base_targets(
             "window_size": _AUTO_STRENGTH_LINEAR_DEPTH_WINDOW,
             "local_reference": "centered_moving_log_median",
             "gain": "family_reference_divided_by_local_depth_reference",
-            "preserves_local_residual_structure": True,
+            "residual_beta": residual_beta,
+            "residual_gain": "(local_depth_reference_divided_by_layer_score)_to_residual_beta",
+            "isolated_outlier_residual_exponent": 1.0,
+            "endpoint_beta_0": "local_depth_only",
+            "endpoint_beta_1": "direct_family_per_layer",
         },
         "linear_outlier_policy": {
             "minimum_sample": _AUTO_STRENGTH_LINEAR_MIN_SAMPLE,
@@ -4625,12 +4691,13 @@ def _auto_strength_analyze_base_targets(
             "minimum_deviation_factor": _AUTO_STRENGTH_LINEAR_MIN_FACTOR,
             "maximum_candidates": _AUTO_STRENGTH_LINEAR_MAX_CANDIDATES,
             "correction_target": "cohort_log_median",
-            "composition": "depth_or_role_gain_times_outlier_gain",
+            "composition": "depth_or_role_gain_times_residual_gain; isolated outliers promote residual exponent to 1",
         },
         "strength_model": float(strength_model),
         "strength_clip": float(strength_clip),
         "ratio_floor": ratio_floor,
         "ratio_ceiling": ratio_ceiling,
+        "residual_beta": residual_beta,
         "mapped_bases": total,
         "analyzable_bases": analyzable,
         "measured_bases": measured,
@@ -4706,7 +4773,7 @@ def _auto_strength_analyze_base_targets(
             }
 
         _LOG.info(
-            "[DoRA Power LoRA Loader] auto-strength: measured %s/%s mapped bases (%s/%s logical groups) (scoring=absolute_update_rms linear_policy=family_local_depth_log_median_plus_single_outlier_gate family_references=%s cohorts=%s ratio_floor=%s ratio_ceiling=%s)",
+            "[DoRA Power LoRA Loader] auto-strength: measured %s/%s mapped bases (%s/%s logical groups) (scoring=absolute_update_rms linear_policy=family_local_depth_plus_log_residual_hybrid family_references=%s cohorts=%s ratio_floor=%s ratio_ceiling=%s residual_beta=%s)",
             measured,
             total,
             measured_logical,
@@ -4715,10 +4782,11 @@ def _auto_strength_analyze_base_targets(
             cohort_summary,
             ratio_floor,
             ratio_ceiling,
+            residual_beta,
         )
         for item in logical_reports[:20]:
             _LOG.info(
-                "[DoRA Power LoRA Loader] auto-strength: logical=%s group=%s family=%s role=%s block=%s fanout=%s update_rms=%s role_reference=%s family_reference=%s role_gain=%s depth_reference=%s depth_gain=%s anomaly_gain=%s robust_z=%s outlier=%s corrected=%s ratio_raw=%s ratio_applied=%s target=%s decision=%s fallback=%s anomaly_fallback=%s",
+                "[DoRA Power LoRA Loader] auto-strength: logical=%s group=%s family=%s role=%s block=%s fanout=%s update_rms=%s role_reference=%s family_reference=%s role_gain=%s depth_reference=%s depth_gain=%s direct_gain=%s residual_beta=%s residual_exp=%s residual_gain=%s anomaly_gain=%s robust_z=%s outlier=%s corrected=%s ratio_raw=%s ratio_applied=%s target=%s decision=%s fallback=%s anomaly_fallback=%s",
                 item.get("logical_id"),
                 item.get("group"),
                 item.get("family"),
@@ -4731,6 +4799,10 @@ def _auto_strength_analyze_base_targets(
                 item.get("role_gain_raw"),
                 item.get("depth_reference_score"),
                 item.get("depth_gain_raw"),
+                item.get("direct_family_gain_raw"),
+                item.get("residual_beta"),
+                item.get("residual_exponent_applied"),
+                item.get("residual_gain_raw"),
                 item.get("anomaly_gain_raw"),
                 item.get("robust_z"),
                 item.get("outlier_candidate"),
@@ -4758,6 +4830,7 @@ def _auto_strength_compute_base_targets(
     strength_clip: float,
     ratio_floor: float,
     ratio_ceiling: float,
+    residual_beta: float = _AUTO_STRENGTH_LINEAR_RESIDUAL_BETA,
     logical_groups: Optional[Dict[str, Tuple[str, float]]] = None,
     verbose: bool = False,
     current_model: Any = None,
@@ -4775,6 +4848,7 @@ def _auto_strength_compute_base_targets(
         strength_clip=strength_clip,
         ratio_floor=ratio_floor,
         ratio_ceiling=ratio_ceiling,
+        residual_beta=residual_beta,
         logical_groups=logical_groups,
         verbose=verbose,
         current_model=current_model,
@@ -5996,6 +6070,7 @@ class DoraPowerLoraLoader:
                     "auto_strength_device": (["auto", "cpu", "gpu"], {"default": "gpu"}),
                     "auto_strength_ratio_floor": ("FLOAT", {"default": _AUTO_STRENGTH_RATIO_FLOOR, "min": 0.0, "max": 16.0, "step": 0.01}),
                     "auto_strength_ratio_ceiling": ("FLOAT", {"default": _AUTO_STRENGTH_RATIO_CEILING, "min": 0.0, "max": 16.0, "step": 0.01}),
+                    "auto_strength_residual_beta": ("FLOAT", {"default": _AUTO_STRENGTH_LINEAR_RESIDUAL_BETA, "min": 0.0, "max": 1.0, "step": 0.05}),
                 },
             ),
             "hidden": {},
@@ -6036,6 +6111,7 @@ class DoraPowerLoraLoader:
         auto_strength_device: str,
         auto_strength_ratio_floor: float,
         auto_strength_ratio_ceiling: float,
+        auto_strength_residual_beta: float,
     ):
         auto_strength_report: Optional[Dict[str, Any]] = None
         lora_path = folder_paths.get_full_path("loras", lora_name)
@@ -6202,6 +6278,7 @@ class DoraPowerLoraLoader:
                 strength_clip=strength_clip,
                 ratio_floor=auto_strength_ratio_floor,
                 ratio_ceiling=auto_strength_ratio_ceiling,
+                residual_beta=auto_strength_residual_beta,
                 logical_groups=auto_strength_logical_groups,
                 verbose=verbose,
                 current_model=model,
@@ -6318,6 +6395,18 @@ class DoraPowerLoraLoader:
             auto_strength_ratio_ceiling = _AUTO_STRENGTH_RATIO_CEILING
         if auto_strength_ratio_ceiling < auto_strength_ratio_floor:
             auto_strength_ratio_floor, auto_strength_ratio_ceiling = auto_strength_ratio_ceiling, auto_strength_ratio_floor
+        try:
+            auto_strength_residual_beta = float(
+                _state_payload_get_loader_global(
+                    state_payload,
+                    "auto_strength_residual_beta",
+                    kwargs.get("auto_strength_residual_beta", _AUTO_STRENGTH_LINEAR_RESIDUAL_BETA),
+                    state_slot,
+                )
+            )
+        except Exception:
+            auto_strength_residual_beta = _AUTO_STRENGTH_LINEAR_RESIDUAL_BETA
+        auto_strength_residual_beta = max(0.0, min(1.0, auto_strength_residual_beta))
 
         _set_dora_decomp_cfg(
             dbg=dora_dbg,
@@ -6351,6 +6440,7 @@ class DoraPowerLoraLoader:
             "auto_strength_device": auto_strength_device,
             "auto_strength_ratio_floor": auto_strength_ratio_floor,
             "auto_strength_ratio_ceiling": auto_strength_ratio_ceiling,
+            "auto_strength_residual_beta": auto_strength_residual_beta,
         }
         lora_stack_payload = _build_lora_stack_payload(entries, loader_globals_payload, state_slot)
 
@@ -6362,6 +6452,7 @@ class DoraPowerLoraLoader:
                 "auto_strength_device": auto_strength_device,
                 "ratio_floor": auto_strength_ratio_floor,
                 "ratio_ceiling": auto_strength_ratio_ceiling,
+                "residual_beta": auto_strength_residual_beta,
                 "rows": report_rows,
             }
             report_json = _auto_strength_json_dumps(stack_report, pretty=True)
@@ -6382,6 +6473,7 @@ class DoraPowerLoraLoader:
                 "auto_strength_device": auto_strength_device,
                 "ratio_floor": auto_strength_ratio_floor,
                 "ratio_ceiling": auto_strength_ratio_ceiling,
+                "residual_beta": auto_strength_residual_beta,
                 "rows": report_rows,
             }
             report_json = _auto_strength_json_dumps(stack_report, pretty=True)
@@ -6478,6 +6570,7 @@ class DoraPowerLoraLoader:
                 auto_strength_device=auto_strength_device,
                 auto_strength_ratio_floor=auto_strength_ratio_floor,
                 auto_strength_ratio_ceiling=auto_strength_ratio_ceiling,
+                auto_strength_residual_beta=auto_strength_residual_beta,
             )
             did_analyze = isinstance(auto_strength_report, dict)
             if did_analyze:
@@ -6506,6 +6599,7 @@ class DoraPowerLoraLoader:
             "auto_strength_device": auto_strength_device,
             "ratio_floor": auto_strength_ratio_floor,
             "ratio_ceiling": auto_strength_ratio_ceiling,
+            "residual_beta": auto_strength_residual_beta,
             "rows": report_rows,
         }
         report_json = _auto_strength_json_dumps(stack_report, pretty=True)

--- a/tests/test_auto_strength.py
+++ b/tests/test_auto_strength.py
@@ -30,6 +30,7 @@ def _analyze(
     strength_clip=1.0,
     ratio_floor=0.1,
     ratio_ceiling=10.0,
+    residual_beta=0.0,
     logical_groups=None,
 ):
     return nodes._auto_strength_analyze_base_targets(
@@ -44,6 +45,7 @@ def _analyze(
         strength_clip=strength_clip,
         ratio_floor=ratio_floor,
         ratio_ceiling=ratio_ceiling,
+        residual_beta=residual_beta,
         logical_groups=logical_groups,
     )
 
@@ -99,6 +101,121 @@ def test_minimax_projection_regimes_are_redistributed_by_uniform_role_gain(dora_
         assert cohort["role_gain_raw"] == pytest.approx(expected_gains[cohort["semantic_role"]])
         assert cohort["family_reference_score"] == pytest.approx(expected_family_reference)
 
+
+
+def test_residual_beta_endpoints_and_log_midpoint(dora_modules):
+    nodes, _ = dora_modules
+    lora_sd = {}
+    key_map = {}
+    model_state = {}
+
+    # Seven points keep the local reference stable at 1.0 for the center block,
+    # while the center layer itself is 0.25.
+    magnitudes = (1.0, 1.0, 1.0, 0.25, 1.0, 1.0, 1.0)
+    for block, magnitude in enumerate(magnitudes):
+        _add_linear(
+            lora_sd,
+            key_map,
+            model_state,
+            f"block_{block}",
+            f"diffusion_model.blocks.{block}.mlp.fc2.weight",
+            magnitude,
+        )
+
+    family_reference = sum(magnitudes) / len(magnitudes)
+    center = "block_3"
+    local_only, local_report = _analyze(
+        nodes, lora_sd, key_map, model_state, residual_beta=0.0
+    )
+    hybrid, hybrid_report = _analyze(
+        nodes, lora_sd, key_map, model_state, residual_beta=0.5
+    )
+    direct, direct_report = _analyze(
+        nodes, lora_sd, key_map, model_state, residual_beta=1.0
+    )
+
+    # The center is the cohort's single statistical outlier, so it is deliberately
+    # promoted to full residual correction at every beta.
+    assert local_only[center] == pytest.approx(family_reference / 0.25)
+    assert hybrid[center] == pytest.approx(family_reference / 0.25)
+    assert direct[center] == pytest.approx(family_reference / 0.25)
+    assert _logical_report(hybrid_report, center)["residual_exponent_applied"] == pytest.approx(1.0)
+
+    # A non-outlier layer with score 1.0 has no residual and therefore stays at the
+    # local depth gain for all beta values.
+    for report in (local_report, hybrid_report, direct_report):
+        item = _logical_report(report, "block_2")
+        assert item["residual_gain_raw"] == pytest.approx(1.0)
+
+
+def test_residual_beta_partially_restores_non_outlier_per_layer_correction(dora_modules):
+    nodes, _ = dora_modules
+    lora_sd = {}
+    key_map = {}
+    model_state = {}
+
+    # Smooth local variation: block 3 is not an outlier, local median is 1.0, and
+    # the direct old-style gain differs from the local-depth gain.
+    magnitudes = (0.8, 0.9, 1.0, 0.7, 1.0, 1.1, 1.2)
+    for block, magnitude in enumerate(magnitudes):
+        _add_linear(
+            lora_sd,
+            key_map,
+            model_state,
+            f"block_{block}",
+            f"diffusion_model.blocks.{block}.mlp.fc2.weight",
+            magnitude,
+        )
+
+    family_reference = sum(magnitudes) / len(magnitudes)
+    local_gain = family_reference / 1.0
+    direct_gain = family_reference / 0.7
+
+    local, _ = _analyze(nodes, lora_sd, key_map, model_state, residual_beta=0.0)
+    half, half_report = _analyze(nodes, lora_sd, key_map, model_state, residual_beta=0.5)
+    direct, _ = _analyze(nodes, lora_sd, key_map, model_state, residual_beta=1.0)
+
+    expected_half = local_gain * math.sqrt(1.0 / 0.7)
+    assert local["block_3"] == pytest.approx(local_gain)
+    assert half["block_3"] == pytest.approx(expected_half)
+    assert direct["block_3"] == pytest.approx(direct_gain)
+    item = _logical_report(half_report, "block_3")
+    assert item["residual_beta"] == pytest.approx(0.5)
+    assert item["residual_exponent_applied"] == pytest.approx(0.5)
+    assert item["residual_gain_raw"] == pytest.approx(math.sqrt(1.0 / 0.7))
+    assert item["direct_family_gain_raw"] == pytest.approx(direct_gain)
+
+
+def test_analyzer_default_residual_beta_is_half(dora_modules):
+    nodes, _ = dora_modules
+    lora_sd = {}
+    key_map = {}
+    model_state = {}
+    for block, magnitude in enumerate((0.8, 0.9, 1.0, 0.7, 1.0, 1.1, 1.2)):
+        _add_linear(
+            lora_sd,
+            key_map,
+            model_state,
+            f"block_{block}",
+            f"diffusion_model.blocks.{block}.mlp.fc2.weight",
+            magnitude,
+        )
+
+    _, report = nodes._auto_strength_analyze_base_targets(
+        lora_sd=lora_sd,
+        lora_bases=sorted(nodes._extract_lora_bases(lora_sd)),
+        key_map=key_map,
+        model_state_dict=model_state,
+        clip_state_dict=None,
+        analysis_device_mode="cpu",
+        analysis_load_device=None,
+        strength_model=1.0,
+        strength_clip=1.0,
+        ratio_floor=0.1,
+        ratio_ceiling=10.0,
+    )
+    assert report["residual_beta"] == pytest.approx(0.5)
+    assert report["linear_depth_redistribution_policy"]["residual_beta"] == pytest.approx(0.5)
 
 
 def test_h3_like_weak_fc2_depth_region_recovers_large_boosts(dora_modules):

--- a/tests/test_auto_strength.py
+++ b/tests/test_auto_strength.py
@@ -1,0 +1,767 @@
+import math
+
+import pytest
+import torch
+
+
+def _linear_pair(magnitude, out_features=2, in_features=2):
+    return (
+        torch.full((out_features, 1), float(magnitude), dtype=torch.float32),
+        torch.ones((1, in_features), dtype=torch.float32),
+    )
+
+
+def _add_linear(lora_sd, key_map, state_dict, base, destination, magnitude, *, shape=(2, 2), mapping=None):
+    up, down = _linear_pair(magnitude, out_features=shape[0], in_features=shape[1])
+    lora_sd[f"{base}.lora_up.weight"] = up
+    lora_sd[f"{base}.lora_down.weight"] = down
+    key_map[base] = destination if mapping is None else mapping
+    state_dict[destination] = torch.ones(shape, dtype=torch.float32)
+
+
+def _analyze(
+    nodes,
+    lora_sd,
+    key_map,
+    model_state_dict,
+    clip_state_dict=None,
+    *,
+    strength_model=1.0,
+    strength_clip=1.0,
+    ratio_floor=0.1,
+    ratio_ceiling=10.0,
+    logical_groups=None,
+):
+    return nodes._auto_strength_analyze_base_targets(
+        lora_sd=lora_sd,
+        lora_bases=sorted(nodes._extract_lora_bases(lora_sd)),
+        key_map=key_map,
+        model_state_dict=model_state_dict,
+        clip_state_dict=clip_state_dict,
+        analysis_device_mode="cpu",
+        analysis_load_device=None,
+        strength_model=strength_model,
+        strength_clip=strength_clip,
+        ratio_floor=ratio_floor,
+        ratio_ceiling=ratio_ceiling,
+        logical_groups=logical_groups,
+    )
+
+
+def _logical_report(report, logical_id):
+    return next(item for item in report["logical_groups"] if item["logical_id"] == logical_id)
+
+
+def test_minimax_projection_regimes_are_redistributed_by_uniform_role_gain(dora_modules):
+    nodes, _ = dora_modules
+    lora_sd = {}
+    key_map = {}
+    model_state = {}
+    regimes = {
+        "attn.qkv_proj": 4.0,
+        "attn.out_proj": 2.0,
+        "mlp.fc1": 5.0,
+        "mlp.fc2": 1.0,
+    }
+
+    for block in range(50):
+        for role, magnitude in regimes.items():
+            base = f"h3_blocks_{block}_{role.replace('.', '_')}"
+            destination = f"diffusion_model.transformer.blocks.{block}.{role}.weight"
+            _add_linear(lora_sd, key_map, model_state, base, destination, magnitude)
+
+    targets, report = _analyze(nodes, lora_sd, key_map, model_state)
+
+    expected_family_reference = 3.0
+    expected_gains = {
+        "attn.qkv_proj": 0.75,
+        "attn.out_proj": 1.5,
+        "mlp.fc1": 0.6,
+        "mlp.fc2": 3.0,
+    }
+    assert len(targets) == 200
+    for block in range(50):
+        for role, expected_gain in expected_gains.items():
+            base = f"h3_blocks_{block}_{role.replace('.', '_')}"
+            assert targets[base] == pytest.approx(expected_gain)
+
+    assert report["schema"] == 2
+    assert report["scoring_basis"] == "absolute_update_rms"
+    assert report["base_relative_scoring"] is False
+    assert report["family_references"]["model/linear"] == pytest.approx(expected_family_reference)
+    assert report["cohort_reference_policy"] == {
+        "repeated_block_linear": "family_arithmetic_local_depth_log_median_plus_single_outlier_gate",
+        "other_tensor_families": "arithmetic_mean",
+    }
+    assert {cohort["semantic_role"] for cohort in report["cohorts"]} == set(regimes)
+    for cohort in report["cohorts"]:
+        assert cohort["measured_logical_count"] == 50
+        assert cohort["role_gain_raw"] == pytest.approx(expected_gains[cohort["semantic_role"]])
+        assert cohort["family_reference_score"] == pytest.approx(expected_family_reference)
+
+
+
+def test_h3_like_weak_fc2_depth_region_recovers_large_boosts(dora_modules):
+    nodes, _ = dora_modules
+    lora_sd = {}
+    key_map = {}
+    model_state = {}
+
+    for block in range(50):
+        _add_linear(
+            lora_sd,
+            key_map,
+            model_state,
+            f"qkv_{block}",
+            f"diffusion_model.blocks.{block}.attn.qkv_proj.weight",
+            1.0,
+        )
+        fc2_magnitude = 0.25 if block < 35 else 2.0
+        _add_linear(
+            lora_sd,
+            key_map,
+            model_state,
+            f"fc2_{block}",
+            f"diffusion_model.blocks.{block}.mlp.fc2.weight",
+            fc2_magnitude,
+        )
+
+    targets, report = _analyze(nodes, lora_sd, key_map, model_state)
+
+    family_reference = (50 * 1.0 + 35 * 0.25 + 15 * 2.0) / 100.0
+    early_gain = family_reference / 0.25
+    late_gain = family_reference / 2.0
+    assert early_gain > 3.5
+    assert all(targets[f"fc2_{block}"] == pytest.approx(early_gain) for block in range(0, 32))
+    assert all(targets[f"fc2_{block}"] == pytest.approx(late_gain) for block in range(38, 50))
+
+    fc2_cohort = next(c for c in report["cohorts"] if c["semantic_role"] == "mlp.fc2")
+    assert fc2_cohort["depth_profile_eligible"] is True
+    assert fc2_cohort["depth_gain_max_raw"] == pytest.approx(early_gain)
+    assert fc2_cohort["depth_gain_min_raw"] == pytest.approx(late_gain)
+
+
+def test_role_gain_preserves_depth_profile_exactly(dora_modules):
+    nodes, _ = dora_modules
+    lora_sd = {}
+    key_map = {}
+    model_state = {}
+
+    role_a = (1.0, 2.0, 3.0, 4.0, 5.0)
+    role_b = (0.5, 1.0, 1.5, 2.0, 2.5)
+    for block, magnitude in enumerate(role_a):
+        _add_linear(
+            lora_sd,
+            key_map,
+            model_state,
+            f"a_{block}",
+            f"diffusion_model.blocks.{block}.attn.qkv_proj.weight",
+            magnitude,
+        )
+    for block, magnitude in enumerate(role_b):
+        _add_linear(
+            lora_sd,
+            key_map,
+            model_state,
+            f"b_{block}",
+            f"diffusion_model.blocks.{block}.mlp.fc2.weight",
+            magnitude,
+        )
+
+    targets, report = _analyze(nodes, lora_sd, key_map, model_state)
+
+    # Family mean is 2.25; role means are 3.0 and 1.5.
+    assert all(targets[f"a_{block}"] == pytest.approx(0.75) for block in range(5))
+    assert all(targets[f"b_{block}"] == pytest.approx(1.5) for block in range(5))
+
+    gains = {cohort["semantic_role"]: cohort["role_gain_raw"] for cohort in report["cohorts"]}
+    assert gains["attn.qkv_proj"] == pytest.approx(0.75)
+    assert gains["mlp.fc2"] == pytest.approx(1.5)
+
+    # The same scalar applies to every member in each role, so trained depth ratios survive.
+    assert _logical_report(report, "a_0")["role_gain_raw"] == pytest.approx(
+        _logical_report(report, "a_4")["role_gain_raw"]
+    )
+    assert _logical_report(report, "b_0")["role_gain_raw"] == pytest.approx(
+        _logical_report(report, "b_4")["role_gain_raw"]
+    )
+
+
+def test_weak_projection_composes_depth_gain_with_isolated_outlier_correction(dora_modules):
+    nodes, _ = dora_modules
+    lora_sd = {}
+    key_map = {}
+    model_state = {}
+
+    for block in range(5):
+        for role, magnitude in {"attn.qkv_proj": 4.0, "mlp.fc2": (0.2 if block == 2 else 1.0)}.items():
+            base = f"blocks_{block}_{role.replace('.', '_')}"
+            destination = f"diffusion_model.blocks.{block}.{role}.weight"
+            _add_linear(lora_sd, key_map, model_state, base, destination, magnitude)
+
+    targets, report = _analyze(nodes, lora_sd, key_map, model_state)
+
+    weak = "blocks_2_mlp_fc2"
+    family_reference = (5 * 4.0 + 0.2 + 4 * 1.0) / 10.0
+    qkv_gain = family_reference / 4.0
+    fc2_depth_gain = family_reference / 1.0
+
+    assert targets[weak] == pytest.approx(10.0)
+    assert all(
+        targets[f"blocks_{block}_attn_qkv_proj"] == pytest.approx(qkv_gain)
+        for block in range(5)
+    )
+    assert all(
+        targets[f"blocks_{block}_mlp_fc2"] == pytest.approx(fc2_depth_gain)
+        for block in (0, 1, 3, 4)
+    )
+    weak_report = _logical_report(report, weak)
+    assert weak_report["semantic_role"] == "mlp.fc2"
+    assert weak_report["block_identity"] == "blocks.2"
+    assert weak_report["depth_reference_score"] == pytest.approx(1.0)
+    assert weak_report["depth_gain_raw"] == pytest.approx(fc2_depth_gain)
+    assert weak_report["anomaly_gain_raw"] == pytest.approx(5.0)
+    assert weak_report["ratio_raw"] == pytest.approx(fc2_depth_gain * 5.0)
+    assert weak_report["ratio_applied"] == pytest.approx(10.0)
+
+
+def test_strong_projection_uses_family_over_local_depth_reference(dora_modules):
+    nodes, _ = dora_modules
+    lora_sd = {}
+    key_map = {}
+    model_state = {}
+
+    for block in range(5):
+        base = f"blocks_{block}_mlp_fc2"
+        destination = f"diffusion_model.blocks.{block}.mlp.fc2.weight"
+        _add_linear(lora_sd, key_map, model_state, base, destination, 5.0 if block == 3 else 1.0)
+
+    targets, report = _analyze(nodes, lora_sd, key_map, model_state)
+
+    strong = "blocks_3_mlp_fc2"
+    family_reference = 9.0 / 5.0
+    assert targets[strong] == pytest.approx(family_reference / 5.0)
+    assert all(
+        targets[f"blocks_{block}_mlp_fc2"] == pytest.approx(family_reference)
+        for block in (0, 1, 2, 4)
+    )
+    strong_report = _logical_report(report, strong)
+    assert strong_report["depth_reference_score"] == pytest.approx(1.0)
+    assert strong_report["anomaly_gain_raw"] == pytest.approx(0.2)
+    assert strong_report["ratio_raw"] == pytest.approx(family_reference / 5.0)
+
+
+def test_mad_gate_composes_with_robust_local_depth_baseline(dora_modules):
+    nodes, _ = dora_modules
+    lora_sd = {}
+    key_map = {}
+    model_state = {}
+    for block, magnitude in enumerate((0.9, 1.0, 1.05, 1.1, 0.2)):
+        _add_linear(
+            lora_sd,
+            key_map,
+            model_state,
+            f"block_{block}",
+            f"diffusion_model.blocks.{block}.mlp.fc2.weight",
+            magnitude,
+        )
+
+    targets, report = _analyze(nodes, lora_sd, key_map, model_state)
+
+    family_reference = 0.85
+    assert targets["block_4"] == pytest.approx(family_reference / 0.2)
+    assert all(targets[f"block_{block}"] == pytest.approx(family_reference) for block in range(4))
+    cohort = report["cohorts"][0]
+    assert cohort["log_mad"] > 0.0
+    assert cohort["depth_profile_eligible"] is True
+    assert cohort["outlier_candidate_count"] == 1
+    assert cohort["corrected_logical_count"] == 1
+
+
+def test_bimodal_depth_regime_receives_coherent_local_gains(dora_modules):
+    nodes, _ = dora_modules
+    lora_sd = {}
+    key_map = {}
+    model_state = {}
+
+    for block in range(50):
+        magnitude = 0.5 if block < 25 else 1.0
+        _add_linear(
+            lora_sd,
+            key_map,
+            model_state,
+            f"block_{block}",
+            f"diffusion_model.blocks.{block}.attn.out_proj.weight",
+            magnitude,
+        )
+
+    targets, report = _analyze(nodes, lora_sd, key_map, model_state)
+
+    assert all(targets[f"block_{block}"] == pytest.approx(1.5) for block in range(25))
+    assert all(targets[f"block_{block}"] == pytest.approx(0.75) for block in range(25, 50))
+    cohort = report["cohorts"][0]
+    assert cohort["depth_profile_eligible"] is True
+    assert cohort["depth_profile_window_size"] == 7
+    assert cohort["outlier_candidate_count"] == 0
+    assert cohort["corrected_logical_count"] == 0
+
+
+def test_smooth_depth_profile_uses_smooth_local_baseline(dora_modules):
+    nodes, _ = dora_modules
+    lora_sd = {}
+    key_map = {}
+    model_state = {}
+
+    magnitudes = []
+    for block in range(50):
+        magnitude = 0.45 + (0.55 * block / 49.0)
+        magnitudes.append(magnitude)
+        _add_linear(
+            lora_sd,
+            key_map,
+            model_state,
+            f"block_{block}",
+            f"diffusion_model.blocks.{block}.attn.out_proj.weight",
+            magnitude,
+        )
+
+    targets, report = _analyze(nodes, lora_sd, key_map, model_state)
+
+    family_reference = sum(magnitudes) / len(magnitudes)
+    for block in (3, 10, 24, 40, 46):
+        assert targets[f"block_{block}"] == pytest.approx(
+            family_reference / magnitudes[block]
+        )
+    assert targets["block_0"] == pytest.approx(family_reference / magnitudes[3])
+    assert targets["block_49"] == pytest.approx(family_reference / magnitudes[46])
+    assert report["cohorts"][0]["depth_profile_eligible"] is True
+
+
+def test_populous_tail_is_redistributed_as_a_coherent_depth_regime(dora_modules):
+    nodes, _ = dora_modules
+    lora_sd = {}
+    key_map = {}
+    model_state = {}
+
+    for block in range(50):
+        magnitude = 0.5 if block < 20 else 1.0
+        _add_linear(
+            lora_sd,
+            key_map,
+            model_state,
+            f"block_{block}",
+            f"diffusion_model.blocks.{block}.attn.out_proj.weight",
+            magnitude,
+        )
+
+    targets, report = _analyze(nodes, lora_sd, key_map, model_state)
+
+    assert all(targets[f"block_{block}"] == pytest.approx(1.6) for block in range(20))
+    assert all(targets[f"block_{block}"] == pytest.approx(0.8) for block in range(20, 50))
+    cohort = report["cohorts"][0]
+    assert cohort["redistribution_eligible"] is True
+    assert cohort["depth_profile_eligible"] is True
+    assert cohort["outlier_candidate_count"] == 20
+    assert cohort["outlier_candidate_limit"] == 1
+    assert cohort["corrected_logical_count"] == 0
+    assert cohort["anomaly_fallback_reason"] == "multiple_outlier_candidates"
+
+
+def test_multiple_outlier_candidates_suppress_only_individual_correction(dora_modules):
+    nodes, _ = dora_modules
+    lora_sd = {}
+    key_map = {}
+    model_state = {}
+
+    magnitudes = (0.2, 1.0, 1.0, 1.0, 1.0, 5.0)
+    for block, magnitude in enumerate(magnitudes):
+        _add_linear(
+            lora_sd,
+            key_map,
+            model_state,
+            f"block_{block}",
+            f"diffusion_model.blocks.{block}.attn.out_proj.weight",
+            magnitude,
+        )
+
+    targets, report = _analyze(nodes, lora_sd, key_map, model_state)
+
+    family_reference = sum(magnitudes) / len(magnitudes)
+    assert all(target == pytest.approx(family_reference) for target in targets.values())
+    cohort = report["cohorts"][0]
+    assert cohort["outlier_candidate_count"] == 2
+    assert cohort["outlier_candidate_limit"] == 1
+    assert cohort["corrected_logical_count"] == 0
+    assert cohort["anomaly_fallback_reason"] == "multiple_outlier_candidates"
+
+
+def test_tiny_linear_cohort_cannot_infer_anomalies(dora_modules):
+    nodes, _ = dora_modules
+    lora_sd = {}
+    key_map = {}
+    model_state = {}
+    for block, magnitude in enumerate((0.1, 10.0)):
+        _add_linear(
+            lora_sd,
+            key_map,
+            model_state,
+            f"block_{block}",
+            f"diffusion_model.blocks.{block}.mlp.fc2.weight",
+            magnitude,
+        )
+
+    targets, report = _analyze(nodes, lora_sd, key_map, model_state)
+
+    assert targets == {"block_0": 1.0, "block_1": 1.0}
+    assert report["cohorts"][0]["fallback_reason"] is None
+    assert report["cohorts"][0]["anomaly_fallback_reason"] == "insufficient_outlier_sample"
+    assert all(item["ratio_applied"] == pytest.approx(1.0) for item in report["logical_groups"])
+
+
+@pytest.mark.parametrize(
+    ("destination", "expected_role", "expected_block"),
+    [
+        ("diffusion_model.double_blocks.7.img_attn.qkv.weight", "img_attn.qkv", "double_blocks.7"),
+        (
+            "diffusion_model.input_blocks.4.1.transformer_blocks.0.attn1.to_q.weight",
+            "attn1.to_q",
+            "input_blocks.4/transformer_blocks.0",
+        ),
+        (
+            "clip.transformer.text_model.encoder.layers.11.self_attn.q_proj.weight",
+            "self_attn.q_proj",
+            "layers.11",
+        ),
+    ],
+)
+def test_projection_role_inference_uses_generic_repeated_paths(
+    dora_modules, destination, expected_role, expected_block
+):
+    nodes, _ = dora_modules
+    base = "adapter"
+    metadata = nodes._auto_strength_projection_metadata(
+        base,
+        {base: destination},
+        torch.ones((2, 2), dtype=torch.float32),
+    )
+
+    assert metadata["semantic_role"] == expected_role
+    assert metadata["block_identity"] == expected_block
+    assert metadata["cohort_eligible"] is True
+
+
+def test_linear_cohort_shape_uses_logical_adapter_shape_not_packed_storage(dora_modules):
+    nodes, _ = dora_modules
+    lora_sd = {}
+    key_map = {}
+    model_state = {}
+
+    for block in range(5):
+        base = f"packed_{block}"
+        destination = f"diffusion_model.blocks.{block}.mlp.fc1.weight"
+        up, down = _linear_pair(1.0, out_features=4, in_features=4)
+        lora_sd[f"{base}.lora_up.weight"] = up
+        lora_sd[f"{base}.lora_down.weight"] = down
+        key_map[base] = destination
+        # Alternate physical storage shapes to emulate packed vs ordinary checkpoint tensors.
+        model_state[destination] = torch.ones((4, 2 if block % 2 else 4), dtype=torch.float32)
+
+    targets, report = _analyze(nodes, lora_sd, key_map, model_state)
+
+    assert all(value == pytest.approx(1.0) for value in targets.values())
+    assert len(report["cohorts"]) == 1
+    cohort = report["cohorts"][0]
+    assert cohort["destination_shape"] == "4x4"
+    assert cohort["destination_shape_source"] == "adapter_update"
+    assert cohort["measured_logical_count"] == 5
+
+
+def test_unclassifiable_and_non_transformer_linear_layers_fall_back_safely(dora_modules):
+    nodes, _ = dora_modules
+    lora_sd = {}
+    key_map = {}
+    model_state = {}
+
+    _add_linear(lora_sd, key_map, model_state, "head_a", "model.classifier.0.weight", 0.1)
+    _add_linear(lora_sd, key_map, model_state, "head_b", "model.classifier.2.weight", 10.0)
+    targets, report = _analyze(nodes, lora_sd, key_map, model_state)
+
+    assert targets == {"head_a": 1.0, "head_b": 1.0}
+    for logical_id in targets:
+        item = _logical_report(report, logical_id)
+        assert item["semantic_role"] is None
+        assert item["ratio_applied"] is None
+        assert item["fallback_to_global"] is True
+        assert item["fallback_reason"] == "semantic_role_unresolved"
+
+
+def test_conv_family_keeps_family_cohorting(dora_modules):
+    nodes, _ = dora_modules
+    lora_sd = {}
+    key_map = {}
+    model_state = {}
+    for index, magnitude in enumerate((1.0, 4.0)):
+        base = f"conv_{index}"
+        destination = f"diffusion_model.convs.{index}.weight"
+        lora_sd[f"{base}.lora_up.weight"] = torch.full((2, 1, 1, 1), magnitude)
+        lora_sd[f"{base}.lora_down.weight"] = torch.ones((1, 2, 3, 3))
+        key_map[base] = destination
+        model_state[destination] = torch.ones((2, 2, 3, 3))
+
+    targets, report = _analyze(nodes, lora_sd, key_map, model_state)
+
+    assert targets["conv_0"] == pytest.approx(2.5)
+    assert targets["conv_1"] == pytest.approx(0.625)
+    assert len(report["cohorts"]) == 1
+    assert report["cohorts"][0]["family"] == "conv:3x3"
+    assert report["cohorts"][0]["reference_statistic"] == "arithmetic_mean"
+    assert report["cohorts"][0]["reference_score"] == pytest.approx(2.5)
+
+
+def test_model_and_clip_roles_never_share_a_cohort(dora_modules):
+    nodes, _ = dora_modules
+    lora_sd = {}
+    key_map = {}
+    model_state = {}
+    clip_state = {}
+
+    for block, magnitude in enumerate((0.2, 1.0, 1.0, 1.0, 1.0)):
+        _add_linear(
+            lora_sd,
+            key_map,
+            model_state,
+            f"model_{block}",
+            f"diffusion_model.blocks.{block}.attn.q_proj.weight",
+            magnitude,
+        )
+    for block in range(5):
+        _add_linear(
+            lora_sd,
+            key_map,
+            clip_state,
+            f"clip_{block}",
+            f"clip.encoder.layers.{block}.self_attn.q_proj.weight",
+            100.0,
+        )
+
+    targets, report = _analyze(nodes, lora_sd, key_map, model_state, clip_state)
+
+    model_family_reference = 0.84
+    assert targets["model_0"] == pytest.approx(model_family_reference * 5.0)
+    assert all(targets[f"model_{block}"] == pytest.approx(model_family_reference) for block in range(1, 5))
+    assert all(targets[f"clip_{block}"] == pytest.approx(1.0) for block in range(5))
+    assert {cohort["group"] for cohort in report["cohorts"]} == {"model", "clip"}
+
+
+def test_same_named_roles_with_different_shapes_do_not_share_a_cohort(dora_modules):
+    nodes, _ = dora_modules
+    lora_sd = {}
+    key_map = {}
+    model_state = {}
+    specs = [
+        *((block, (2, 2), 0.2 if block == 0 else 1.0) for block in range(5)),
+        *((block + 5, (3, 3), 1.0) for block in range(5)),
+    ]
+    for block, shape, magnitude in specs:
+        _add_linear(
+            lora_sd,
+            key_map,
+            model_state,
+            f"shape_{block}",
+            f"diffusion_model.blocks.{block}.attn.q_proj.weight",
+            magnitude,
+            shape=shape,
+        )
+
+    targets, report = _analyze(nodes, lora_sd, key_map, model_state)
+
+    family_reference = (0.2 + 4 * 1.0 + 5 * 1.0) / 10.0
+    assert targets["shape_0"] == pytest.approx(family_reference * 5.0)
+    assert all(
+        targets[f"shape_{block}"] == pytest.approx(family_reference)
+        for block in range(1, 10)
+    )
+    assert {cohort["destination_shape"] for cohort in report["cohorts"]} == {"2x2", "3x3"}
+    assert len(report["cohorts"]) == 2
+
+
+def test_logical_fanout_and_sliced_targets_are_not_double_counted(dora_modules):
+    nodes, _ = dora_modules
+    lora_sd = {}
+    key_map = {}
+    model_state = {}
+    logical_groups = {}
+
+    for logical_index in range(5):
+        logical_id = f"source_{logical_index}"
+        magnitude = 0.1 if logical_index == 0 else 0.5
+        for clone in range(2):
+            block = logical_index * 2 + clone
+            base = f"slice_{block}"
+            destination = f"diffusion_model.blocks.{block}.attn.qkv.weight"
+            _add_linear(
+                lora_sd,
+                key_map,
+                model_state,
+                base,
+                destination,
+                magnitude,
+                shape=(2, 2),
+                mapping=(destination, (0, 0, 2)),
+            )
+            logical_groups[base] = (logical_id, 0.5)
+
+    targets, report = _analyze(
+        nodes,
+        lora_sd,
+        key_map,
+        model_state,
+        logical_groups=logical_groups,
+    )
+
+    assert report["logical_groups_total"] == 5
+    assert report["logical_groups_measured"] == 5
+    assert all(_logical_report(report, f"source_{index}")["fanout"] == 2 for index in range(5))
+    assert targets["slice_0"] == pytest.approx(5.0)
+    assert targets["slice_1"] == pytest.approx(5.0)
+    assert all(targets[f"slice_{block}"] == pytest.approx(1.0) for block in range(2, 10))
+
+
+def test_alpha_and_no_alpha_scaling_preserve_source_tensors_and_dora_magnitude(dora_modules):
+    nodes, _ = dora_modules
+    up = torch.tensor([[1.0], [2.0]])
+    down = torch.tensor([[3.0, 4.0]])
+    alpha = torch.tensor(2.0)
+    dora_scale = torch.tensor([1.0, 1.0])
+    with_alpha = {
+        "layer.lora_up.weight": up,
+        "layer.lora_down.weight": down,
+        "layer.alpha": alpha,
+        "layer.dora_scale": dora_scale,
+    }
+
+    scaled_alpha, changed = nodes._apply_base_strength_ratios(with_alpha, {"layer": 2.5})
+
+    assert changed is True
+    assert scaled_alpha["layer.alpha"].item() == pytest.approx(5.0)
+    assert with_alpha["layer.alpha"].item() == pytest.approx(2.0)
+    assert scaled_alpha["layer.lora_up.weight"] is up
+    assert scaled_alpha["layer.lora_down.weight"] is down
+    assert scaled_alpha["layer.dora_scale"] is dora_scale
+
+    without_alpha = {
+        "layer.lora_up.weight": up,
+        "layer.lora_down.weight": down,
+        "layer.dora_scale": dora_scale,
+    }
+    scaled_up, changed = nodes._apply_base_strength_ratios(without_alpha, {"layer": 0.25})
+
+    assert changed is True
+    torch.testing.assert_close(scaled_up["layer.lora_up.weight"], up * 0.25)
+    torch.testing.assert_close(without_alpha["layer.lora_up.weight"], up)
+    assert scaled_up["layer.lora_down.weight"] is down
+    assert scaled_up["layer.dora_scale"] is dora_scale
+
+    no_op, changed = nodes._apply_base_strength_ratios(with_alpha, {"layer": 1.0})
+    assert changed is False
+    assert no_op["layer.alpha"] is alpha
+    assert no_op["layer.lora_up.weight"] is up
+    assert no_op["layer.lora_down.weight"] is down
+    assert no_op["layer.dora_scale"] is dora_scale
+
+
+def test_dora_measurement_remains_post_normalization_update_rms(dora_modules):
+    nodes, _ = dora_modules
+    weight = torch.tensor([[1.0, 0.0], [0.0, 1.0]])
+    delta = torch.tensor([[0.0, 0.25], [0.5, 0.0]])
+    dora_scale = torch.ones(2)
+
+    measured = nodes._auto_strength_measure_dora_effect(weight, delta, dora_scale)
+
+    weight_calc = weight + delta
+    expected_weight = weight_calc * (
+        dora_scale.reshape(2, 1)
+        / (weight_calc.reshape(2, -1).norm(dim=1, keepdim=True) + torch.finfo(torch.float32).eps)
+    )
+    expected = (expected_weight - weight).norm().item() / math.sqrt(weight.numel())
+    assert measured == pytest.approx(expected)
+
+
+def test_zero_global_strength_and_ratio_clamps_are_safe(dora_modules):
+    nodes, _ = dora_modules
+    lora_sd = {}
+    key_map = {}
+    model_state = {}
+    for role, magnitudes in {
+        "mlp.fc1": (0.01, 1.0, 1.0, 1.0, 1.0),
+        "mlp.fc2": (100.0, 1.0, 1.0, 1.0, 1.0),
+    }.items():
+        for block, magnitude in enumerate(magnitudes):
+            base = f"{role.replace('.', '_')}_{block}"
+            _add_linear(
+                lora_sd,
+                key_map,
+                model_state,
+                base,
+                f"diffusion_model.blocks.{block}.{role}.weight",
+                magnitude,
+            )
+
+    zero_targets, zero_report = _analyze(
+        nodes,
+        lora_sd,
+        key_map,
+        model_state,
+        strength_model=0.0,
+    )
+    zero_ratios = nodes._auto_strength_targets_to_ratios(
+        zero_targets, key_map, model_state, None, strength_model=0.0, strength_clip=0.0
+    )
+
+    assert all(target == 0.0 for target in zero_targets.values())
+    assert all(ratio == 1.0 for ratio in zero_ratios.values())
+    assert zero_report["measured_bases"] == 0
+
+    clamped_targets, report = _analyze(
+        nodes,
+        lora_sd,
+        key_map,
+        model_state,
+        ratio_floor=0.5,
+        ratio_ceiling=2.0,
+    )
+    assert clamped_targets["mlp_fc1_0"] == pytest.approx(2.0)
+    assert clamped_targets["mlp_fc2_0"] == pytest.approx(0.5)
+    assert _logical_report(report, "mlp_fc1_0")["anomaly_gain_raw"] == pytest.approx(100.0)
+    assert _logical_report(report, "mlp_fc2_0")["anomaly_gain_raw"] == pytest.approx(0.01)
+    assert _logical_report(report, "mlp_fc1_0")["depth_gain_raw"] > 10.0
+    assert _logical_report(report, "mlp_fc2_0")["depth_gain_raw"] > 10.0
+    assert _logical_report(report, "mlp_fc1_0")["ratio_raw"] > 1000.0
+    assert 0.1 < _logical_report(report, "mlp_fc2_0")["ratio_raw"] < 0.2
+
+
+def test_standard_lora_scoring_is_checkpoint_weight_independent(dora_modules):
+    nodes, _ = dora_modules
+    lora_sd = {}
+    key_map = {}
+    model_state_a = {}
+    for block, magnitude in enumerate((0.2, 1.0, 1.0, 1.0, 1.0)):
+        _add_linear(
+            lora_sd,
+            key_map,
+            model_state_a,
+            f"block_{block}",
+            f"diffusion_model.blocks.{block}.mlp.fc2.weight",
+            magnitude,
+        )
+    model_state_b = {key: value * 1000.0 for key, value in model_state_a.items()}
+
+    targets_a, report_a = _analyze(nodes, lora_sd, key_map, model_state_a)
+    targets_b, report_b = _analyze(nodes, lora_sd, key_map, model_state_b)
+
+    assert targets_a == pytest.approx(targets_b)
+    assert [item["update_rms"] for item in report_a["logical_groups"]] == pytest.approx(
+        [item["update_rms"] for item in report_b["logical_groups"]]
+    )
+    assert all(item["base_weight_rms"] is None for item in report_a["logical_groups"])
+    assert all(item["relative_perturbation"] is None for item in report_a["logical_groups"])

--- a/tests/test_runtime_bypass.py
+++ b/tests/test_runtime_bypass.py
@@ -250,6 +250,69 @@ def test_stacked_runtime_loras_match_additive_lora_math_and_restore_forward(dora
     torch.testing.assert_close(model.layer(x), base)
 
 
+def test_auto_strength_ratio_has_runtime_and_materialized_parity(dora_modules):
+    nodes, runtime = dora_modules
+
+    class TinyModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.layer = torch.nn.Linear(3, 2, bias=False)
+
+    source = {
+        "adapter.lora_up.weight": torch.tensor([[0.8], [-0.3]], dtype=torch.float32),
+        "adapter.lora_down.weight": torch.tensor([[0.4, -0.2, 0.6]], dtype=torch.float32),
+        "adapter.alpha": torch.tensor(1.0, dtype=torch.float32),
+    }
+    auto_ratio = 2.5
+    outer_strength = 0.65
+    scaled, changed = nodes._apply_base_strength_ratios(source, {"adapter": auto_ratio})
+    assert changed is True
+    adapter = nodes.comfy.lora.load_lora(
+        scaled,
+        {"adapter": "layer.weight"},
+    )["layer.weight"]
+
+    model = TinyModel()
+    with torch.no_grad():
+        model.layer.weight.copy_(
+            torch.tensor(
+                [[0.20, -0.40, 0.10], [0.50, 0.30, -0.20]],
+                dtype=torch.float32,
+            )
+        )
+    x = torch.tensor([[0.2, -0.7, 1.1], [1.3, 0.4, -0.2]], dtype=torch.float32)
+    base_output = model.layer(x).detach().clone()
+    expected_delta = (
+        F.linear(F.linear(x, source["adapter.lora_down.weight"]), source["adapter.lora_up.weight"])
+        * auto_ratio
+        * outer_strength
+    )
+
+    injections, hook_count = runtime._make_stacked_injection(
+        model,
+        [
+            {
+                "key": "layer.weight",
+                "adapter": adapter,
+                "strength": outer_strength,
+                "lora_name": "auto.safetensors",
+            }
+        ],
+    )
+    assert hook_count == 1
+    injections[0].inject(None)
+    try:
+        torch.testing.assert_close(model.layer(x), base_output + expected_delta)
+    finally:
+        injections[0].eject(None)
+
+    materialized_weight = model.layer.weight.detach() + (
+        source["adapter.lora_up.weight"] @ source["adapter.lora_down.weight"]
+    ) * auto_ratio * outer_strength
+    torch.testing.assert_close(F.linear(x, materialized_weight), base_output + expected_delta)
+    torch.testing.assert_close(model.layer(x), base_output)
+
+
 def test_load_loras_intercepts_cloned_patcher_end_to_end(dora_modules, monkeypatch):
     _, runtime = dora_modules
     comfy_weight_adapter = runtime.comfy.weight_adapter

--- a/web/dora_power_lora_loader.js
+++ b/web/dora_power_lora_loader.js
@@ -1478,7 +1478,24 @@ class DoraAutoStrengthReportWidget {
       ctx.fillText(fitText(ctx, topLine, cardWidth - 24), x + 12, y + 48);
 
       const cohortNames = Array.isArray(row.report?.cohorts)
-        ? row.report.cohorts.map((cohort) => `${cohort.group}/${cohort.family}`).join("  ·  ")
+        ? row.report.cohorts
+            .map((cohort) => {
+              const name = `${cohort.group}/${cohort.family}/${cohort.semantic_role || "unclassified"}`;
+              if (cohort.family !== "linear") return name;
+              const minDepthGain = toFiniteNumberOrNull(cohort.depth_gain_min_raw);
+              const maxDepthGain = toFiniteNumberOrNull(cohort.depth_gain_max_raw);
+              const roleGain = toFiniteNumberOrNull(cohort.role_gain_raw);
+              let gainText = "gain —";
+              if (minDepthGain !== null && maxDepthGain !== null) {
+                gainText = Math.abs(maxDepthGain - minDepthGain) <= 1e-6
+                  ? `depth ×${formatNumber(minDepthGain, 2)}`
+                  : `depth ×${formatNumber(minDepthGain, 2)}–${formatNumber(maxDepthGain, 2)}`;
+              } else if (roleGain !== null) {
+                gainText = `role ×${formatNumber(roleGain, 2)}`;
+              }
+              return `${name} ${gainText} · ${cohort.corrected_logical_count || 0}/${cohort.outlier_candidate_count || 0} outliers corrected`;
+            })
+            .join("  ·  ")
         : "";
       ctx.fillText(fitText(ctx, cohortNames, cardWidth - 24), x + 12, y + 66);
 

--- a/web/dora_power_lora_loader.js
+++ b/web/dora_power_lora_loader.js
@@ -584,6 +584,7 @@ function defaultState() {
       auto_strength_device: "gpu",
       auto_strength_ratio_floor: 0.30,
       auto_strength_ratio_ceiling: 1.50,
+      auto_strength_residual_beta: 0.50,
       dora_decompose_debug: false,
       dora_decompose_debug_n: 30,
       dora_decompose_debug_stack_depth: 10,
@@ -627,6 +628,9 @@ function sanitizeState(st) {
     auto_strength_ratio_ceiling: Number.isFinite(+globalsIn.auto_strength_ratio_ceiling)
       ? Math.max(0, +globalsIn.auto_strength_ratio_ceiling)
       : 1.50,
+    auto_strength_residual_beta: Number.isFinite(+globalsIn.auto_strength_residual_beta)
+      ? Math.max(0, Math.min(1, +globalsIn.auto_strength_residual_beta))
+      : 0.50,
     dora_decompose_debug: globalsIn.dora_decompose_debug !== undefined ? !!globalsIn.dora_decompose_debug : false,
     dora_decompose_debug_n: Number.isFinite(+globalsIn.dora_decompose_debug_n)
       ? Math.max(0, Math.floor(+globalsIn.dora_decompose_debug_n))
@@ -1849,6 +1853,20 @@ function buildUI(node, state, loraValues) {
   );
   wAutoStrengthCeiling.label = "Auto-strength ratio ceiling";
 
+  const wAutoStrengthResidualBeta = node.addWidget(
+    "number",
+    "auto_strength_residual_beta",
+    Number.isFinite(+node._doraGlobals.auto_strength_residual_beta)
+      ? +node._doraGlobals.auto_strength_residual_beta
+      : 0.50,
+    (v) => {
+      node._doraGlobals.auto_strength_residual_beta = Math.max(0, Math.min(1, +v || 0));
+      persistNodeState(node);
+    },
+    { min: 0.0, max: 1.0, step: 0.05 }
+  );
+  wAutoStrengthResidualBeta.label = "Auto-strength residual β (0=local, 1=old per-layer)";
+
   const autoStrengthReportWidget =
     reusableCustomWidgets.report || new DoraAutoStrengthReportWidget("auto_strength_visualization", node);
   autoStrengthReportWidget.parentNode = node;
@@ -1920,6 +1938,7 @@ app.registerExtension({
               auto_strength_device: "gpu",
               auto_strength_ratio_floor: 0.30,
               auto_strength_ratio_ceiling: 1.50,
+              auto_strength_residual_beta: 0.50,
               dora_decompose_debug: false,
               dora_decompose_debug_n: 30,
               dora_decompose_debug_stack_depth: 10,


### PR DESCRIPTION
Temporary mirror PR for validating the configurable log-space residual hybrid. Do not merge; PR #74 is the real PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a configurable residual correction control for automatic strength adjustment.
  - The setting ranges from 0 to 1, defaults to 0.50, and is available in the loader interface.
  - Lower values favor local-depth correction, while higher values apply stronger direct layer correction.
  - Isolated outliers continue receiving full correction automatically.

- **Documentation**
  - Updated the README with the new behavior and setting details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->