### PR TITLE
Add distribution-safe State Manager serialization

### DIFF
--- a/docs/STATE_MANAGER_DISTRIBUTION_SAFE_SERIALIZATION.md
+++ b/docs/STATE_MANAGER_DISTRIBUTION_SAFE_SERIALIZATION.md
@@ -1,0 +1,47 @@
+# State Manager: distribution-safe workflow serialization
+
+The State Manager keeps its character/prompt library in persistent local storage and normally serializes only workflow binding state plus the currently selected character/prompt UUIDs.
+
+For workflows intended for public distribution, even those local UUID bindings are unnecessary. Enable **Distribution-safe workflow serialization** in the State Manager's **Settings / seed** panel.
+
+When enabled, workflow saves/exports serialize:
+
+```text
+selected_character_id = default_character
+selected_prompt_id    = default_prompt
+```
+
+instead of the currently selected local UUIDs.
+
+## What it does not change
+
+The option only rewrites the serialized workflow output. It does **not** change:
+
+- the live selected character or prompt in the current ComfyUI session;
+- the persistent State Manager library;
+- connected DoRA/LoRA state;
+- prompt/seed/settings state;
+- queued runtime selection or generation behavior.
+
+This means a release author can keep working with a private local preset while every workflow save/export remains clean for distribution.
+
+## Workflow-level behavior
+
+The toggle is stored as the workflow node property:
+
+```text
+dora_state_manager_distribution_safe_serialization = true
+```
+
+It is disabled by default for backward compatibility.
+
+A distributed workflow may intentionally ship with the option enabled. In that case, users who want their own local character/prompt selection to persist into future workflow saves should disable the option after importing the workflow.
+
+## Scope
+
+The feature sanitizes both serialization forms when present:
+
+- positional `widgets_values`;
+- named `widgets_values_named`.
+
+It supports both the current `State Manager` node class and the legacy `DoRA State Manager` class.

--- a/tests/test_state_manager_distribution_safe_frontend.mjs
+++ b/tests/test_state_manager_distribution_safe_frontend.mjs
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+
+async function loadDistributionSafeExtension() {
+  const sourceUrl = new URL("../web/dora_state_manager_distribution_safe.js", import.meta.url);
+  let source = await readFile(sourceUrl, "utf8");
+  source = source.replace(
+    'import { app } from "../../scripts/app.js";',
+    'let capturedExtension = null; const app = { registerExtension(value) { capturedExtension = value; } };',
+  );
+  source += `\nexport { capturedExtension };\n`;
+  const encoded = Buffer.from(source, "utf8").toString("base64");
+  return import(`data:text/javascript;base64,${encoded}#${Date.now()}-${Math.random()}`);
+}
+
+
+function makeNodeType(className = "State Manager") {
+  class StateManagerNode {
+    onSerialize(output) {
+      output.widgets_values = this.widgets.map((widget) => widget.value);
+      output.widgets_values_named = Object.fromEntries(
+        this.widgets.map((widget) => [widget.name, widget.value]),
+      );
+      output.properties = { ...this.properties };
+    }
+  }
+  StateManagerNode.comfyClass = className;
+  return StateManagerNode;
+}
+
+
+function makeNode(StateManagerNode, enabled) {
+  const node = new StateManagerNode();
+  node.properties = {
+    dora_state_manager_distribution_safe_serialization: enabled,
+  };
+  node.widgets = [
+    { name: "state_json", value: '{"version":1,"kind":"dora_state_manager_binding"}' },
+    { name: "ui_state_json", value: '{"version":2}' },
+    { name: "selected_character_id", value: "private-character-uuid" },
+    { name: "selected_prompt_id", value: "private-prompt-uuid" },
+  ];
+  return node;
+}
+
+
+test("distribution-safe mode scrubs only serialized selection bindings", async () => {
+  const helpers = await loadDistributionSafeExtension();
+  const StateManagerNode = makeNodeType();
+  await helpers.capturedExtension.beforeRegisterNodeDef(StateManagerNode, {
+    name: "State Manager",
+    input: { required: {} },
+  });
+
+  const node = makeNode(StateManagerNode, true);
+  const output = {};
+  node.onSerialize(output);
+
+  assert.equal(output.widgets_values[2], "default_character");
+  assert.equal(output.widgets_values[3], "default_prompt");
+  assert.equal(output.widgets_values_named.selected_character_id, "default_character");
+  assert.equal(output.widgets_values_named.selected_prompt_id, "default_prompt");
+  assert.equal(output.properties.dora_state_manager_distribution_safe_serialization, true);
+
+  // The live widgets remain on the real local selection, so queue/generation state is unchanged.
+  assert.equal(node.widgets[2].value, "private-character-uuid");
+  assert.equal(node.widgets[3].value, "private-prompt-uuid");
+});
+
+
+test("normal mode preserves selected local UUID bindings", async () => {
+  const helpers = await loadDistributionSafeExtension();
+  const StateManagerNode = makeNodeType();
+  await helpers.capturedExtension.beforeRegisterNodeDef(StateManagerNode, {
+    name: "State Manager",
+    input: { required: {} },
+  });
+
+  const node = makeNode(StateManagerNode, false);
+  const output = {};
+  node.onSerialize(output);
+
+  assert.equal(output.widgets_values[2], "private-character-uuid");
+  assert.equal(output.widgets_values[3], "private-prompt-uuid");
+  assert.equal(output.widgets_values_named.selected_character_id, "private-character-uuid");
+  assert.equal(output.widgets_values_named.selected_prompt_id, "private-prompt-uuid");
+});
+
+
+test("legacy State Manager class receives the same protection", async () => {
+  const helpers = await loadDistributionSafeExtension();
+  const LegacyNode = makeNodeType("DoRA State Manager");
+  await helpers.capturedExtension.beforeRegisterNodeDef(LegacyNode, {
+    name: "DoRA State Manager",
+    input: { required: {} },
+  });
+
+  const node = makeNode(LegacyNode, true);
+  const output = {};
+  node.onSerialize(output);
+
+  assert.equal(output.widgets_values_named.selected_character_id, "default_character");
+  assert.equal(output.widgets_values_named.selected_prompt_id, "default_prompt");
+});

--- a/web/dora_state_manager_distribution_safe.js
+++ b/web/dora_state_manager_distribution_safe.js
@@ -1,0 +1,181 @@
+import { app } from "../../scripts/app.js";
+
+const EXT_NAME = "comfyui_dora_dynamic_lora.state_manager_distribution_safe";
+const NODE_CLASSES = new Set(["State Manager", "DoRA State Manager"]);
+const PROPERTY = "dora_state_manager_distribution_safe_serialization";
+const SELECTED_CHARACTER_WIDGET = "selected_character_id";
+const SELECTED_PROMPT_WIDGET = "selected_prompt_id";
+const DEFAULT_CHARACTER_ID = "default_character";
+const DEFAULT_PROMPT_ID = "default_prompt";
+const CONTROL_ATTR = "data-dsm-distribution-safe-control";
+
+function isStateManagerDef(nodeData, nodeType) {
+  return [nodeData?.name, nodeData?.display_name, nodeType?.comfyClass, nodeType?.title]
+    .map((value) => String(value ?? ""))
+    .some((value) => NODE_CLASSES.has(value));
+}
+
+function isStateManagerNode(node) {
+  return [node?.comfyClass, node?.type, node?.constructor?.title]
+    .map((value) => String(value ?? ""))
+    .some((value) => NODE_CLASSES.has(value));
+}
+
+function isDistributionSafe(node) {
+  return node?.properties?.[PROPERTY] === true;
+}
+
+function setDistributionSafe(node, enabled) {
+  if (!node) return;
+  node.properties = node.properties || {};
+  node.properties[PROPERTY] = Boolean(enabled);
+  node.graph?.change?.();
+  node.setDirtyCanvas?.(true, true);
+  renderDistributionSafeControl(node);
+}
+
+function setSerializedWidget(output, node, widgetName, value) {
+  if (!output || !node) return false;
+  const widgets = Array.isArray(node.widgets) ? node.widgets : [];
+  const index = widgets.findIndex((widget) => widget?.name === widgetName);
+  let changed = false;
+
+  if (Array.isArray(output.widgets_values) && index >= 0) {
+    output.widgets_values[index] = value;
+    changed = true;
+  }
+  if (output.widgets_values_named && typeof output.widgets_values_named === "object") {
+    output.widgets_values_named[widgetName] = value;
+    changed = true;
+  }
+  return changed;
+}
+
+function applyDistributionSafeSerialization(output, node) {
+  if (!isDistributionSafe(node)) return false;
+  const characterChanged = setSerializedWidget(
+    output,
+    node,
+    SELECTED_CHARACTER_WIDGET,
+    DEFAULT_CHARACTER_ID,
+  );
+  const promptChanged = setSerializedWidget(
+    output,
+    node,
+    SELECTED_PROMPT_WIDGET,
+    DEFAULT_PROMPT_ID,
+  );
+  return characterChanged || promptChanged;
+}
+
+function findSettingsTabs(root) {
+  for (const tabs of root?.querySelectorAll?.(".dsm-tabs") || []) {
+    const buttons = [...tabs.querySelectorAll("button")];
+    const settingsButton = buttons.find(
+      (button) => String(button.textContent || "").trim() === "Settings / seed",
+    );
+    if (settingsButton) return { tabs, settingsButton };
+  }
+  return null;
+}
+
+function renderDistributionSafeControl(node) {
+  const root = node?.__dsm?.root;
+  if (!root?.querySelectorAll) return false;
+
+  const existing = root.querySelector(`[${CONTROL_ATTR}]`);
+  const settings = findSettingsTabs(root);
+  const visible = Boolean(settings?.settingsButton?.classList?.contains("selected"));
+
+  if (!visible) {
+    existing?.remove?.();
+    return false;
+  }
+
+  if (existing) {
+    const checkbox = existing.querySelector('input[type="checkbox"]');
+    if (checkbox) checkbox.checked = isDistributionSafe(node);
+    return true;
+  }
+
+  const wrapper = document.createElement("div");
+  wrapper.setAttribute(CONTROL_ATTR, "");
+  wrapper.className = "dsm-section";
+
+  const label = document.createElement("label");
+  label.className = "dsm-checkline";
+
+  const checkbox = document.createElement("input");
+  checkbox.type = "checkbox";
+  checkbox.checked = isDistributionSafe(node);
+
+  const text = document.createElement("span");
+  text.className = "dsm-checkline-text";
+
+  const title = document.createElement("strong");
+  title.textContent = "Distribution-safe workflow serialization";
+
+  const detail = document.createElement("small");
+  detail.textContent =
+    "When enabled, workflow saves/exports serialize default_character/default_prompt instead of your currently selected local UUIDs. The live selection, local library, and runtime queue/generation state are not changed.";
+
+  text.append(title, detail);
+  label.append(checkbox, text);
+  wrapper.appendChild(label);
+
+  checkbox.addEventListener("change", () => {
+    setDistributionSafe(node, checkbox.checked);
+  });
+
+  settings.tabs.insertAdjacentElement("afterend", wrapper);
+  return true;
+}
+
+function attachDistributionSafeUi(node) {
+  if (!isStateManagerNode(node) || node.__dsmDistributionSafeAttached) return;
+  node.__dsmDistributionSafeAttached = true;
+
+  let attempts = 0;
+  const attach = () => {
+    const root = node?.__dsm?.root;
+    if (!root) {
+      if (attempts++ < 120) requestAnimationFrame(attach);
+      return;
+    }
+
+    renderDistributionSafeControl(node);
+    const observer = new MutationObserver(() => renderDistributionSafeControl(node));
+    observer.observe(root, { childList: true, subtree: true });
+    node.__dsmDistributionSafeObserver = observer;
+
+    const originalRemoved = node.onRemoved;
+    node.onRemoved = function (...args) {
+      node.__dsmDistributionSafeObserver?.disconnect?.();
+      node.__dsmDistributionSafeObserver = null;
+      return originalRemoved?.apply(this, args);
+    };
+  };
+  requestAnimationFrame(attach);
+}
+
+app.registerExtension({
+  name: EXT_NAME,
+
+  async beforeRegisterNodeDef(nodeType, nodeData) {
+    if (!isStateManagerDef(nodeData, nodeType)) return;
+    const originalOnSerialize = nodeType.prototype.onSerialize;
+    nodeType.prototype.onSerialize = function (output) {
+      const result = originalOnSerialize?.apply(this, arguments);
+      try {
+        applyDistributionSafeSerialization(output, this);
+      } catch (error) {
+        console.warn(`[${EXT_NAME}] distribution-safe serialization failed`, error);
+      }
+      return result;
+    };
+  },
+
+  nodeCreated(node) {
+    attachDistributionSafeUi(node);
+  },
+});


### PR DESCRIPTION
## Summary

Adds a workflow-level **Distribution-safe workflow serialization** option to State Manager for release/distribution workflows.

When enabled, workflow save/export rewrites only the serialized selection bindings to:

- `selected_character_id = default_character`
- `selected_prompt_id = default_prompt`

The live State Manager selection is deliberately left untouched, so the current local character/prompt, persistent library, connected state, queue behavior, and generation behavior continue to use the real local selection.

## UI

The toggle is injected into the State Manager **Settings / seed** panel and persists as the workflow node property:

`dora_state_manager_distribution_safe_serialization`

Default is off for backward compatibility.

## Serialization contract

The frontend sanitizes both positional `widgets_values` and `widgets_values_named` when present. The current `State Manager` and legacy `DoRA State Manager` classes are both supported.

A distributed workflow can ship with the toggle enabled. Users who want their own selected local preset to persist in subsequent workflow saves can disable it after import.

## Tests

Added frontend tests covering:

- enabled mode serializes neutral default bindings;
- live widget UUIDs remain unchanged;
- disabled mode preserves normal UUID serialization;
- legacy State Manager class compatibility.

Local validation: `node --test tests/test_state_manager_distribution_safe_frontend.mjs` — 3/3 passing.

The branch is squashed to a single commit.